### PR TITLE
Add RF frequency option

### DIFF
--- a/ld-decode.py
+++ b/ld-decode.py
@@ -34,6 +34,7 @@ parser.add_argument('--noEFM', dest='noefm', action='store_true', default=False,
 parser.add_argument('--daa', dest='daa', action='store_true', default=False, help='Disable analog audio decoding')
 parser.add_argument('--ignoreleadout', dest='ignoreleadout', action='store_true', default=False, help='continue decoding after lead-out seen')
 
+parser.add_argument('-f', '--frequency', dest='inputfreq', metavar='FREQ', type=parse_frequency, default=40, help='RF sampling frequency (default is 40MHz)')
 parser.add_argument('--video_bpf_high', dest='vbpf_high', metavar='FREQ', type=parse_frequency, default=None, help='Video BPF high end frequency')
 parser.add_argument('--video_lpf', dest='vlpf', metavar='FREQ', type=parse_frequency, default=None, help='Video low-pass filter frequency')
 
@@ -72,7 +73,7 @@ else:
 
 system = 'PAL' if args.pal else 'NTSC'
     
-ldd = LDdecode(filename, outname, loader, analog_audio = not args.daa, digital_audio = not args.noefm, system=system, doDOD = not args.nodod)
+ldd = LDdecode(filename, outname, loader, inputfreq = args.inputfreq, analog_audio = not args.daa, digital_audio = not args.noefm, system=system, doDOD = not args.nodod)
 ldd.roughseek(firstframe * 2)
 
 if system == 'NTSC' and not args.ntscj:

--- a/ld-decode.py
+++ b/ld-decode.py
@@ -15,7 +15,8 @@ from lddutils import *
 import lddecode_core
 from lddecode_core import *
 
-parser = argparse.ArgumentParser(description='Extracts audio and video from raw RF laserdisc captures')
+options_epilog = """FREQ can be a bare number in MHz, or a number with one of the case-insensitive suffixes Hz, kHz, MHz, GHz, fSC (meaning NTSC) or fSCPAL."""
+parser = argparse.ArgumentParser(description='Extracts audio and video from raw RF laserdisc captures', epilog=options_epilog)
 parser.add_argument('infile', metavar='infile', type=str, help='source file')
 parser.add_argument('outfile', metavar='outfile', type=str, help='base name for destination files')
 parser.add_argument('-s', '--start', metavar='start', type=int, default=0, help='rough jump to frame n of capture (default is 0)')
@@ -33,8 +34,8 @@ parser.add_argument('--noEFM', dest='noefm', action='store_true', default=False,
 parser.add_argument('--daa', dest='daa', action='store_true', default=False, help='Disable analog audio decoding')
 parser.add_argument('--ignoreleadout', dest='ignoreleadout', action='store_true', default=False, help='continue decoding after lead-out seen')
 
-parser.add_argument('--video_bpf_high', dest='vbpf_high', type=float, default=None, help='Video BPF high end frequency')
-parser.add_argument('--video_lpf', dest='vlpf', type=float, default=None, help='Video low-pass filter frequency')
+parser.add_argument('--video_bpf_high', dest='vbpf_high', metavar='FREQ', type=parse_frequency, default=None, help='Video BPF high end frequency')
+parser.add_argument('--video_lpf', dest='vlpf', metavar='FREQ', type=parse_frequency, default=None, help='Video low-pass filter frequency')
 
 
 args = parser.parse_args()

--- a/lddecode_core.py
+++ b/lddecode_core.py
@@ -986,7 +986,7 @@ class Field:
         for i, p in enumerate(pulses):
             if p.len > self.usectoinpx(10):
                 vsync_locs.append(i)
-                vsync_means.append(np.mean(self.data[0]['demod_05'][p.start+self.rf.freq:p.start+p.len-self.rf.freq]))
+                vsync_means.append(np.mean(self.data[0]['demod_05'][int(p.start+self.rf.freq):int(p.start+p.len-self.rf.freq)]))
                 
         synclevel = np.median(vsync_means)
 
@@ -1011,7 +1011,7 @@ class Field:
 
             p = pulses[i]
             if inrange(p.len, self.rf.freq * .75, self.rf.freq * 2.5):
-                black_means.append(np.mean(self.data[0]['demod_05'][p.start+(self.rf.freq*5):p.start+(self.rf.freq*20)]))
+                black_means.append(np.mean(self.data[0]['demod_05'][int(p.start+(self.rf.freq*5)):int(p.start+(self.rf.freq*20))]))
 
         blacklevel = np.median(black_means)
 
@@ -1026,7 +1026,7 @@ class Field:
 
         if pulses is None or len(pulses) == 0:
             print("Unable to find any sync pulses")
-            return None, None, self.rf.freq_hz
+            return None, None, int(self.rf.freq_hz)
 
         validpulses = self.refinepulses(pulses)
         self.validpulses = validpulses
@@ -1372,7 +1372,7 @@ class Field:
 
         # Each valid pulse is definitely *not* an error, so exclude it here at the end
         for v in self.validpulses:
-            iserr[v[1].start-self.rf.freq:v[1].start+v[1].len+self.rf.freq] = False
+            iserr[int(v[1].start-self.rf.freq):int(v[1].start+v[1].len+self.rf.freq)] = False
         
         return iserr
 

--- a/lddecode_core.py
+++ b/lddecode_core.py
@@ -1887,7 +1887,7 @@ class CombNTSC:
 
 class LDdecode:
     
-    def __init__(self, fname_in, fname_out, freader, analog_audio = True, digital_audio = False, system = 'NTSC', doDOD = True):
+    def __init__(self, fname_in, fname_out, freader, inputfreq = 40, analog_audio = True, digital_audio = False, system = 'NTSC', doDOD = True):
         self.infile = open(fname_in, 'rb')
         self.freader = freader
 
@@ -1925,13 +1925,12 @@ class LDdecode:
         self.fieldloc = 0
 
         self.system = system
+        self.rf = RFDecode(inputfreq=inputfreq, system=system, decode_analog_audio=analog_audio, decode_digital_audio=digital_audio)
         if system == 'PAL':
-            self.rf = RFDecode(system = 'PAL', decode_analog_audio=analog_audio, decode_digital_audio=digital_audio)
             self.FieldClass = FieldPAL
             self.readlen = self.rf.linelen * 400
             self.clvfps = 25
         else: # NTSC
-            self.rf = RFDecode(system = 'NTSC', decode_analog_audio=analog_audio, decode_digital_audio=digital_audio)
             self.FieldClass = FieldNTSC
             self.readlen = ((self.rf.linelen * 350) // 16384) * 16384
             self.clvfps = 30

--- a/lddutils.py
+++ b/lddutils.py
@@ -113,6 +113,25 @@ def downscale_field(data, lineinfo, outwidth=1820, lines=625, usewow=False):
         
     return dsout
 
+frequency_suffixes = [
+    ("ghz", 1.0e9),
+    ("mhz", 1.0e6),
+    ("khz", 1.0e3),
+    ("hz", 1.0),
+    ("fsc", 315.0e6 / 88.0),
+    ("fscpal", (283.75 * 15625) + 25),
+]
+
+"""Parse an argument string, returning a float frequency in MHz."""
+def parse_frequency(string):
+    multiplier = 1.0e6
+    for suffix, mult in frequency_suffixes:
+        if string.lower().endswith(suffix):
+            multiplier = mult
+            string = string[:-len(suffix)]
+            break
+    return (multiplier * float(string)) / 1.0e6
+
 '''
 
 For this part of the loader phase I found myself going to function objects that implement this sample API:


### PR DESCRIPTION
Add an option to specify the RF sampling frequency, and fix a few places where it was assumed that `rf.freq` or `rf.freq_hz` was an integer.

Partly addresses #155. The remaining problem is that the ["repeat the above - but for [analogue] audio"](https://github.com/happycube/ld-decode/blob/61808aac41fd402e613d2e44086cdbdc9b8da568/lddecode_core.py#L497) code computes the array size wrongly at 8fSC, resulting in a "could not broadcast input array" exception.

With `-f 8fsc -p --daa`, this successfully decodes a PAL cx88 capture.