### PR TITLE
Zoom tweaks

### DIFF
--- a/tools/ld-analyse/configuration.cpp
+++ b/tools/ld-analyse/configuration.cpp
@@ -70,6 +70,7 @@ void Configuration::writeConfiguration(void)
     // Windows
     configuration->beginGroup("windows");
     configuration->setValue("mainWindowGeometry", settings.windows.mainWindowGeometry);
+    configuration->setValue("mainWindowScaleFactor", settings.windows.mainWindowScaleFactor);
     configuration->setValue("vbiDialogGeometry", settings.windows.vbiDialogGeometry);
     configuration->setValue("oscilloscopeDialogGeometry", settings.windows.oscilloscopeDialogGeometry);
     configuration->setValue("dropoutAnalysisDialogGeometry", settings.windows.dropoutAnalysisDialogGeometry);
@@ -98,6 +99,7 @@ void Configuration::readConfiguration(void)
     // Windows
     configuration->beginGroup("windows");
     settings.windows.mainWindowGeometry = configuration->value("mainWindowGeometry").toByteArray();
+    settings.windows.mainWindowScaleFactor = configuration->value("mainWindowScaleFactor").toReal();
     settings.windows.vbiDialogGeometry = configuration->value("vbiDialogGeometry").toByteArray();
     settings.windows.oscilloscopeDialogGeometry = configuration->value("oscilloscopeDialogGeometry").toByteArray();
     settings.windows.dropoutAnalysisDialogGeometry = configuration->value("dropoutAnalysisDialogGeometry").toByteArray();
@@ -117,6 +119,7 @@ void Configuration::setDefault(void)
 
     // Windows
     settings.windows.mainWindowGeometry = QByteArray();
+    settings.windows.mainWindowScaleFactor = 1.0;
     settings.windows.vbiDialogGeometry = QByteArray();
     settings.windows.oscilloscopeDialogGeometry = QByteArray();
     settings.windows.dropoutAnalysisDialogGeometry = QByteArray();
@@ -168,6 +171,16 @@ void Configuration::setMainWindowGeometry(QByteArray mainWindowGeometry)
 QByteArray Configuration::getMainWindowGeometry(void)
 {
     return settings.windows.mainWindowGeometry;
+}
+
+void Configuration::setMainWindowScaleFactor(qreal mainWindowScaleFactor)
+{
+    settings.windows.mainWindowScaleFactor = mainWindowScaleFactor;
+}
+
+qreal Configuration::getMainWindowScaleFactor(void)
+{
+    return settings.windows.mainWindowScaleFactor;
 }
 
 void Configuration::setVbiDialogGeometry(QByteArray vbiDialogGeometry)

--- a/tools/ld-analyse/configuration.h
+++ b/tools/ld-analyse/configuration.h
@@ -54,6 +54,8 @@ public:
     // Get and set methods - windows
     void setMainWindowGeometry(QByteArray mainWindowGeometry);
     QByteArray getMainWindowGeometry(void);
+    void setMainWindowScaleFactor(qreal mainWindowScaleFactor);
+    qreal getMainWindowScaleFactor(void);
     void setVbiDialogGeometry(QByteArray vbiDialogGeometry);
     QByteArray getVbiDialogGeometry(void);
     void setOscilloscopeDialogGeometry(QByteArray oscilloscopeDialogGeometry);
