### PR TITLE
Clone the matrix in OpticalFlow::convertYtoMat

### DIFF
--- a/tools/ld-chroma-decoder/opticalflow.cpp
+++ b/tools/ld-chroma-decoder/opticalflow.cpp
@@ -86,7 +86,7 @@ cv::Mat OpticalFlow::convertYtoMat(const YiqBuffer &yiqBuffer)
     }
 
     // Return a Mat y * x in CV_16UC1 format
-    return cv::Mat(525, 910, CV_16UC1, frame);
+    return cv::Mat(525, 910, CV_16UC1, frame).clone();
 }
 
 // This method calculates the distance between points where x is the difference between the x-coordinates


### PR DESCRIPTION
The cv::Mat here is constructed with a pointer to a local array; it doesn't copy the array by default. This meant the image data was getting overwritten before the optical flow was computed.

This doesn't solve #133, but at least it puts it back to how it was before...