### PR TITLE
Set PalColour::arraySize appropriately for ld-decode's sample rate

### DIFF
--- a/tools/ld-chroma-decoder/palcolour.cpp
+++ b/tools/ld-chroma-decoder/palcolour.cpp
@@ -73,10 +73,16 @@ void PalColour::buildLookUpTables()
 
     // Create filter-profile lookup
     // chromaBandwidthHz values between 1.1MHz and 1.3MHz can be tried. Some specific values in that range may work best at minimising residual
-    // dot pattern at given sample rates due to the discrete nature of the filters. It'd be good to find ways to optimise this more rigourously
+    // dot pattern at given sample rates due to the discrete nature of the filters. It'd be good to find ways to optimise this more rigourously.
+    // Note in principle you could have different bandwidths for extracting the luma and chroma, according to aesthetic tradeoffs. Not really very justifyable though.
     double chromaBandwidthHz=1100000.0 /0.93; // the 0.93 is a bit empirical for the 4Fsc sampled LaserDisc scans
+
+    // Compute filter widths based on chroma bandwidth.
+    // arraySize must be wide enough to hold both filters (and ideally no
+    // wider, else we're doing more computation than we need to).
     double ca=0.5*videoParameters.sampleRate/chromaBandwidthHz, ya=0.5*videoParameters.sampleRate/chromaBandwidthHz; // where does the 0.5* come from?
-    // note in principle you could have different bandwidths for extracting the luma and chroma, according to aesthetic tradeoffs. Not really very justifyable though.
+    assert(arraySize >= static_cast<qint32>(ca));
+    assert(arraySize >= static_cast<qint32>(ya));
 
     // Simon: The array declarations (used here and in the processing method) have been moved
     // to the class' private space (in the .h)

--- a/tools/ld-chroma-decoder/palcolour.cpp
+++ b/tools/ld-chroma-decoder/palcolour.cpp
@@ -80,7 +80,8 @@ void PalColour::buildLookUpTables()
 
     // Simon: The array declarations (used here and in the processing method) have been moved
     // to the class' private space (in the .h)
-    cdiv=0; ydiv=0;
+    double cdiv=0;
+    double ydiv=0;
 
     // Note that we choose to make the y-filter *much* less selective in the vertical direction:
     // - this is to prevent castellation on horizontal colour boundaries.
@@ -126,6 +127,15 @@ void PalColour::buildLookUpTables()
         ydiv+=yfilt[f][0]+2*0+2*yfilt[f][1]+2*0;
     }
     cdiv*=2; ydiv*=2;
+
+    for (qint32 f = 0; f <= arraySize; f++) {
+        for (qint32 i = 0; i < 4; i++) {
+            cfilt[f][i] /= cdiv;
+        }
+        for (qint32 i = 0; i < 2; i++) {
+            yfilt[f][i] /= ydiv;
+        }
+    }
 
     // Calculate the frame height and resize the output buffer
     qint32 frameHeight = (videoParameters.fieldHeight * 2) - 1;
@@ -284,9 +294,9 @@ QByteArray PalColour::performDecode(QByteArray firstFieldData, QByteArray second
                         PV+=(m[0][r]+m[0][l])*cfilt[b][0]+(m[1][r]+m[1][l])*cfilt[b][1]-(n[2][r]+n[2][l])*cfilt[b][2]-(n[3][r]+n[3][l])*cfilt[b][3];
                         QV+=(n[0][r]+n[0][l])*cfilt[b][0]+(n[1][r]+n[1][l])*cfilt[b][1]+(m[2][r]+m[2][l])*cfilt[b][2]+(m[3][r]+m[3][l])*cfilt[b][3];
                     }
-                    pu[i]=PU/cdiv; qu[i]=QU/cdiv;
-                    pv[i]=PV/cdiv; qv[i]=QV/cdiv;
-                    py[i]=PY/ydiv; qy[i]=QY/ydiv;
+                    pu[i]=PU; qu[i]=QU;
+                    pv[i]=PV; qv[i]=QV;
+                    py[i]=PY; qy[i]=QY;
                 }
 
                 // Generate the luminance (Y), by filtering out Fsc (by re-synthesising the detected py qy and subtracting), and subtracting the black-level

--- a/tools/ld-chroma-decoder/palcolour.cpp
+++ b/tools/ld-chroma-decoder/palcolour.cpp
@@ -93,7 +93,7 @@ void PalColour::buildLookUpTables()
     // and that 'lines' of the masks were equivalent, then
     // significant time-savings could be made.
 