@@ -80,6 +82,7 @@ private:
     // Window geometry and settings
     struct Windows {
         QByteArray mainWindowGeometry;
+        qreal mainWindowScaleFactor;
         QByteArray vbiDialogGeometry;
         QByteArray oscilloscopeDialogGeometry;
         QByteArray dropoutAnalysisDialogGeometry;

--- a/tools/ld-analyse/mainwindow.cpp
+++ b/tools/ld-analyse/mainwindow.cpp
@@ -271,7 +271,8 @@ void MainWindow::showFrame(void)
 void MainWindow::updateFrameViewer(void)
 {
     ui->frameViewerLabel->setPixmap(QPixmap::fromImage(tbcSource.getFrameImage(currentFrameNumber)));
-    ui->frameViewerLabel->setPixmap(ui->frameViewerLabel->pixmap()->scaled(scaleFactor * ui->frameViewerLabel->pixmap()->size()));
+    ui->frameViewerLabel->setPixmap(ui->frameViewerLabel->pixmap()->scaled(scaleFactor * ui->frameViewerLabel->pixmap()->size(),
+                                                                           Qt::IgnoreAspectRatio, Qt::SmoothTransformation));
 }
 
 // Method to hide the current frame

--- a/tools/ld-analyse/mainwindow.cpp
+++ b/tools/ld-analyse/mainwindow.cpp
@@ -46,9 +46,8 @@ MainWindow::MainWindow(QString inputFilenameParam, QWidget *parent) :
     sourceVideoStatus.setText(tr("No source video file loaded"));
     fieldNumberStatus.setText(tr(" -  Fields: ./."));
 
-    // Set the initial frame number and scale
+    // Set the initial frame number
     currentFrameNumber = 1;
-    scaleFactor = 1.0;
 
     // Add an event filter to the frame viewer label to catch mouse events
 //    ui->frameViewerLabel->installEventFilter(ui->frameViewerLabel);
@@ -62,8 +61,9 @@ MainWindow::MainWindow(QString inputFilenameParam, QWidget *parent) :
     connect(&tbcSource, &TbcSource::busyLoading, this, &MainWindow::on_busyLoading);
     connect(&tbcSource, &TbcSource::finishedLoading, this, &MainWindow::on_finishedLoading);
 
-    // Load the window geometry from the configuration
+    // Load the window geometry and settings from the configuration
     restoreGeometry(configuration.getMainWindowGeometry());
+    scaleFactor = configuration.getMainWindowScaleFactor();
     vbiDialog->restoreGeometry(configuration.getVbiDialogGeometry());
     oscilloscopeDialog->restoreGeometry(configuration.getOscilloscopeDialogGeometry());
     dropoutAnalysisDialog->restoreGeometry(configuration.getDropoutAnalysisDialogGeometry());
@@ -83,8 +83,9 @@ MainWindow::MainWindow(QString inputFilenameParam, QWidget *parent) :
 
 MainWindow::~MainWindow()
 {
-    // Save the window geometry to the configuration
+    // Save the window geometry and settings to the configuration
     configuration.setMainWindowGeometry(saveGeometry());
+    configuration.setMainWindowScaleFactor(scaleFactor);
     configuration.setVbiDialogGeometry(vbiDialog->saveGeometry());
     configuration.setOscilloscopeDialogGeometry(oscilloscopeDialog->saveGeometry());
     configuration.setDropoutAnalysisDialogGeometry(dropoutAnalysisDialog->saveGeometry());
@@ -166,9 +167,6 @@ void MainWindow::updateGuiLoaded(void)
     statusText += QString::number(tbcSource.getNumberOfFrames());
     statusText += " sequential frames available";
     sourceVideoStatus.setText(statusText);
-
-    // Set the frame scale factor
-    scaleFactor = 1.0;
 
     // Show the current frame
     showFrame();

--- a/tools/ld-analyse/mainwindow.cpp
+++ b/tools/ld-analyse/mainwindow.cpp
@@ -136,7 +136,11 @@ void MainWindow::updateGuiLoaded(void)
     ui->actionNTSC->setEnabled(true);
     ui->actionVideo_metadata->setEnabled(true);
     ui->actionVITS_Metrics->setEnabled(true);
-    ui->action1_1_Frame_size->setEnabled(true);
+    ui->actionZoom_In->setEnabled(true);
+    ui->actionZoom_Out->setEnabled(true);
+    ui->actionZoom_1x->setEnabled(true);
+    ui->actionZoom_2x->setEnabled(true);
+    ui->actionZoom_3x->setEnabled(true);
     ui->actionDropout_analysis->setEnabled(true);
     ui->actionSNR_analysis->setEnabled(true);
     ui->actionSave_frame_as_PNG->setEnabled(true);
@@ -204,7 +208,11 @@ void MainWindow::updateGuiUnloaded(void)
     ui->actionNTSC->setEnabled(false);
     ui->actionVideo_metadata->setEnabled(false);
     ui->actionVITS_Metrics->setEnabled(false);
-    ui->action1_1_Frame_size->setEnabled(false);
+    ui->actionZoom_In->setEnabled(false);
+    ui->actionZoom_Out->setEnabled(false);
+    ui->actionZoom_1x->setEnabled(false);
+    ui->actionZoom_2x->setEnabled(false);
+    ui->actionZoom_3x->setEnabled(false);
     ui->actionDropout_analysis->setEnabled(false);
     ui->actionSNR_analysis->setEnabled(false);
     ui->actionSave_frame_as_PNG->setEnabled(false);
@@ -561,15 +569,29 @@ void MainWindow::on_actionZoom_In_triggered()
 }
 
 // Zoom out
-void MainWindow::on_actionZoom_out_triggered()
+void MainWindow::on_actionZoom_Out_triggered()
 {
     on_zoomOutPushButton_clicked();
 }
 
 // Original size 1:1 zoom
-void MainWindow::on_action1_1_Frame_size_triggered()
+void MainWindow::on_actionZoom_1x_triggered()
 {
     on_originalSizePushButton_clicked();
+}
+
+// 2:1 zoom
+void MainWindow::on_actionZoom_2x_triggered()
+{
+    scaleFactor = 2.0;
+    updateFrameViewer();
+}
+
+// 3:1 zoom
+void MainWindow::on_actionZoom_3x_triggered()
+{
+    scaleFactor = 3.0;
+    updateFrameViewer();
 }
 
 // Zoom in

--- a/tools/ld-analyse/mainwindow.cpp
+++ b/tools/ld-analyse/mainwindow.cpp
@@ -171,7 +171,7 @@ void MainWindow::updateGuiLoaded(void)
     scaleFactor = 1.0;
 
     // Show the current frame
-    showFrame(currentFrameNumber);
+    showFrame();
 }
 
 // Method to update the GUI when a file is unloaded
