### PR TITLE
Add support for reading .raw.oga files using ffmpeg

### DIFF
--- a/ld-decode.py
+++ b/ld-decode.py
@@ -68,6 +68,8 @@ elif filename[-3:] == 'r16':
     loader = load_unpacked_data_s16
 elif filename[-2:] == 'r8':
     loader = load_unpacked_data_u8
+elif filename[-7:] == 'raw.oga':
+    loader = LoadFFmpeg()
 else:
     loader = load_packed_data_4_40
 


### PR DESCRIPTION
This uses a buffer to allow short backwards seeks, which works fine for decoding a complete file; it doesn't work with -S which needs to be able to seek around arbitrarily in the file.

This could be generalised to support more extensions (since ffmpeg will read all sorts of formats), or to shell out to a different command.

Partly addresses #116.