### PR TITLE
#225 Implement subline-only replacement option

### DIFF
--- a/tools/ld-combine/combine.cpp
+++ b/tools/ld-combine/combine.cpp
@@ -29,7 +29,7 @@ Combine::Combine(QObject *parent) : QObject(parent)
 
 }
 
-bool Combine::process(QString primaryFilename, QString secondaryFilename, QString outputFilename, bool reverse)
+bool Combine::process(QString primaryFilename, QString secondaryFilename, QString outputFilename, bool reverse, bool subline)
 {
     linesReplaced = 0;
     dropoutsReplaced = 0;
@@ -58,6 +58,11 @@ bool Combine::process(QString primaryFilename, QString secondaryFilename, QStrin
         qInfo() << "Expected field order is reversed to second field/first field";
         primaryLdDecodeMetaData.setIsFirstFieldFirst(false);
         secondaryLdDecodeMetaData.setIsFirstFieldFirst(false);
+    }
+    
+        // Sub-line replacements only
+    if (subline) {
+        qInfo() << "Sub-line replacements only";
     }
 
     primaryVideoParameters = primaryLdDecodeMetaData.getVideoParameters();
@@ -217,8 +222,8 @@ bool Combine::process(QString primaryFilename, QString secondaryFilename, QStrin
             qint32 secondarySecondField = secondaryLdDecodeMetaData.getSecondFieldNumber(secondarySeqFrameNumber);
 
             // Process the frame's field pair
-            firstFieldData = processField(primaryFirstField, secondaryFirstField);
-            secondFieldData = processField(primarySecondField, secondarySecondField);
+            firstFieldData = processField(primaryFirstField, secondaryFirstField, subline);
+            secondFieldData = processField(primarySecondField, secondarySecondField, subline);
         } else {
             // No matching frame found
             qDebug() << "Combine::process(): Frame" << primarySeqFrameNumber << "no matching frame found";
@@ -375,7 +380,7 @@ qint32 Combine::getClvFrameNumber(qint32 frameSeqNumber, LdDecodeMetaData *ldDec
 //
 // Note: This would probably be better if only the dropout areas were replaced
 // but that can be a future enhancement for now
-QByteArray Combine::processField(qint32 primarySeqFieldNumber, qint32 secondarySeqFieldNumber)
+QByteArray Combine::processField(qint32 primarySeqFieldNumber, qint32 secondarySeqFieldNumber, bool subline)
 {
     // Read the primary and secondary source video data for the field
     QByteArray primaryFieldData = primarySourceVideo.getVideoField(primarySeqFieldNumber)->getFieldData();
@@ -391,7 +396,7 @@ QByteArray Combine::processField(qint32 primarySeqFieldNumber, qint32 secondaryS
         // Is the primary line damaged?
         if (primaryLineQuality != 0) {
             // If the secondary field line is perfect, just copy the whole line to the primary
-            if (secondaryLineQuality == 0) {
+            if (subline != true && secondaryLineQuality == 0) {
                 // Replace the whole primary line data with the secondary line data
                 qInfo() << "[Line   ] - [Field #" << primarySeqFieldNumber << "] - [Line #" << lineNumber << "] - Replaced";
                 linesReplaced++;

--- a/tools/ld-combine/combine.h
+++ b/tools/ld-combine/combine.h
@@ -36,7 +36,7 @@ class Combine : public QObject
 public:
     explicit Combine(QObject *parent = nullptr);
 
-    bool process(QString primaryFilename, QString secondaryFilename, QString outputFilename, bool reverse);
+    bool process(QString primaryFilename, QString secondaryFilename, QString outputFilename, bool reverse, bool subline);
 
 signals:
 
@@ -62,7 +62,7 @@ private:
     qint32 getCavFrameNumber(qint32 frameSeqNumber, LdDecodeMetaData *ldDecodeMetaData);
     qint32 getClvFrameNumber(qint32 frameSeqNumber, LdDecodeMetaData *ldDecodeMetaData);
 
-    QByteArray processField(qint32 primarySeqFieldNumber, qint32 secondarySeqFieldNumber);
+    QByteArray processField(qint32 primarySeqFieldNumber, qint32 secondarySeqFieldNumber, bool subline);
     qint32 assessLineQuality(LdDecodeMetaData::Field field, qint32 lineNumber);
     QByteArray replaceVideoLineData(QByteArray primaryFieldData, QByteArray secondaryFieldData, qint32 lineNumber);
     QByteArray replaceVideoDropoutData(QByteArray primaryFieldData, QByteArray secondaryFieldData,

--- a/tools/ld-combine/main.cpp
+++ b/tools/ld-combine/main.cpp
@@ -99,6 +99,11 @@ int main(int argc, char *argv[])
     QCommandLineOption setReverseOption(QStringList() << "r" << "reverse",
                                        QCoreApplication::translate("main", "Reverse the field order to second/first (default first/second)"));
     parser.addOption(setReverseOption);
+    
+        // Option to force sub-line replacements (-s)
+    QCommandLineOption setSublineOption(QStringList() << "s" << "subline",
+                                       QCoreApplication::translate("main", "Force sub-line replacements (default full-line)"));
+    parser.addOption(setSublineOption);
 
     // Positional argument to specify input video file
     parser.addPositionalArgument("primary", QCoreApplication::translate("main", "Specify primary input TBC file"));
@@ -113,6 +118,7 @@ int main(int argc, char *argv[])
     // Get the options from the parser
     bool isDebugOn = parser.isSet(showDebugOption);
     bool reverse = parser.isSet(setReverseOption);
+    bool subline = parser.isSet(setSublineOption);
 
     // Get the arguments from the parser
     QString primaryFilename;
@@ -140,7 +146,7 @@ int main(int argc, char *argv[])
 
     // Perform the processing
     Combine combine;
-    combine.process(primaryFilename, secondaryFilename, outputFilename, reverse);
+    combine.process(primaryFilename, secondaryFilename, outputFilename, reverse, subline);
 
     // Quit with success
     return 0;


### PR DESCRIPTION
-s option for ld-combine to only replace individual dropouts rather than entire lines.