### PR TITLE
Centre the active area in the output frame

### DIFF
--- a/tools/ld-chroma-decoder/decoder.cpp
+++ b/tools/ld-chroma-decoder/decoder.cpp
@@ -1,0 +1,81 @@
+/************************************************************************
+
+    decoder.cpp
+
+    ld-chroma-decoder - Colourisation filter for ld-decode
+    Copyright (C) 2019 Adam Sampson
+
+    This file is part of ld-decode-tools.
+
+    ld-chroma-decoder is free software: you can redistribute it and/or
+    modify it under the terms of the GNU General Public License as
+    published by the Free Software Foundation, either version 3 of the
+    License, or (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+************************************************************************/
+
+#include "decoder.h"
+
+void Decoder::setVideoParameters(Decoder::Configuration &config, const LdDecodeMetaData::VideoParameters &videoParameters,
+                                 qint32 firstActiveScanLine, qint32 lastActiveScanLine, qint32 outputHeight) {
+    // Check parameters are consistent.
+    // Both width and height should be divisible by 8, as video codecs expect this.
+    assert((outputHeight % 8) == 0);
+    assert((lastActiveScanLine - firstActiveScanLine) <= outputHeight);
+
+    config.videoParameters = videoParameters;
+    config.firstActiveScanLine = firstActiveScanLine;
+    config.lastActiveScanLine = lastActiveScanLine;
+    config.outputHeight = outputHeight;
+
+    // Expand horizontal active region so the width is divisible by 8
+    qint32 outputWidth;
+    while (true) {
+        outputWidth = config.videoParameters.activeVideoEnd - config.videoParameters.activeVideoStart;
+        if ((outputWidth % 8) == 0) {
+            break;
+        }
+
+        // Add pixels to the right and left sides in turn, to keep the active area centred
+        if ((outputWidth % 2) == 0) {
+            config.videoParameters.activeVideoEnd++;
+        } else {
+            config.videoParameters.activeVideoStart--;
+        }
+    }
+
+    // Show output information to the user
+    const qint32 frameHeight = (videoParameters.fieldHeight * 2) - 1;
+    qInfo() << "Input video of" << config.videoParameters.fieldWidth << "x" << frameHeight <<
+               "will be colourised and trimmed to" << outputWidth << "x" << config.outputHeight << "RGB 16-16-16 frames";
+}
+
+QByteArray Decoder::cropOutputFrame(const Decoder::Configuration &config, QByteArray outputData) {
+    QByteArray croppedData;
+
+    // Add blank lines at the top to reach the intended output height
+    const qint32 activeVideoStart = config.videoParameters.activeVideoStart;
+    const qint32 activeVideoEnd = config.videoParameters.activeVideoEnd;
+    QByteArray blankLine;
+    blankLine.resize((activeVideoEnd - activeVideoStart) * 6);
+    blankLine.fill(0);
+    for (qint32 y = 0; y < config.outputHeight - (config.lastActiveScanLine - config.firstActiveScanLine); y++) {
+        croppedData.append(blankLine);
+    }
+
+    // Copy the active region from the decoded image
+    for (qint32 y = config.firstActiveScanLine; y < config.lastActiveScanLine; y++) {
+        croppedData.append(outputData.mid((y * config.videoParameters.fieldWidth * 6) + (activeVideoStart * 6),
+                                          ((activeVideoEnd - activeVideoStart) * 6)));
+    }
+
+    return croppedData;
+}

--- a/tools/ld-chroma-decoder/decoder.h
+++ b/tools/ld-chroma-decoder/decoder.h
@@ -26,6 +26,9 @@
 #define DECODER_H
 
 #include <QAtomicInt>
+#include <QByteArray>
+#include <QDebug>
+#include <cassert>
 
 #include "lddecodemetadata.h"
 
@@ -59,6 +62,24 @@ public:
 
     // Construct a new worker thread
     virtual QThread *makeThread(QAtomicInt& abort, DecoderPool& decoderPool) = 0;
+
+    // Parameters used by the decoder and its threads.
+    // This may be subclassed by decoders to add extra parameters.
+    struct Configuration {
+        // Parameters computed from the video metadata
+        LdDecodeMetaData::VideoParameters videoParameters;
+        qint32 firstActiveScanLine;
+        qint32 lastActiveScanLine;
+        qint32 outputHeight;
+    };
+
+    // Compute the output frame size in Configuration, adjusting the active
+    // video region as required
+    static void setVideoParameters(Configuration &config, const LdDecodeMetaData::VideoParameters &videoParameters,
+                                   qint32 firstActiveScanLine, qint32 lastActiveScanLine, qint32 outputHeight);
+
+    // Crop a full decoded frame to the output frame size
+    static QByteArray cropOutputFrame(const Decoder::Configuration &config, QByteArray outputData);
 };
 
 #endif

