### PR TITLE
Performance improvements to ld-comb-pal

### DIFF
--- a/tools/ld-comb-pal/filterthread.cpp
+++ b/tools/ld-comb-pal/filterthread.cpp
@@ -23,16 +23,15 @@
 ************************************************************************/
 
 #include "filterthread.h"
+#include "palcombfilter.h"
 
-FilterThread::FilterThread(LdDecodeMetaData::VideoParameters videoParametersParam, QObject *parent) : QThread(parent)
+FilterThread::FilterThread(QAtomicInt& abortParam, PalCombFilter& combFilterParam, LdDecodeMetaData::VideoParameters videoParametersParam, bool blackAndWhiteParam, QObject *parent)
+    : QThread(parent), abort(abortParam), combFilter(combFilterParam)
 {
-    // Thread control variables
-    isProcessing = false;
-    abort = false;
-
     // Configure PAL colour
     videoParameters = videoParametersParam;
     palColour.updateConfiguration(videoParameters);
+    blackAndWhite = blackAndWhiteParam;
 
     // Calculate the frame height
     qint32 frameHeight = (videoParameters.fieldHeight * 2) - 1;
@@ -56,93 +55,58 @@ FilterThread::FilterThread(LdDecodeMetaData::VideoParameters videoParametersPara
     }
 }
 