-    for (int16_t f=0; f<=arraySize; f++)
+    for (qint32 f=0; f<=arraySize; f++)
     {
         double  fc=f; if (fc>ca) fc=ca;
         double  ff=sqrt(f*f+2*2); if ( ff>ca)  ff=ca;  // 2 -- 4 -- 6 sequence

--- a/tools/ld-chroma-decoder/palcolour.h
+++ b/tools/ld-chroma-decoder/palcolour.h
@@ -43,8 +43,8 @@ public:
     QByteArray performDecode(QByteArray topFieldData, QByteArray bottomFieldData, qint32 brightness, qint32 saturation, bool blackAndWhite);
 
     // Replacements for #DEFINE values
-    static const int MAX_WIDTH = 1135; // Simon: Maximum based on PAL width
-    static const int MAX_HEIGHT = 625; // Simon: Maximum based on PAL height
+    static const qint32 MAX_WIDTH = 1135; // Simon: Maximum based on PAL width
+    static const qint32 MAX_HEIGHT = 625; // Simon: Maximum based on PAL height
 
 private:
     // Configuration parameters
@@ -52,7 +52,7 @@ private:
 
     // Look up tables array and constant definitions
     double sine[MAX_WIDTH], cosine[MAX_WIDTH];    // formerly short int
-    static const int32_t arraySize = 14; // 'a' is the array-size, corresponding to at least half the filter-width, and should be at least Fsampling(max supported by build)/colourfilterBandwidth(min supported by build)
+    static const qint32 arraySize = 14; // 'a' is the array-size, corresponding to at least half the filter-width, and should be at least Fsampling(max supported by build)/colourfilterBandwidth(min supported by build)
     //  'a' must be greater than or equal to the bigger of 'ca' and 'ya' above
     double cfilt[arraySize + 1][4];
     double yfilt[arraySize + 1][2];

--- a/tools/ld-chroma-decoder/palcolour.h
+++ b/tools/ld-chroma-decoder/palcolour.h
@@ -59,7 +59,7 @@ private:
     // 2D array represents one quarter of a filter. The zeroth horizontal
     // element is included in the sum twice, so the coefficient is halved to
     // compensate. Each filter is (2 * arraySize) + 1 elements wide.
-    static const qint32 arraySize = 14;
+    static const qint32 arraySize = 7;
     double cfilt[arraySize + 1][4];
     double yfilt[arraySize + 1][2];
 

--- a/tools/ld-chroma-decoder/palcolour.h
+++ b/tools/ld-chroma-decoder/palcolour.h
@@ -28,6 +28,7 @@
 #include <QObject>
 #include <QtMath>
 #include <QDebug>
+#include <cassert>
 
 #include "lddecodemetadata.h"
 
@@ -52,8 +53,13 @@ private:
 
     // Look up tables array and constant definitions
     double sine[MAX_WIDTH], cosine[MAX_WIDTH];    // formerly short int
-    static const qint32 arraySize = 14; // 'a' is the array-size, corresponding to at least half the filter-width, and should be at least Fsampling(max supported by build)/colourfilterBandwidth(min supported by build)
-    //  'a' must be greater than or equal to the bigger of 'ca' and 'ya' above
+    // cfilt and yfilt are the coefficients for the chroma and luma 2D FIR filters.
+    // The filters are horizontally and vertically symmetrical (with signs
+    // adjusted later to deal with phase differences between lines), so each
+    // 2D array represents one quarter of a filter. The zeroth horizontal
+    // element is included in the sum twice, so the coefficient is halved to
+    // compensate. Each filter is (2 * arraySize) + 1 elements wide.
+    static const qint32 arraySize = 14;
     double cfilt[arraySize + 1][4];
     double yfilt[arraySize + 1][2];
 

--- a/tools/ld-chroma-decoder/palcolour.h
+++ b/tools/ld-chroma-decoder/palcolour.h
@@ -57,8 +57,6 @@ private:
     double cfilt[arraySize + 1][4];
     double yfilt[arraySize + 1][2];
 
-    double cdiv;
-    double ydiv;
     double refAmpl;
     double normalise;
     QByteArray outputFrame;


### PR DESCRIPTION
I modified PALColour to show the coefficients it was using for its 2D FIR filters, and was a bit surprised to find that half the array was zeroes!

This means that we can reduce the width of the filter arrays from 14 to 7 -- i.e. the chroma filter goes from 29x9 to 15x9 -- nearly doubling the speed of the filter code.

This may need revisiting if we add NTSC support back in at some point, depending on how different the sample rate is (but I've added some asserts that will trip if this is necessary).