--- a/tools/ld-chroma-decoder/decoder.h
+++ b/tools/ld-chroma-decoder/decoder.h
@@ -70,13 +70,14 @@ public:
         LdDecodeMetaData::VideoParameters videoParameters;
         qint32 firstActiveScanLine;
         qint32 lastActiveScanLine;
-        qint32 outputHeight;
+        qint32 topPadLines;
+        qint32 bottomPadLines;
     };
 
     // Compute the output frame size in Configuration, adjusting the active
     // video region as required
     static void setVideoParameters(Configuration &config, const LdDecodeMetaData::VideoParameters &videoParameters,
-                                   qint32 firstActiveScanLine, qint32 lastActiveScanLine, qint32 outputHeight);
+                                   qint32 firstActiveScanLine, qint32 lastActiveScanLine);
 
     // Crop a full decoded frame to the output frame size
     static QByteArray cropOutputFrame(const Decoder::Configuration &config, QByteArray outputData);

--- a/tools/ld-chroma-decoder/ld-chroma-decoder.pro
+++ b/tools/ld-chroma-decoder/ld-chroma-decoder.pro
@@ -16,6 +16,7 @@ DEFINES += QT_DEPRECATED_WARNINGS
 
 SOURCES += \
     main.cpp \
+    decoder.cpp \
     decoderpool.cpp \
     palcolour.cpp \
     paldecoder.cpp \