@@ -231,14 +231,14 @@ void MainWindow::updateGuiUnloaded(void)
 }
 
 // Method to display a sequential frame
-void MainWindow::showFrame(qint32 frameNumber)
+void MainWindow::showFrame(void)
 {
     // Show the field numbers
-    fieldNumberStatus.setText(" -  Fields: " + QString::number(tbcSource.getFirstFieldNumber(frameNumber)) + "/" +
-                              QString::number(tbcSource.getSecondFieldNumber(frameNumber)));
+    fieldNumberStatus.setText(" -  Fields: " + QString::number(tbcSource.getFirstFieldNumber(currentFrameNumber)) + "/" +
+                              QString::number(tbcSource.getSecondFieldNumber(currentFrameNumber)));
 
     // If there are dropouts in the frame, highlight the show dropouts button
-    if (tbcSource.getIsDropoutPresent(frameNumber)) {
+    if (tbcSource.getIsDropoutPresent(currentFrameNumber)) {
         QPalette tempPalette = buttonPalette;
         tempPalette.setColor(QPalette::Button, QColor(Qt::lightGray));
         ui->dropoutsPushButton->setAutoFillBackground(true);
@@ -258,7 +258,7 @@ void MainWindow::showFrame(qint32 frameNumber)
     ui->frameViewerLabel->clear();
     ui->frameViewerLabel->setScaledContents(false);
     ui->frameViewerLabel->setAlignment(Qt::AlignCenter);
-    ui->frameViewerLabel->setPixmap(QPixmap::fromImage(tbcSource.getFrameImage(frameNumber)));
+    ui->frameViewerLabel->setPixmap(QPixmap::fromImage(tbcSource.getFrameImage(currentFrameNumber)));
     ui->frameViewerLabel->setPixmap(ui->frameViewerLabel->pixmap()->scaled(scaleFactor * ui->frameViewerLabel->pixmap()->size()));
 
     // If the scope window is open, update it too (using the last scope line selected by the user)
@@ -361,7 +361,7 @@ void MainWindow::on_frameNumberSpinBox_editingFinished()
         if (ui->frameNumberSpinBox->value() > tbcSource.getNumberOfFrames()) ui->frameNumberSpinBox->setValue(tbcSource.getNumberOfFrames());
         currentFrameNumber = ui->frameNumberSpinBox->value();
         ui->frameHorizontalSlider->setValue(currentFrameNumber);
-        showFrame(currentFrameNumber);
+        showFrame();
     }
 }
 
@@ -377,7 +377,7 @@ void MainWindow::on_frameHorizontalSlider_valueChanged(int value)
     // otherwisew we just ignore this
     if (ui->frameNumberSpinBox->isEnabled()) {
         ui->frameNumberSpinBox->setValue(currentFrameNumber);
-        showFrame(currentFrameNumber);
+        showFrame();
     }
 }
 
