### PR TITLE
Enable 8bit loader and add option for disabling audio

### DIFF
--- a/ld-decode.py
+++ b/ld-decode.py
@@ -30,7 +30,7 @@ parser.add_argument('--MTF_offset', metavar='mtf_offset', type=float, default=No
 parser.add_argument('--NTSCJ', dest='ntscj', action='store_true', help='source is in NTSC-J (IRE 0 black) format')
 parser.add_argument('--noDOD', dest='nodod', action='store_true', default=False, help='disable dropout detector')
 parser.add_argument('--EFM', dest='efm', action='store_true', default=False, help='Filter EFM output (WIP!)')
-
+parser.add_argument('--daa', dest='daa', action='store_true', default=False, help='Disable analog audio decoding')
 parser.add_argument('--ignoreleadout', dest='ignoreleadout', action='store_true', default=False, help='continue decoding after lead-out seen')
 
 
@@ -68,7 +68,7 @@ else:
 
 system = 'PAL' if args.pal else 'NTSC'
     
-ldd = LDdecode(filename, outname, loader, digital_audio = args.efm, system=system, doDOD = not args.nodod)
+ldd = LDdecode(filename, outname, loader, analog_audio = not args.daa, digital_audio = args.efm, system=system, doDOD = not args.nodod)
 ldd.roughseek(firstframe * 2)
 
 if system == 'NTSC' and not args.ntscj:

--- a/ld-decode.py
+++ b/ld-decode.py
@@ -61,6 +61,8 @@ elif filename[-3:] == 'r30':
     loader = load_packed_data_3_32
 elif filename[-3:] == 'r16':
     loader = load_unpacked_data_s16
+elif filename[-2:] == 'r8':
+    loader = load_unpacked_data_u8
 else:
     loader = load_packed_data_4_40
 

--- a/lddecode_core.py
+++ b/lddecode_core.py
@@ -943,6 +943,7 @@ class Field:
         self.dspicture = None
         self.dsaudio = None
         self.audio_offset = audio_offset
+        self.audio_next_offset = audio_offset
 
         if len(self.vsyncs) == 0:
             self.nextfieldoffset = start + (self.rf.linelen * 200)
@@ -1698,7 +1699,7 @@ class LDdecode:
         fi = {'isFirstField': True if f.isFirstField else False, 
               'syncConf': f.sync_confidence, 
               'seqNo': len(self.fieldinfo) + 1, 
-              'audioSamples': int(len(audio) / 2),
+              'audioSamples': 0 if audio is None else int(len(audio) / 2),
               'diskLoc': np.round((self.fieldloc / self.bytes_per_field) * 10) / 10,
               'medianBurstIRE': f.burstmedian}
 


### PR DESCRIPTION
Needed to disable some stuff when working on VHS decoding as it has no audio, so adding an option to disable analog audio decoding entirely.

Some code assumed it to be enabled so fixed that too.