### PR TITLE
ld-compress: fix 'binary operator expected' error

### DIFF
--- a/scripts/ld-compress.sh
+++ b/scripts/ld-compress.sh
@@ -26,7 +26,7 @@ done
 shift $(( OPTIND - 1 ))
 
 # Check if input files have been entered, and if so, process according to the selected mode.
-if [ -z "$@" ]
+if [[ $# < 1 ]]
 then
   help_msg ; exit
 else


### PR DESCRIPTION
Fix complaint when more than 1 file is given.