### PR TITLE
Vectorise palcolour's inner loop

### DIFF
--- a/tools/ld-comb-pal/palcolour.h
+++ b/tools/ld-comb-pal/palcolour.h
@@ -54,12 +54,8 @@ private:
     double sine[MAX_WIDTH], cosine[MAX_WIDTH];    // formerly short int
     static const int32_t arraySize = 14; // 'a' is the array-size, corresponding to at least half the filter-width, and should be at least Fsampling(max supported by build)/colourfilterBandwidth(min supported by build)
     //  'a' must be greater than or equal to the bigger of 'ca' and 'ya' above
-    double cfilt0[arraySize + 1];
-    double cfilt1[arraySize + 1];
-    double cfilt2[arraySize + 1];
-    double cfilt3[arraySize + 1];
-    double yfilt0[arraySize + 1];
-    double yfilt2[arraySize + 1];
+    double cfilt[arraySize + 1][4];
+    double yfilt[arraySize + 1][2];
 
     double cdiv;
     double ydiv;


### PR DESCRIPTION
Taking advantage of the vertical symmetry of the 2D filter and restructuring the arrays a bit simplifies the inner loop enough that GCC can vectorise it - and gives a pretty decent performance increase even without vectorisation.

From left to right: performance before #261, after #261, and after this change, on a quad-core i7-2600 with GCC 6 -O3 -march=native. More recent CPUs and GCCs may benefit more (with a bit of luck).

![Figure_2](https://user-images.githubusercontent.com/436317/60290258-49e85480-9910-11e9-970d-6de434c5516c.png)