@@ -510,7 +510,7 @@ void MainWindow::on_videoPushButton_clicked()
     }
 
     // Show the current frame
-    showFrame(currentFrameNumber);
+    showFrame();
 }
 
 // Show/hide dropouts button clicked
@@ -525,7 +525,7 @@ void MainWindow::on_dropoutsPushButton_clicked()
     }
 
     // Show the current frame (why isn't this option passed?)
-    showFrame(currentFrameNumber);
+    showFrame();
 }
 
 // Normal/Reverse field order button clicked
@@ -546,7 +546,7 @@ void MainWindow::on_fieldOrderPushButton_clicked()
     }
 
     // Show the current frame
-    showFrame(currentFrameNumber);
+    showFrame();
 }
 
 // Zoom in

--- a/tools/ld-analyse/mainwindow.cpp
+++ b/tools/ld-analyse/mainwindow.cpp
@@ -258,14 +258,20 @@ void MainWindow::showFrame(void)
     ui->frameViewerLabel->clear();
     ui->frameViewerLabel->setScaledContents(false);
     ui->frameViewerLabel->setAlignment(Qt::AlignCenter);
-    ui->frameViewerLabel->setPixmap(QPixmap::fromImage(tbcSource.getFrameImage(currentFrameNumber)));
-    ui->frameViewerLabel->setPixmap(ui->frameViewerLabel->pixmap()->scaled(scaleFactor * ui->frameViewerLabel->pixmap()->size()));
+    updateFrameViewer();
 
     // If the scope window is open, update it too (using the last scope line selected by the user)
     if (oscilloscopeDialog->isVisible()) {
         // Show the oscilloscope dialogue for the selected scan-line
         updateOscilloscopeDialogue(currentFrameNumber, lastScopeLine);
     }
+}
+
+// Redraw the frame viewer (for example, when scaleFactor has been changed)
+void MainWindow::updateFrameViewer(void)
+{
+    ui->frameViewerLabel->setPixmap(QPixmap::fromImage(tbcSource.getFrameImage(currentFrameNumber)));
+    ui->frameViewerLabel->setPixmap(ui->frameViewerLabel->pixmap()->scaled(scaleFactor * ui->frameViewerLabel->pixmap()->size()));
 }
 
 // Method to hide the current frame
@@ -575,9 +581,7 @@ void MainWindow::on_zoomInPushButton_clicked()
         scaleFactor *= factor;
     }
 
-    //ui->frameViewerLabel->resize(scaleFactor * ui->frameViewerLabel->pixmap()->size());
-    ui->frameViewerLabel->setPixmap(QPixmap::fromImage(tbcSource.getFrameImage(currentFrameNumber)));
-    ui->frameViewerLabel->setPixmap(ui->frameViewerLabel->pixmap()->scaled(scaleFactor * ui->frameViewerLabel->pixmap()->size()));
+    updateFrameViewer();
 }
 
 // Zoom out
@@ -588,17 +592,14 @@ void MainWindow::on_zoomOutPushButton_clicked()
         scaleFactor *= factor;
     }
 
-    //ui->frameViewerLabel->resize(scaleFactor * ui->frameViewerLabel->pixmap()->size());
-    ui->frameViewerLabel->setPixmap(QPixmap::fromImage(tbcSource.getFrameImage(currentFrameNumber)));
-    ui->frameViewerLabel->setPixmap(ui->frameViewerLabel->pixmap()->scaled(scaleFactor * ui->frameViewerLabel->pixmap()->size()));
+    updateFrameViewer();
 }
 
 // Original size 1:1 zoom
 void MainWindow::on_originalSizePushButton_clicked()
 {
     scaleFactor = 1.0;
-    ui->frameViewerLabel->setPixmap(QPixmap::fromImage(tbcSource.getFrameImage(currentFrameNumber)));
-    ui->frameViewerLabel->setPixmap(ui->frameViewerLabel->pixmap()->scaled(scaleFactor * ui->frameViewerLabel->pixmap()->size()));
+    updateFrameViewer();
 }
 
 void MainWindow::scanLineChangedSignalHandler(qint32 scanLine)

