### PR TITLE
Fix vertical alignment of PALcolour output.

### DIFF
--- a/tools/ld-comb-pal/palcolour.cpp
+++ b/tools/ld-comb-pal/palcolour.cpp
@@ -179,7 +179,7 @@ QByteArray PalColour::performDecode(QByteArray firstFieldData, QByteArray second
         quint16 *b6 = nullptr;
 
         for (qint32 field = 0; field < 2; field++) {
-            for (qint32 fieldLine = 3; fieldLine < (videoParameters.fieldHeight - 4); fieldLine++) {
+            for (qint32 fieldLine = 3; fieldLine < (videoParameters.fieldHeight - 3); fieldLine++) {
                 if (field == 0) {
                     b0 = topFieldDataPointer+ (fieldLine      * (videoParameters.fieldWidth));
                     b1 = topFieldDataPointer+((fieldLine - 1) * (videoParameters.fieldWidth));
@@ -299,7 +299,7 @@ QByteArray PalColour::performDecode(QByteArray firstFieldData, QByteArray second
                 }
 
                 // Define scan line pointer to output buffer using 16 bit unsigned words
-                quint16 *ptr = reinterpret_cast<quint16*>(outputFrame.data() + (((fieldLine * 2) + field + 2) * videoParameters.fieldWidth * 6));
+                quint16 *ptr = reinterpret_cast<quint16*>(outputFrame.data() + (((fieldLine * 2) + field) * videoParameters.fieldWidth * 6));
 
                 // 'saturation' is a user saturation control, nom. 100%
                 double scaledSaturation = (saturation / 50.0) / norm;  // 'norm' normalises bp and bq to 1


### PR DESCRIPTION
The PAL decoded output was off by a line after the fix to the initialisation of the line pointers in #262. This was the result of the "+ 2" in the output buffer pointer setup, which looks like it was compensating for the original bug: the first output line should be at the top of the buffer.

Checking alignment with Test Card G from Jason and the Argonauts showed that the bottom line was also being cut off, because the Y loop had the wrong upper bound. TCG is now vertically symmetrical.

(It isn't _horizontally_ symmetrical, which would also be worth looking at at some point...)

Fixes #276.