### PR TITLE
Fix zpk2tf with current numpy/scipy

### DIFF
--- a/lddecode_core.py
+++ b/lddecode_core.py
@@ -265,11 +265,11 @@ class RFDecode:
 
         # The deemphasis filter.  This math is probably still quite wrong, but with the right values it works
         deemp0, deemp1 = DP['video_deemp']
-        [tf_b, tf_a] = sps.zpk2tf(-deemp1*(10**-10), -deemp0*(10**-10), deemp0 / deemp1)
+        [tf_b, tf_a] = sps.zpk2tf([-deemp1*(10**-10)], [-deemp0*(10**-10)], deemp0 / deemp1)
         SF['Fdeemp'] = filtfft(sps.bilinear(tf_b, tf_a, 1.0/self.freq_hz_half), self.blocklen)
 
         # The direct opposite of the above, used in test signal generation
-        [tf_b, tf_a] = sps.zpk2tf(-deemp0*(10**-10), -deemp1*(10**-10), deemp1 / deemp0)
+        [tf_b, tf_a] = sps.zpk2tf([-deemp0*(10**-10)], [-deemp1*(10**-10)], deemp1 / deemp0)
         SF['Femp'] = filtfft(sps.bilinear(tf_b, tf_a, 1.0/self.freq_hz_half), self.blocklen)
         
         # Post processing:  lowpass filter + deemp

--- a/lddecode_core.py
+++ b/lddecode_core.py
@@ -2053,6 +2053,8 @@ class CombNTSC:
 class LDdecode:
     
     def __init__(self, fname_in, fname_out, freader, inputfreq = 40, analog_audio = True, digital_audio = False, system = 'NTSC', doDOD = True, threads=4):
+        self.demodcache = None
+
         self.infile = open(fname_in, 'rb')
         self.freader = freader
 


### PR DESCRIPTION
zpk2tf seems to require iterable args with numpy 1.17/scipy 1.3 - I think this was caused by the numpy upgrade since I've had the new scipy for a few days and hadn't spotted this.

I've checked that it still produces the same result. On Debian stable:

```
>>> import scipy.signal
>>> deemp0, deemp1 = 120*.32, 320*.32
>>> scipy.signal.zpk2tf(-deemp1*(10**-10), -deemp0*(10**-10), deemp0 / deemp1)
(array([3.75e-01, 3.84e-09]), array([1.00e+00, 3.84e-09]))
>>> scipy.signal.zpk2tf([-deemp1*(10**-10)], [-deemp0*(10**-10)], deemp0 / deemp1)
(array([3.75e-01, 3.84e-09]), array([1.00e+00, 3.84e-09]))
```

With current numpy/scipy:

```
>>> scipy.signal.zpk2tf(-deemp1*(10**-10), -deemp0*(10**-10), deemp0 / deemp1)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/gar/lib/python3.7/site-packages/scipy/signal/filter_design.py", line 1106, in zpk2tf
    a = atleast_1d(poly(p))
  File "<__array_function__ internals>", line 6, in poly
TypeError: dispatcher for __array_function__ did not return an iterable
>>> scipy.signal.zpk2tf([-deemp1*(10**-10)], [-deemp0*(10**-10)], deemp0 / deemp1)
(array([3.75e-01, 3.84e-09]), array([1.00e+00, 3.84e-09]))
```