### PR TITLE
Use ffmpeg resampling to handle non-standard sample rates

### DIFF
--- a/ld-decode.py
+++ b/ld-decode.py
@@ -37,7 +37,7 @@ parser.add_argument('--verboseVITS', dest='verboseVITS', action='store_true', de
 
 parser.add_argument('-t', '--threads', metavar='threads', type=int, default=5, help='number of CPU threads to use')
 
-parser.add_argument('-f', '--frequency', dest='inputfreq', metavar='FREQ', type=parse_frequency, default=40, help='RF sampling frequency (default is 40MHz)')
+parser.add_argument('-f', '--frequency', dest='inputfreq', metavar='FREQ', type=parse_frequency, default=None, help='RF sampling frequency in source file (default is 40MHz)')
 parser.add_argument('--video_bpf_high', dest='vbpf_high', metavar='FREQ', type=parse_frequency, default=None, help='Video BPF high end frequency')
 parser.add_argument('--video_lpf', dest='vlpf', metavar='FREQ', type=parse_frequency, default=None, help='Video low-pass filter frequency')
 
@@ -54,11 +54,15 @@ if args.pal and args.ntsc:
     print("ERROR: Can only be PAL or NTSC")
     exit(1)
 
-loader = make_loader(filename)
+try:
+    loader = make_loader(filename, args.inputfreq)
+except ValueError as e:
+    print(e)
+    exit(1)
 
 system = 'PAL' if args.pal else 'NTSC'
     
-ldd = LDdecode(filename, outname, loader, inputfreq = args.inputfreq, analog_audio = not args.daa, digital_audio = not args.noefm, system=system, doDOD = not args.nodod, threads=args.threads)
+ldd = LDdecode(filename, outname, loader, analog_audio = not args.daa, digital_audio = not args.noefm, system=system, doDOD = not args.nodod, threads=args.threads)
 ldd.roughseek(firstframe * 2)
 
 if system == 'NTSC' and not args.ntscj:

--- a/ld-decode.py
+++ b/ld-decode.py
@@ -54,15 +54,6 @@ if args.pal and args.ntsc:
     print("ERROR: Can only be PAL or NTSC")
     exit(1)
 
-# make sure we have at least two frames' worth of data (so we can be sure we will get at least one full frame)
-#infile_size = os.path.getsize(filename)
-#if (infile_size // bytes_per_frame - firstframe) < 2: 
-	#print('Error: start frame is past end of file')
-	#exit(1)
-#num_frames = req_frames if req_frames is not None else infile_size // bytes_per_frame - firstframe
-
-#fd = open(filename, 'rb')
-
 if filename[-3:] == 'lds':
     loader = load_packed_data_4_40
 elif filename[-3:] == 'r30':

--- a/ld-decode.py
+++ b/ld-decode.py
@@ -54,18 +54,7 @@ if args.pal and args.ntsc:
     print("ERROR: Can only be PAL or NTSC")
     exit(1)
 
-if filename[-3:] == 'lds':
-    loader = load_packed_data_4_40
-elif filename[-3:] == 'r30':
-    loader = load_packed_data_3_32
-elif filename[-3:] == 'r16':
-    loader = load_unpacked_data_s16
-elif filename[-2:] == 'r8':
-    loader = load_unpacked_data_u8
-elif filename[-7:] == 'raw.oga':
-    loader = LoadFFmpeg()
-else:
-    loader = load_packed_data_4_40
+loader = make_loader(filename)
 
 system = 'PAL' if args.pal else 'NTSC'
     

--- a/lddecode_core.py
+++ b/lddecode_core.py
@@ -2060,7 +2060,7 @@ class CombNTSC:
 
 class LDdecode:
     
-    def __init__(self, fname_in, fname_out, freader, inputfreq = 40, analog_audio = True, digital_audio = False, system = 'NTSC', doDOD = True, threads=4):
+    def __init__(self, fname_in, fname_out, freader, analog_audio = True, digital_audio = False, system = 'NTSC', doDOD = True, threads=4):
         self.demodcache = None
 
         self.infile = open(fname_in, 'rb')
@@ -2104,7 +2104,7 @@ class LDdecode:
         self.fieldloc = 0
 
         self.system = system
-        self.rf = RFDecode(inputfreq=inputfreq, system=system, decode_analog_audio=analog_audio, decode_digital_audio=digital_audio)
+        self.rf = RFDecode(system=system, decode_analog_audio=analog_audio, decode_digital_audio=digital_audio)
         if system == 'PAL':
             self.FieldClass = FieldPAL
             self.readlen = self.rf.linelen * 400

--- a/lddutils.py
+++ b/lddutils.py
@@ -142,8 +142,8 @@ frequency_suffixes = [
     ("fscpal", (283.75 * 15625) + 25),
 ]
 
-"""Parse an argument string, returning a float frequency in MHz."""
 def parse_frequency(string):
+    """Parse an argument string, returning a float frequency in MHz."""
     multiplier = 1.0e6
     for suffix, mult in frequency_suffixes:
         if string.lower().endswith(suffix):

--- a/lddutils.py
+++ b/lddutils.py
@@ -166,6 +166,22 @@ Returns data if successful, or None or an upstream exception if not (including i
 This might probably need to become a full object once FLAC support is added.
 '''
 
+def make_loader(filename):
+    """Return an appropriate loader function for filename."""
+
+    if filename[-3:] == 'lds':
+        return load_packed_data_4_40
+    elif filename[-3:] == 'r30':
+        return load_packed_data_3_32
+    elif filename[-3:] == 'r16':
+        return load_unpacked_data_s16
+    elif filename[-2:] == 'r8':
+        return load_unpacked_data_u8
+    elif filename[-7:] == 'raw.oga':
+        return LoadFFmpeg()
+    else:
+        return load_packed_data_4_40
+
 def load_unpacked_data(infile, sample, readlen, sampletype):
     # this is run for unpacked data - 1 is for old cxadc data, 2 for 16bit DD
     infile.seek(sample * sampletype, 0)

--- a/lddutils.py
+++ b/lddutils.py
@@ -162,8 +162,6 @@ sample: starting sample #
 readlen: # of samples
 ```
 Returns data if successful, or None or an upstream exception if not (including if not enough data is available)
-
-This might probably need to become a full object once FLAC support is added.
 '''
 
 def make_loader(filename):

--- a/lddutils.py
+++ b/lddutils.py
@@ -336,6 +336,11 @@ class LoadFFmpeg:
         self.rewind_size = 2 * 1024 * 1024
         self.rewind_buf = b''
 
+    def __del__(self):
+        if self.ffmpeg is not None:
+            self.ffmpeg.kill()
+            self.ffmpeg.wait()
+
     def _read_data(self, count):
         """Read data as bytes from ffmpeg, append it to the rewind buffer, and
         return it. May return less than count bytes if EOF is reached."""


### PR DESCRIPTION
This seems to work pretty well - I've tried it with a number of 8fSC captures and it produces better results than running the rest of the decoder at 8fSC. It should simplify future testing as well.

The script i used to test this with a few different input formats is [here](https://github.com/atsampson/ld-decode-testsuite/blob/master/try-ld-decode).

There's probably enough loader code in lddutils to make it worth moving into a module of its own now (lddecode.loaders?).