--- a/tools/ld-analyse/mainwindow.h
+++ b/tools/ld-analyse/mainwindow.h
@@ -119,6 +119,7 @@ private:
     void updateGuiUnloaded(void);
 
     void showFrame(void);
+    void updateFrameViewer(void);
     void hideFrame(void);
 
     void loadTbcFile(QString inputFileName);

--- a/tools/ld-analyse/mainwindow.h
+++ b/tools/ld-analyse/mainwindow.h
@@ -118,7 +118,7 @@ private:
     void updateGuiLoaded(void);
     void updateGuiUnloaded(void);
 
-    void showFrame(qint32 frameNumber);
+    void showFrame(void);
     void hideFrame(void);
 
     void loadTbcFile(QString inputFileName);

--- a/tools/ld-analyse/mainwindow.h
+++ b/tools/ld-analyse/mainwindow.h
@@ -84,8 +84,10 @@ private slots:
     void on_finishedLoading();
 
     void on_actionZoom_In_triggered();
-    void on_actionZoom_out_triggered();
-    void on_action1_1_Frame_size_triggered();
+    void on_actionZoom_Out_triggered();
+    void on_actionZoom_1x_triggered();
+    void on_actionZoom_2x_triggered();
+    void on_actionZoom_3x_triggered();
     void on_zoomInPushButton_clicked();
     void on_zoomOutPushButton_clicked();
     void on_originalSizePushButton_clicked();

--- a/tools/ld-analyse/mainwindow.ui
+++ b/tools/ld-analyse/mainwindow.ui
@@ -489,10 +489,16 @@
    <property name="text">
     <string>Zoom In</string>
    </property>
+   <property name="shortcut">
+    <string>Ctrl++</string>
+   </property>
   </action>
   <action name="actionZoom_out">
    <property name="text">
     <string>Zoom Out</string>
+   </property>
+   <property name="shortcut">
+    <string>Ctrl+-</string>
    </property>
   </action>
  </widget>

--- a/tools/ld-analyse/mainwindow.ui
+++ b/tools/ld-analyse/mainwindow.ui
@@ -378,8 +378,10 @@
      <string>View</string>
     </property>
     <addaction name="actionZoom_In"/>
-    <addaction name="actionZoom_out"/>
-    <addaction name="action1_1_Frame_size"/>
+    <addaction name="actionZoom_Out"/>
+    <addaction name="actionZoom_1x"/>
+    <addaction name="actionZoom_2x"/>
+    <addaction name="actionZoom_3x"/>
    </widget>
    <addaction name="menuFile"/>
    <addaction name="menuView"/>
@@ -440,12 +442,28 @@
     <string>Ctrl+M</string>
    </property>
   </action>
-  <action name="action1_1_Frame_size">
+  <action name="actionZoom_1x">
    <property name="text">
-    <string>1:1 Frame size</string>
+    <string>Zoom to original size</string>
    </property>
    <property name="shortcut">
     <string>Ctrl+1</string>
+   </property>
+  </action>
+  <action name="actionZoom_2x">
+   <property name="text">
+    <string>Zoom to 2x size</string>
+   </property>
+   <property name="shortcut">
+    <string>Ctrl+2</string>
+   </property>
+  </action>
+  <action name="actionZoom_3x">
+   <property name="text">
+    <string>Zoom to 3x size</string>
+   </property>
+   <property name="shortcut">
+    <string>Ctrl+3</string>
    </property>
   </action>
   <action name="actionDropout_analysis">
@@ -493,7 +511,7 @@
     <string>Ctrl++</string>
    </property>
   </action>
-  <action name="actionZoom_out">
+  <action name="actionZoom_Out">
    <property name="text">
     <string>Zoom Out</string>
    </property>


### PR DESCRIPTION
Some minor tweaks to ld-analyse's new zoom menu to make it work better on larger displays:

- Remember the zoom setting in the configuration
- Use bilinear image scaling
- Add keyboard shortcuts for zooming
- Add menu entries for 2x/3x zoom