--- a/tools/ld-chroma-decoder/ntscdecoder.cpp
+++ b/tools/ld-chroma-decoder/ntscdecoder.cpp
@@ -64,8 +64,18 @@ bool NtscDecoder::configure(const LdDecodeMetaData::VideoParameters &videoParame
     config.outputHeight = 488;
 
     // Make sure output width is divisible by 8 (better for ffmpeg processing)
-    while (((config.videoEnd - config.videoStart) % 8) != 0) {
-        config.videoEnd++;
+    while (true) {
+        const qint32 width = config.videoEnd - config.videoStart;
+        if ((width % 8) == 0) {
+            break;
+        }
+
+        // Add pixels to the right and left sides in turn, to keep the active area centred
+        if ((width % 2) == 0) {
+            config.videoEnd++;
+        } else {
+            config.videoStart--;
+        }
     }
 
     // Show output information to the user

--- a/tools/ld-chroma-decoder/ntscdecoder.cpp
+++ b/tools/ld-chroma-decoder/ntscdecoder.cpp
@@ -51,7 +51,7 @@ bool NtscDecoder::configure(const LdDecodeMetaData::VideoParameters &videoParame
     }
 
     // Compute cropping parameters
-    setVideoParameters(config, videoParameters, 40, 525, 488);
+    setVideoParameters(config, videoParameters, 40, 525);
 
     // Set the input buffer dimensions configuration
     config.combConfig.fieldWidth = videoParameters.fieldWidth;

--- a/tools/ld-chroma-decoder/ntscdecoder.h
+++ b/tools/ld-chroma-decoder/ntscdecoder.h
@@ -49,12 +49,10 @@ public:
 
     // Parameters used by NtscDecoder and NtscThread
     struct Configuration {
+        LdDecodeMetaData::VideoParameters videoParameters;
         Comb::Configuration combConfig;
         qint32 firstActiveScanLine;
         qint32 lastActiveScanLine;
-        qint32 fieldWidth;
-        qint32 videoStart;
-        qint32 videoEnd;
         qint32 outputHeight;
     };
 

--- a/tools/ld-chroma-decoder/ntscdecoder.h
+++ b/tools/ld-chroma-decoder/ntscdecoder.h
@@ -48,12 +48,8 @@ public:
     QThread *makeThread(QAtomicInt& abort, DecoderPool& decoderPool) override;
 
     // Parameters used by NtscDecoder and NtscThread
-    struct Configuration {
-        LdDecodeMetaData::VideoParameters videoParameters;
+    struct Configuration : public Decoder::Configuration {
         Comb::Configuration combConfig;
-        qint32 firstActiveScanLine;
-        qint32 lastActiveScanLine;
-        qint32 outputHeight;
     };
 
 private:

--- a/tools/ld-chroma-decoder/paldecoder.cpp
+++ b/tools/ld-chroma-decoder/paldecoder.cpp
@@ -41,17 +41,12 @@ bool PalDecoder::configure(const LdDecodeMetaData::VideoParameters &videoParamet
 
     config.videoParameters = videoParameters;
 
-    // Calculate the frame size
-    config.frameHeight = (videoParameters.fieldHeight * 2) - 1;
-
     // Set the first and last active scan line
     config.firstActiveScanLine = 44;
     config.lastActiveScanLine = 620;
 
-    // Make sure output height is even (better for ffmpeg processing)
-    if (((config.lastActiveScanLine - config.firstActiveScanLine) % 2) != 0) {
-       config.lastActiveScanLine--;
-    }
+    // Default to standard output size
+    config.outputHeight = 576;
 
     // Make sure output width is divisible by 16 (better for ffmpeg processing)
     while (true) {
@@ -69,10 +64,10 @@ bool PalDecoder::configure(const LdDecodeMetaData::VideoParameters &videoParamet
     }
 
     // Show output information to the user
-    qInfo() << "Input video of" << config.videoParameters.fieldWidth << "x" << config.frameHeight <<
-               "will be colourised and trimmed to" <<
-               config.videoParameters.activeVideoEnd - config.videoParameters.activeVideoStart <<
-               "x" << config.lastActiveScanLine - config.firstActiveScanLine << "RGB 16-16-16 frames";
+    const qint32 frameHeight = (videoParameters.fieldHeight * 2) - 1;
+    const qint32 outputWidth = config.videoParameters.activeVideoEnd - config.videoParameters.activeVideoStart;
+    qInfo() << "Input video of" << config.videoParameters.fieldWidth << "x" << frameHeight <<
+               "will be colourised and trimmed to" << outputWidth << "x" << config.outputHeight << "RGB 16-16-16 frames";
 
     return true;
 }
@@ -96,14 +91,11 @@ void PalThread::run()
     // Input data buffers
     QByteArray firstFieldData;
     QByteArray secondFieldData;
-    QByteArray rgbOutputData;
 
     // Frame metadata
     qint32 firstFieldPhaseID; // not used in PAL
     qint32 secondFieldPhaseID; // not used in PAL
     qreal burstMedianIre;
-
-    qDebug() << "PalThread::run(): Thread running";
 
     while(!abort) {
         // Get the next frame to process from the input file
@@ -119,12 +111,12 @@ void PalThread::run()
         qreal tSaturation = 125.0 + ((100.0 / 20.0) * (20.0 - burstMedianIre));
 
         // Perform the PALcolour filtering
-        outputData = palColour.performDecode(firstFieldData, secondFieldData, 100, static_cast<qint32>(tSaturation),
-                                             config.blackAndWhite);
+        QByteArray outputData = palColour.performDecode(firstFieldData, secondFieldData, 100,
+                                                        static_cast<qint32>(tSaturation), config.blackAndWhite);
 
         // The PALcolour library outputs the whole frame, so here we have to strip all the non-visible stuff to just get the
         // actual required image - it would be better if PALcolour gave back only the required RGB, but it's not my library.
-        rgbOutputData.clear();
+        QByteArray croppedData;
 
         // Add additional output lines to ensure the output height is 576 lines
         const qint32 activeVideoStart = config.videoParameters.activeVideoStart;
@@ -132,19 +124,19 @@ void PalThread::run()
         QByteArray blankLine;
         blankLine.resize((activeVideoEnd - activeVideoStart) * 6);
         blankLine.fill(0);
-        for (qint32 y = 0; y < 576 - (config.lastActiveScanLine - config.firstActiveScanLine); y++) {
-            rgbOutputData.append(blankLine);
+        for (qint32 y = 0; y < config.outputHeight - (config.lastActiveScanLine - config.firstActiveScanLine); y++) {
+            croppedData.append(blankLine);
         }
 
         // Since PALcolour uses +-3 scan-lines to colourise, the final lines before the non-visible area may not come out quite
         // right, but we're including them here anyway.
         for (qint32 y = config.firstActiveScanLine; y < config.lastActiveScanLine; y++) {
-            rgbOutputData.append(outputData.mid((y * config.videoParameters.fieldWidth * 6) + (activeVideoStart * 6),
-                                                ((activeVideoEnd - activeVideoStart) * 6)));
+            croppedData.append(outputData.mid((y * config.videoParameters.fieldWidth * 6) + (activeVideoStart * 6),
+                                              ((activeVideoEnd - activeVideoStart) * 6)));
         }
 
         // Write the result to the output file
-        if (!decoderPool.putOutputFrame(frameNumber, rgbOutputData)) {
+        if (!decoderPool.putOutputFrame(frameNumber, croppedData)) {
             abort = true;
             break;
         }

--- a/tools/ld-chroma-decoder/paldecoder.cpp
+++ b/tools/ld-chroma-decoder/paldecoder.cpp
@@ -48,10 +48,10 @@ bool PalDecoder::configure(const LdDecodeMetaData::VideoParameters &videoParamet
     // Default to standard output size
     config.outputHeight = 576;
 
-    // Make sure output width is divisible by 16 (better for ffmpeg processing)
+    // Make sure output width is divisible by 8 (better for ffmpeg processing)
     while (true) {
         const qint32 width = config.videoParameters.activeVideoEnd - config.videoParameters.activeVideoStart;
-        if ((width % 16) == 0) {
+        if ((width % 8) == 0) {
             break;
         }
 

--- a/tools/ld-chroma-decoder/paldecoder.cpp
+++ b/tools/ld-chroma-decoder/paldecoder.cpp
@@ -87,8 +87,6 @@ PalThread::PalThread(QAtomicInt& abortParam, DecoderPool& decoderPoolParam,
 {
     // Configure PALcolour
     palColour.updateConfiguration(config.videoParameters);
-
-    outputData.resize(config.videoParameters.fieldWidth * config.frameHeight * 6);
 }
 
 void PalThread::run()

--- a/tools/ld-chroma-decoder/paldecoder.cpp
+++ b/tools/ld-chroma-decoder/paldecoder.cpp
@@ -40,7 +40,7 @@ bool PalDecoder::configure(const LdDecodeMetaData::VideoParameters &videoParamet
     }
 
     // Compute cropping parameters
-    setVideoParameters(config, videoParameters, 44, 620, 576);
+    setVideoParameters(config, videoParameters, 44, 620);
 
     return true;
 }

--- a/tools/ld-chroma-decoder/paldecoder.cpp
+++ b/tools/ld-chroma-decoder/paldecoder.cpp
@@ -39,35 +39,8 @@ bool PalDecoder::configure(const LdDecodeMetaData::VideoParameters &videoParamet
         return false;
     }
 
-    config.videoParameters = videoParameters;
-
-    // Set the first and last active scan line
-    config.firstActiveScanLine = 44;
-    config.lastActiveScanLine = 620;
-
-    // Default to standard output size
-    config.outputHeight = 576;
-
-    // Make sure output width is divisible by 8 (better for ffmpeg processing)
-    while (true) {
-        const qint32 width = config.videoParameters.activeVideoEnd - config.videoParameters.activeVideoStart;
-        if ((width % 8) == 0) {
-            break;
-        }
-
-        // Add pixels to the right and left sides in turn, to keep the active area centred
-        if ((width % 2) == 0) {
-            config.videoParameters.activeVideoEnd++;
-        } else {
-            config.videoParameters.activeVideoStart--;
-        }
-    }
-
-    // Show output information to the user
-    const qint32 frameHeight = (videoParameters.fieldHeight * 2) - 1;
-    const qint32 outputWidth = config.videoParameters.activeVideoEnd - config.videoParameters.activeVideoStart;
-    qInfo() << "Input video of" << config.videoParameters.fieldWidth << "x" << frameHeight <<
-               "will be colourised and trimmed to" << outputWidth << "x" << config.outputHeight << "RGB 16-16-16 frames";
+    // Compute cropping parameters
+    setVideoParameters(config, videoParameters, 44, 620, 576);
 
     return true;
 }
@@ -116,24 +89,9 @@ void PalThread::run()
 
         // The PALcolour library outputs the whole frame, so here we have to strip all the non-visible stuff to just get the
         // actual required image - it would be better if PALcolour gave back only the required RGB, but it's not my library.
-        QByteArray croppedData;
-
-        // Add additional output lines to ensure the output height is 576 lines
-        const qint32 activeVideoStart = config.videoParameters.activeVideoStart;
-        const qint32 activeVideoEnd = config.videoParameters.activeVideoEnd;
-        QByteArray blankLine;
-        blankLine.resize((activeVideoEnd - activeVideoStart) * 6);
-        blankLine.fill(0);
-        for (qint32 y = 0; y < config.outputHeight - (config.lastActiveScanLine - config.firstActiveScanLine); y++) {
-            croppedData.append(blankLine);
-        }
-
         // Since PALcolour uses +-3 scan-lines to colourise, the final lines before the non-visible area may not come out quite
         // right, but we're including them here anyway.
-        for (qint32 y = config.firstActiveScanLine; y < config.lastActiveScanLine; y++) {
-            croppedData.append(outputData.mid((y * config.videoParameters.fieldWidth * 6) + (activeVideoStart * 6),
-                                              ((activeVideoEnd - activeVideoStart) * 6)));
-        }
+        QByteArray croppedData = PalDecoder::cropOutputFrame(config, outputData);
 
         // Write the result to the output file
         if (!decoderPool.putOutputFrame(frameNumber, croppedData)) {

--- a/tools/ld-chroma-decoder/paldecoder.cpp
+++ b/tools/ld-chroma-decoder/paldecoder.cpp
@@ -54,8 +54,18 @@ bool PalDecoder::configure(const LdDecodeMetaData::VideoParameters &videoParamet
     }
 
     // Make sure output width is divisible by 16 (better for ffmpeg processing)
-    while (((config.videoParameters.activeVideoEnd - config.videoParameters.activeVideoStart) % 16) != 0) {
-       config.videoParameters.activeVideoEnd++;
+    while (true) {
+        const qint32 width = config.videoParameters.activeVideoEnd - config.videoParameters.activeVideoStart;
+        if ((width % 16) == 0) {
+            break;
+        }
+
+        // Add pixels to the right and left sides in turn, to keep the active area centred
+        if ((width % 2) == 0) {
+            config.videoParameters.activeVideoEnd++;
+        } else {
+            config.videoParameters.activeVideoStart--;
+        }
     }
 
     // Show output information to the user

--- a/tools/ld-chroma-decoder/paldecoder.h
+++ b/tools/ld-chroma-decoder/paldecoder.h
@@ -52,10 +52,7 @@ public:
         bool blackAndWhite;
         qint32 firstActiveScanLine;
         qint32 lastActiveScanLine;
-        qint32 fieldWidth;
         qint32 frameHeight;
-        qint32 videoStart;
-        qint32 videoEnd;
     };
 
 private:

--- a/tools/ld-chroma-decoder/paldecoder.h
+++ b/tools/ld-chroma-decoder/paldecoder.h
@@ -52,7 +52,7 @@ public:
         bool blackAndWhite;
         qint32 firstActiveScanLine;
         qint32 lastActiveScanLine;
-        qint32 frameHeight;
+        qint32 outputHeight;
     };
 
 private:

--- a/tools/ld-chroma-decoder/paldecoder.h
+++ b/tools/ld-chroma-decoder/paldecoder.h
@@ -47,12 +47,8 @@ public:
     QThread *makeThread(QAtomicInt& abort, DecoderPool& decoderPool) override;
 
     // Parameters used by PalDecoder and PalThread
-    struct Configuration {
-        LdDecodeMetaData::VideoParameters videoParameters;
+    struct Configuration : public Decoder::Configuration {
         bool blackAndWhite;
-        qint32 firstActiveScanLine;
-        qint32 lastActiveScanLine;
-        qint32 outputHeight;
     };
 
 private:


### PR DESCRIPTION
Experimenting with Test Card G, I spotted that PalDecoder was cutting off the right-hand side of the image, and neither decoder was centring the active area within the output frame. Both PalDecoder and NtscDecoder do so now, extending the active area horizontally and padding with blank lines vertically as necessary to make both dimensions a multiple of 8.

In the process, I've factored out most of the common code between the two classes; they now use the same code to compute the output frame size and crop the output image, and there are fewer hardcoded values. The output sizes are the same as before.

This doesn't change Comb/PalColour, so it shouldn't affect ld-analyse.

Before (note the castellations on the right are truncated, and the centre line isn't in the centre):
![tcg-lopsided](https://user-images.githubusercontent.com/436317/60554938-dbe9c600-9d31-11e9-9060-e435b3f6dc6a.png)

After:
![tcg](https://user-images.githubusercontent.com/436317/60554942-e86e1e80-9d31-11e9-9007-2c33821755b4.png)