-FilterThread::~FilterThread()
-{
-    mutex.lock();
-    abort = true;
-    condition.wakeOne();
-    mutex.unlock();
-
-    wait();
-}
-
-void FilterThread::startFilter(QByteArray firstFieldParam, QByteArray secondFieldParam, qreal burstMedianIreParam, bool blackAndWhiteParam)
-{
-    QMutexLocker locker(&mutex);
-
-    // Move all the parameters to be local
-    firstFieldData = firstFieldParam;
-    secondFieldData = secondFieldParam;
-    burstMedianIre = burstMedianIreParam;
-    blackAndWhite = blackAndWhiteParam;
-
-    // Is the run process already running?
-    if (!isRunning()) {
-        // Yes, start with low priority
-        start(LowPriority);
-        isProcessing = true;
-    } else {
-        // No, set the restart condition
-        isProcessing = true;
-        condition.wakeOne();
-    }
-}
-
-QByteArray FilterThread::getResult(void)
-{
-    return rgbOutputData;
-}
-
-bool FilterThread::isBusy(void)
-{
-    return isProcessing;
-}
-
 void FilterThread::run()
 {
+    qint32 frameNumber;
+
+    // Input data buffers
+    QByteArray firstFieldData;
+    QByteArray secondFieldData;
+    QByteArray rgbOutputData;
+
+    // Burst level data
+    qreal burstMedianIre;
+
     qDebug() << "FilterThread::run(): Thread running";
 
     while(!abort) {
-        if (isProcessing) {
-            // Lock and copy all parameters to 'thread-safe' variables
-            mutex.lock();
-            tsFirstFieldData = firstFieldData;
-            tsSecondFieldData = secondFieldData;
-            mutex.unlock();
-
-            // Calculate the saturation level from the burst median IRE
-            // Note: This code works as a temporary MTF compensator whilst ld-decode gets
-            // real MTF compensation added to it.
-            qreal tSaturation = 125.0 + ((100.0 / 20.0) * (20.0 - burstMedianIre));
-
-            // Perform the PALcolour filtering
-            outputData = palColour.performDecode(tsFirstFieldData, tsSecondFieldData, 100, static_cast<qint32>(tSaturation), blackAndWhite);
-
-            // The PAL colour library outputs the whole frame, so here we have to strip all the non-visible stuff to just get the
-            // actual required image - it would be better if PALcolour gave back only the required RGB, but it's not my library.
-            rgbOutputData.clear();
-
-            // Add additional output lines to ensure the output height is 576 lines
-            QByteArray blankLine;
-            blankLine.resize((videoEnd - videoStart) * 6 );
-            blankLine.fill(0);
-            for (qint32 y = 0; y < 576 - (lastActiveScanLine - firstActiveScanLine); y++) {
-                rgbOutputData.append(blankLine);
-            }
-
-            // Since PALcolour uses +-3 scan-lines to colourise, the final lines before the non-visible area may not come out quite
-            // right, but we're including them here anyway.
-            for (qint32 y = firstActiveScanLine; y < lastActiveScanLine; y++) {
-                rgbOutputData.append(outputData.mid((y * videoParameters.fieldWidth * 6) + (videoStart * 6),
-                                                        ((videoEnd - videoStart) * 6)));
-            }
-
-            isProcessing = false;
+        // Get the next frame to process from the input file
+        if (!combFilter.getInputFrame(frameNumber, firstFieldData, secondFieldData, burstMedianIre)) {
+            // No more input frames -- exit
+            break;
         }
 
-        // Sleep the thread until it is restarted
-        mutex.lock();
-        if (!isProcessing && !abort) condition.wait(&mutex);
-        mutex.unlock();
+        // Calculate the saturation level from the burst median IRE
+        // Note: This code works as a temporary MTF compensator whilst ld-decode gets
+        // real MTF compensation added to it.
+        qreal tSaturation = 125.0 + ((100.0 / 20.0) * (20.0 - burstMedianIre));
+
+        // Perform the PALcolour filtering
+        outputData = palColour.performDecode(firstFieldData, secondFieldData, 100, static_cast<qint32>(tSaturation), blackAndWhite);
+
+        // The PAL colour library outputs the whole frame, so here we have to strip all the non-visible stuff to just get the
+        // actual required image - it would be better if PALcolour gave back only the required RGB, but it's not my library.
+        rgbOutputData.clear();
+
+        // Add additional output lines to ensure the output height is 576 lines
+        QByteArray blankLine;
+        blankLine.resize((videoEnd - videoStart) * 6 );
+        blankLine.fill(0);
+        for (qint32 y = 0; y < 576 - (lastActiveScanLine - firstActiveScanLine); y++) {
+            rgbOutputData.append(blankLine);
+        }
+
+        // Since PALcolour uses +-3 scan-lines to colourise, the final lines before the non-visible area may not come out quite
+        // right, but we're including them here anyway.
+        for (qint32 y = firstActiveScanLine; y < lastActiveScanLine; y++) {
+            rgbOutputData.append(outputData.mid((y * videoParameters.fieldWidth * 6) + (videoStart * 6),
+                                                    ((videoEnd - videoStart) * 6)));
+        }
+
+        // Write the result to the output file
+        if (!combFilter.putOutputFrame(frameNumber, rgbOutputData)) {
+            abort = true;
+            break;
+        }
     }
 }

--- a/tools/ld-comb-pal/main.cpp
+++ b/tools/ld-comb-pal/main.cpp
@@ -26,6 +26,7 @@
 #include <QDebug>
 #include <QtGlobal>
 #include <QCommandLineParser>
+#include <QThread>
 
 #include "palcombfilter.h"
 
@@ -132,7 +133,7 @@ int main(int argc, char *argv[])
 
     // Option to select the number of threads (-t)
     QCommandLineOption threadsOption(QStringList() << "t" << "threads",
-                                        QCoreApplication::translate("main", "Specify the number of concurrent threads (default is 32)"),
+                                        QCoreApplication::translate("main", "Specify the number of concurrent threads (default number of logical CPUs plus 2)"),
                                         QCoreApplication::translate("main", "number"));
     parser.addOption(threadsOption);
 
@@ -178,7 +179,7 @@ int main(int argc, char *argv[])
 
     qint32 startFrame = -1;
     qint32 length = -1;
-    qint32 maxThreads = 32;
+    qint32 maxThreads = QThread::idealThreadCount() + 2;
 
     if (parser.isSet(startFrameOption)) {
         startFrame = parser.value(startFrameOption).toInt();

--- a/tools/ld-comb-pal/palcolour.cpp
+++ b/tools/ld-comb-pal/palcolour.cpp
@@ -268,13 +268,13 @@ QByteArray PalColour::performDecode(QByteArray firstFieldData, QByteArray second
                     {
                         l=i-b; r=i+b;
 
-                        PU+=(m[r]+m[l])*cfilt0[b]+(+nx[r][0]+nx[l][0]-nx[l][1]-nx[r][1])*cfilt1[b]-(mx[l][2]+mx[r][2]+mx[l][3]+mx[r][3])*cfilt2[b]+(-nx[r][4]-nx[l][4]+nx[l][5]+nx[r][5])*cfilt3[b];
-                        QU+=(n[r]+n[l])*cfilt0[b]+(-mx[r][0]-mx[l][0]+mx[l][1]+mx[r][1])*cfilt1[b]-(nx[l][2]+nx[r][2]+nx[l][3]+nx[r][3])*cfilt2[b]+(+mx[r][4]+mx[l][4]-mx[l][5]-mx[r][5])*cfilt3[b];
-                        PV+=(m[r]+m[l])*cfilt0[b]+(-nx[r][0]-nx[l][0]+nx[l][1]+nx[r][1])*cfilt1[b]-(mx[l][2]+mx[r][2]+mx[l][3]+mx[r][3])*cfilt2[b]+(+nx[r][4]+nx[l][4]-nx[l][5]-nx[r][5])*cfilt3[b];
-                        QV+=(n[r]+n[l])*cfilt0[b]+(+mx[r][0]+mx[l][0]-mx[l][1]-mx[r][1])*cfilt1[b]-(nx[l][2]+nx[r][2]+nx[l][3]+nx[r][3])*cfilt2[b]+(-mx[r][4]-mx[l][4]+mx[l][5]+mx[r][5])*cfilt3[b];
+                        PY+=(m[r]+m[l])*yfilt0[b]-(mx[r][2]+mx[l][2]+mx[r][3]+mx[l][3])*yfilt2[b];  // note omission of yfilt[1] and [3] for PAL
+                        QY+=(n[r]+n[l])*yfilt0[b]-(nx[r][2]+nx[l][2]+nx[r][3]+nx[l][3])*yfilt2[b];  // note omission of yfilt[1] and [3] for PAL
 
-                        PY+=(m[r]+m[l])*yfilt0[b]-(mx[l][2]+mx[r][2]+mx[l][3]+mx[r][3])*yfilt2[b];  // note omission of yfilt[1] and [3] for PAL
-                        QY+=(n[r]+n[l])*yfilt0[b]-(nx[l][2]+nx[r][2]+nx[l][3]+nx[r][3])*yfilt2[b];  // note omission of yfilt[1] and [3] for PAL
+                        PU+=(m[r]+m[l])*cfilt0[b]-(mx[r][2]+mx[l][2]+mx[r][3]+mx[l][3])*cfilt2[b]+(nx[r][0]+nx[l][0]-nx[r][1]-nx[l][1])*cfilt1[b]-(nx[r][4]+nx[l][4]-nx[r][5]-nx[l][5])*cfilt3[b];
+                        QU+=(n[r]+n[l])*cfilt0[b]-(nx[r][2]+nx[l][2]+nx[r][3]+nx[l][3])*cfilt2[b]-(mx[r][0]+mx[l][0]-mx[r][1]-mx[l][1])*cfilt1[b]+(mx[r][4]+mx[l][4]-mx[r][5]-mx[l][5])*cfilt3[b];
+                        PV+=(m[r]+m[l])*cfilt0[b]-(mx[r][2]+mx[l][2]+mx[r][3]+mx[l][3])*cfilt2[b]-(nx[r][0]+nx[l][0]-nx[r][1]-nx[l][1])*cfilt1[b]+(nx[r][4]+nx[l][4]-nx[r][5]-nx[l][5])*cfilt3[b];
+                        QV+=(n[r]+n[l])*cfilt0[b]-(nx[r][2]+nx[l][2]+nx[r][3]+nx[l][3])*cfilt2[b]+(mx[r][0]+mx[l][0]-mx[r][1]-mx[l][1])*cfilt1[b]-(mx[r][4]+mx[l][4]-mx[r][5]-mx[l][5])*cfilt3[b];
                     }
                     pu[i]=PU/cdiv; qu[i]=QU/cdiv;
                     pv[i]=PV/cdiv; qv[i]=QV/cdiv;

--- a/tools/ld-comb-pal/palcolour.cpp
+++ b/tools/ld-comb-pal/palcolour.cpp
@@ -154,9 +154,7 @@ QByteArray PalColour::performDecode(QByteArray firstFieldData, QByteArray second
         // were all short ints
         double pu[MAX_WIDTH], qu[MAX_WIDTH], pv[MAX_WIDTH], qv[MAX_WIDTH], py[MAX_WIDTH], qy[MAX_WIDTH];
         double m[MAX_WIDTH], n[MAX_WIDTH];
-        double m1[MAX_WIDTH], n1[MAX_WIDTH], m2[MAX_WIDTH], n2[MAX_WIDTH];
-        double m3[MAX_WIDTH], n3[MAX_WIDTH], m4[MAX_WIDTH], n4[MAX_WIDTH];
-        double m5[MAX_WIDTH], n5[MAX_WIDTH], m6[MAX_WIDTH], n6[MAX_WIDTH];
+        double mx[MAX_WIDTH][6], nx[MAX_WIDTH][6];
 
         qint32 Vsw; // this will represent the PAL Vswitch state later on...
 
@@ -200,12 +198,12 @@ QByteArray PalColour::performDecode(QByteArray firstFieldData, QByteArray second
                 for (qint32 i = videoParameters.colourBurstStart; i < videoParameters.fieldWidth; i++) {
                     m[i]=b0[i]*sine[i]; n[i]=b0[i]*cosine[i];
 
-                    m1[i]=b1[i]*sine[i];  n1[i]=b1[i]*cosine[i];
-                    m2[i]=b2[i]*sine[i];  n2[i]=b2[i]*cosine[i];
-                    m3[i]=b3[i]*sine[i];  n3[i]=b3[i]*cosine[i];
-                    m4[i]=b4[i]*sine[i];  n4[i]=b4[i]*cosine[i];
-                    m5[i]=b5[i]*sine[i];  n5[i]=b5[i]*cosine[i];
-                    m6[i]=b6[i]*sine[i];  n6[i]=b6[i]*cosine[i];
+                    mx[i][0]=b1[i]*sine[i];  nx[i][0]=b1[i]*cosine[i];
+                    mx[i][1]=b2[i]*sine[i];  nx[i][1]=b2[i]*cosine[i];
+                    mx[i][2]=b3[i]*sine[i];  nx[i][2]=b3[i]*cosine[i];
+                    mx[i][3]=b4[i]*sine[i];  nx[i][3]=b4[i]*cosine[i];
+                    mx[i][4]=b5[i]*sine[i];  nx[i][4]=b5[i]*cosine[i];
+                    mx[i][5]=b6[i]*sine[i];  nx[i][5]=b6[i]*cosine[i];
                 }
 
                 // Find absolute burst phase
@@ -219,10 +217,10 @@ QByteArray PalColour::performDecode(QByteArray firstFieldData, QByteArray second
                 // this is a classic "product-" or "synchronous demodulation" operation. We "detect" the burst relative to the arbitrary sine[] and cosine[] reference phases
                 qint32 bp=0, bq=0, bpo=0, bqo=0;
                 for (qint32 i=videoParameters.colourBurstStart; i<videoParameters.colourBurstEnd; i++) {
-                    bp+=(m[i]-(m3[i]+m4[i])/2)/2;
-                    bq+=(n[i]-(n3[i]+n4[i])/2)/2;
-                    bpo+=(m2[i]-m1[i])/2;
-                    bqo+=(n2[i]-n1[i])/2;
+                    bp+=(m[i]-(mx[i][2]+mx[i][3])/2)/2;
+                    bq+=(n[i]-(nx[i][2]+nx[i][3])/2)/2;
+                    bpo+=(mx[i][1]-mx[i][0])/2;
+                    bqo+=(nx[i][1]-nx[i][0])/2;
                 }
 
                 bp/=(videoParameters.colourBurstEnd-videoParameters.colourBurstStart);  bq/=(videoParameters.colourBurstEnd-videoParameters.colourBurstStart);  // normalises those sums
@@ -270,13 +268,13 @@ QByteArray PalColour::performDecode(QByteArray firstFieldData, QByteArray second
                     {
                         l=i-b; r=i+b;
 
-                        PU+=(m[r]+m[l])*cfilt0[b]+(+n1[r]+n1[l]-n2[l]-n2[r])*cfilt1[b]-(m3[l]+m3[r]+m4[l]+m4[r])*cfilt2[b]+(-n5[r]-n5[l]+n6[l]+n6[r])*cfilt3[b];
-                        QU+=(n[r]+n[l])*cfilt0[b]+(-m1[r]-m1[l]+m2[l]+m2[r])*cfilt1[b]-(n3[l]+n3[r]+n4[l]+n4[r])*cfilt2[b]+(+m5[r]+m5[l]-m6[l]-m6[r])*cfilt3[b];
-                        PV+=(m[r]+m[l])*cfilt0[b]+(-n1[r]-n1[l]+n2[l]+n2[r])*cfilt1[b]-(m3[l]+m3[r]+m4[l]+m4[r])*cfilt2[b]+(+n5[r]+n5[l]-n6[l]-n6[r])*cfilt3[b];
-                        QV+=(n[r]+n[l])*cfilt0[b]+(+m1[r]+m1[l]-m2[l]-m2[r])*cfilt1[b]-(n3[l]+n3[r]+n4[l]+n4[r])*cfilt2[b]+(-m5[r]-m5[l]+m6[l]+m6[r])*cfilt3[b];
+                        PU+=(m[r]+m[l])*cfilt0[b]+(+nx[r][0]+nx[l][0]-nx[l][1]-nx[r][1])*cfilt1[b]-(mx[l][2]+mx[r][2]+mx[l][3]+mx[r][3])*cfilt2[b]+(-nx[r][4]-nx[l][4]+nx[l][5]+nx[r][5])*cfilt3[b];
+                        QU+=(n[r]+n[l])*cfilt0[b]+(-mx[r][0]-mx[l][0]+mx[l][1]+mx[r][1])*cfilt1[b]-(nx[l][2]+nx[r][2]+nx[l][3]+nx[r][3])*cfilt2[b]+(+mx[r][4]+mx[l][4]-mx[l][5]-mx[r][5])*cfilt3[b];
+                        PV+=(m[r]+m[l])*cfilt0[b]+(-nx[r][0]-nx[l][0]+nx[l][1]+nx[r][1])*cfilt1[b]-(mx[l][2]+mx[r][2]+mx[l][3]+mx[r][3])*cfilt2[b]+(+nx[r][4]+nx[l][4]-nx[l][5]-nx[r][5])*cfilt3[b];
+                        QV+=(n[r]+n[l])*cfilt0[b]+(+mx[r][0]+mx[l][0]-mx[l][1]-mx[r][1])*cfilt1[b]-(nx[l][2]+nx[r][2]+nx[l][3]+nx[r][3])*cfilt2[b]+(-mx[r][4]-mx[l][4]+mx[l][5]+mx[r][5])*cfilt3[b];
 
-                        PY+=(m[r]+m[l])*yfilt0[b]-(m3[l]+m3[r]+m4[l]+m4[r])*yfilt2[b];  // note omission of yfilt[1] and [3] for PAL
-                        QY+=(n[r]+n[l])*yfilt0[b]-(n3[l]+n3[r]+n4[l]+n4[r])*yfilt2[b];  // note omission of yfilt[1] and [3] for PAL
+                        PY+=(m[r]+m[l])*yfilt0[b]-(mx[l][2]+mx[r][2]+mx[l][3]+mx[r][3])*yfilt2[b];  // note omission of yfilt[1] and [3] for PAL
+                        QY+=(n[r]+n[l])*yfilt0[b]-(nx[l][2]+nx[r][2]+nx[l][3]+nx[r][3])*yfilt2[b];  // note omission of yfilt[1] and [3] for PAL
                     }
                     pu[i]=PU/cdiv; qu[i]=QU/cdiv;
                     pv[i]=PV/cdiv; qv[i]=QV/cdiv;

--- a/tools/ld-comb-pal/palcolour.cpp
+++ b/tools/ld-comb-pal/palcolour.cpp
@@ -249,7 +249,7 @@ QByteArray PalColour::performDecode(QByteArray firstFieldData, QByteArray second
                 // NB: Multiline averaging/filtering assumes perfect
                 //     inter-line phase registration...
 
-                qint32 PU,QU, PV,QV, PY,QY;
+                double PU,QU, PV,QV, PY,QY;
                 for (qint32 i = videoParameters.activeVideoStart; i < videoParameters.activeVideoEnd; i++) {
                     PU=QU=0; PV=QV=0; PY=QY=0;
 


### PR DESCRIPTION
Profiling ld-comb-pal, I found a few things that could be tweaked to speed it up a bit: some changes to the palcolour inner loop, and some restructuring to the PalCombFilter thread pool to keep the worker threads busier.

Here are scaling boxplots (against ideal scaling curves) for the original version and the 1st, 4th and 5th commits below, on a quad-core i7-2600 machine built with `-O3 -march=native`. The Y axis is time in seconds for a 233-frame sample, and the X axis is the `-t` argument. Overall it's about 40% faster.

![Figure_1](https://user-images.githubusercontent.com/436317/60137496-fd313c00-979e-11e9-8b89-916796816876.png)

It may be possible to get a bit more speed out of it through some vectorisation; at present, GCC compiles nearly all of the inner loop as scalar instructions.

I've tried to follow the style of the existing ld-comb-pal/palcolour code. Let me know if there's anything that looks odd to you here...