### PR TITLE
Minor ld-chroma-decoder improvements

### DIFF
--- a/tools/ld-analyse/tbcsource.cpp
+++ b/tools/ld-analyse/tbcsource.cpp
@@ -536,7 +536,7 @@ QImage TbcSource::generateQImage(qint32 firstFieldNumber, qint32 secondFieldNumb
 
             // Perform the PALcolour filtering (output is RGB 16-16-16)
             outputData = palColour.performDecode(firstFieldData, secondFieldData,
-                                                  100, static_cast<qint32>(tSaturation), false);
+                                                  100, static_cast<qint32>(tSaturation));
         } else {
             // NTSC source
 

--- a/tools/ld-chroma-decoder/palcolour.cpp
+++ b/tools/ld-chroma-decoder/palcolour.cpp
@@ -153,7 +153,7 @@ void PalColour::buildLookUpTables()
 //
 // Note: This method does not clear the output array before writing to it; if there is garbage
 // in the allocated memory, it will be in the output with the decoded image on top.
-QByteArray PalColour::performDecode(QByteArray firstFieldData, QByteArray secondFieldData, qint32 brightness, qint32 saturation, bool blackAndWhite)
+QByteArray PalColour::performDecode(QByteArray firstFieldData, QByteArray secondFieldData, qint32 brightness, qint32 saturation)
 {
     // Ensure the object has been configured
     if (!configurationSet) {
@@ -322,12 +322,6 @@ QByteArray PalColour::performDecode(QByteArray firstFieldData, QByteArray second
                     // burst phase (relative to the arb phase), in order to recover U and V. The Vswitch is applied to flip the V-phase on alternate lines for PAL
                     rU = (-((pu[i]*bp+qu[i]*bq)) * scaledSaturation);
                     rV = (-(Vsw*(qv[i]*bp-pv[i]*bq)) * scaledSaturation);
-
-                    // Remove UV colour components if black and white (Y only) output is required
-                    if (blackAndWhite) {
-                        rU = 0;
-                        rV = 0;
-                    }
 
                     // This conversion is taken from Video Demystified (5th edition) page 18
                     R = ( rY + (1.140 * rV) );

--- a/tools/ld-chroma-decoder/palcolour.cpp
+++ b/tools/ld-chroma-decoder/palcolour.cpp
@@ -51,9 +51,15 @@ void PalColour::updateConfiguration(LdDecodeMetaData::VideoParameters videoParam
 // must be called by the constructor when the object is created
 void PalColour::buildLookUpTables()
 {
-    // Step 1: create sine/cosine lookups
+    // Generate quadrature samples of a sine wave at the subcarrier frequency.
+    // We'll use this for two purposes below:
+    // - product-detecting the line samples, to give us quadrature samples of
+    //   the chroma information centred on 0 Hz
+    // - working out what the phase of the subcarrier is on each line,
+    //   so we can rotate the chroma samples to put U/V on the right axes
+    // refAmpl is the sinewave amplitude.
     refAmpl = 1.28;
-    normalise = (refAmpl * refAmpl / 2);     // refAmpl is the integer sinewave amplitude
+    normalise = (refAmpl * refAmpl / 2);
 
     double rad;
     for (qint32 i = 0; i < videoParameters.fieldWidth; i++)
@@ -84,8 +90,6 @@ void PalColour::buildLookUpTables()
     assert(arraySize >= static_cast<qint32>(ca));
     assert(arraySize >= static_cast<qint32>(ya));
 
-    // Simon: The array declarations (used here and in the processing method) have been moved
-    // to the class' private space (in the .h)
     double cdiv=0;
     double ydiv=0;
 
@@ -166,9 +170,6 @@ QByteArray PalColour::performDecode(QByteArray firstFieldData, QByteArray second
     double scaledBrightness = (65535.0 / (videoParameters.white16bIre - videoParameters.black16bIre)) * brightness / 100.0;
 
     if (!firstFieldData.isNull() && !secondFieldData.isNull()) {
-        // Step 2:
-
-        // were all short ints
         double pu[MAX_WIDTH], qu[MAX_WIDTH], pv[MAX_WIDTH], qv[MAX_WIDTH], py[MAX_WIDTH], qy[MAX_WIDTH];
         double m[4][MAX_WIDTH], n[4][MAX_WIDTH];
 

--- a/tools/ld-chroma-decoder/palcolour.cpp
+++ b/tools/ld-chroma-decoder/palcolour.cpp
@@ -150,9 +150,6 @@ void PalColour::buildLookUpTables()
 
 // Performs a decode of the 16-bit greyscale input frame and produces a RGB 16-16-16-bit output frame
 // with 16 bit processing
-//
-// Note: This method does not clear the output array before writing to it; if there is garbage
-// in the allocated memory, it will be in the output with the decoded image on top.
 QByteArray PalColour::performDecode(QByteArray firstFieldData, QByteArray secondFieldData, qint32 brightness, qint32 saturation)
 {
     // Ensure the object has been configured

--- a/tools/ld-chroma-decoder/palcolour.cpp
+++ b/tools/ld-chroma-decoder/palcolour.cpp
@@ -175,38 +175,18 @@ QByteArray PalColour::performDecode(QByteArray firstFieldData, QByteArray second
 
         qint32 Vsw; // this will represent the PAL Vswitch state later on...
 
-        // Since we're not using Image objects, we need a pointer to the 16-bit image data
-        quint16 *topFieldDataPointer = reinterpret_cast<quint16*>(firstFieldData.data());
-        quint16 *bottomFieldDataPointer = reinterpret_cast<quint16*>(secondFieldData.data());
-
-        // Define the 16-bit line buffers
-        quint16 *b0 = nullptr;
-        quint16 *b1 = nullptr;
-        quint16 *b2 = nullptr;
-        quint16 *b3 = nullptr;
-        quint16 *b4 = nullptr;
-        quint16 *b5 = nullptr;
-        quint16 *b6 = nullptr;
-
         for (qint32 field = 0; field < 2; field++) {
+            const quint16 *fieldData = reinterpret_cast<const quint16 *>(field == 0 ? firstFieldData.data()
+                                                                                    : secondFieldData.data());
+
             for (qint32 fieldLine = 3; fieldLine < (videoParameters.fieldHeight - 3); fieldLine++) {
-                if (field == 0) {
-                    b0 = topFieldDataPointer+ (fieldLine      * (videoParameters.fieldWidth));
-                    b1 = topFieldDataPointer+((fieldLine - 1) * (videoParameters.fieldWidth));
-                    b2 = topFieldDataPointer+((fieldLine + 1) * (videoParameters.fieldWidth));
-                    b3 = topFieldDataPointer+((fieldLine - 2) * (videoParameters.fieldWidth));
-                    b4 = topFieldDataPointer+((fieldLine + 2) * (videoParameters.fieldWidth));
-                    b5 = topFieldDataPointer+((fieldLine - 3) * (videoParameters.fieldWidth));
-                    b6 = topFieldDataPointer+((fieldLine + 3) * (videoParameters.fieldWidth));
-                } else {
-                    b0 = bottomFieldDataPointer+ (fieldLine      * (videoParameters.fieldWidth));
-                    b1 = bottomFieldDataPointer+((fieldLine - 1) * (videoParameters.fieldWidth));
-                    b2 = bottomFieldDataPointer+((fieldLine + 1) * (videoParameters.fieldWidth));
-                    b3 = bottomFieldDataPointer+((fieldLine - 2) * (videoParameters.fieldWidth));
-                    b4 = bottomFieldDataPointer+((fieldLine + 2) * (videoParameters.fieldWidth));
-                    b5 = bottomFieldDataPointer+((fieldLine - 3) * (videoParameters.fieldWidth));
-                    b6 = bottomFieldDataPointer+((fieldLine + 3) * (videoParameters.fieldWidth));
-                }
+                const quint16 *b0 = fieldData +  (fieldLine      * (videoParameters.fieldWidth));
+                const quint16 *b1 = fieldData + ((fieldLine - 1) * (videoParameters.fieldWidth));
+                const quint16 *b2 = fieldData + ((fieldLine + 1) * (videoParameters.fieldWidth));
+                const quint16 *b3 = fieldData + ((fieldLine - 2) * (videoParameters.fieldWidth));
+                const quint16 *b4 = fieldData + ((fieldLine + 2) * (videoParameters.fieldWidth));
+                const quint16 *b5 = fieldData + ((fieldLine - 3) * (videoParameters.fieldWidth));
+                const quint16 *b6 = fieldData + ((fieldLine + 3) * (videoParameters.fieldWidth));
 
                 for (qint32 i = videoParameters.colourBurstStart; i < videoParameters.fieldWidth; i++) {
                     // The 2D filter is vertically symmetrical, so we can

--- a/tools/ld-chroma-decoder/palcolour.cpp
+++ b/tools/ld-chroma-decoder/palcolour.cpp
@@ -165,10 +165,8 @@ QByteArray PalColour::performDecode(QByteArray firstFieldData, QByteArray second
     // is no picture data
     outputFrame.fill(0);
 
-    // Note: 1.75 is the nominal scaling factor of 75% amplitude for full-range digitised
-    // composite (with sync at code 0 or 1, blanking at code 64 (40h), and peak white at
-    // code 211 (d3h) to give 0-255 RGB).
-    double scaledBrightness = 1.75 * brightness / 100.0;
+    // Scaling factor to put black at 0 and peak white at 65535
+    double scaledBrightness = (65535.0 / (videoParameters.white16bIre - videoParameters.black16bIre)) * brightness / 100.0;
 
     if (!firstFieldData.isNull() && !secondFieldData.isNull()) {
         // Step 2:
@@ -325,7 +323,6 @@ QByteArray PalColour::performDecode(QByteArray firstFieldData, QByteArray second
                 {
                     // the next two lines "rotate" the p&q components (at the arbitrary sine/cosine reference phase) backwards by the
                     // burst phase (relative to the arb phase), in order to recover U and V. The Vswitch is applied to flip the V-phase on alternate lines for PAL
-                    // The scaledBrightness provides 75% amplitude (x1.75)
                     rY = Y[i] * scaledBrightness;
                     rU = (-((pu[i]*bp+qu[i]*bq)) * scaledSaturation);
                     rV = (-(Vsw*(qv[i]*bp-pv[i]*bq)) * scaledSaturation);

--- a/tools/ld-chroma-decoder/palcolour.h
+++ b/tools/ld-chroma-decoder/palcolour.h
@@ -38,7 +38,7 @@ class PalColour : public QObject
 
 public:
     explicit PalColour(QObject *parent = nullptr);
-    void updateConfiguration(LdDecodeMetaData::VideoParameters videoParametersParam);
+    void updateConfiguration(LdDecodeMetaData::VideoParameters videoParameters, qint32 firstActiveLine, qint32 lastActiveLine);
 
     // Method to perform the colour decoding
     QByteArray performDecode(QByteArray topFieldData, QByteArray bottomFieldData, qint32 brightness, qint32 saturation);
@@ -50,6 +50,8 @@ public:
 private:
     // Configuration parameters
     LdDecodeMetaData::VideoParameters videoParameters;
+    qint32 firstActiveLine;
+    qint32 lastActiveLine;
 
     // Look up tables array and constant definitions
     double sine[MAX_WIDTH], cosine[MAX_WIDTH];

--- a/tools/ld-chroma-decoder/palcolour.h
+++ b/tools/ld-chroma-decoder/palcolour.h
@@ -41,7 +41,7 @@ public:
     void updateConfiguration(LdDecodeMetaData::VideoParameters videoParametersParam);
 
     // Method to perform the colour decoding
-    QByteArray performDecode(QByteArray topFieldData, QByteArray bottomFieldData, qint32 brightness, qint32 saturation, bool blackAndWhite);
+    QByteArray performDecode(QByteArray topFieldData, QByteArray bottomFieldData, qint32 brightness, qint32 saturation);
 
     // Replacements for #DEFINE values
     static const qint32 MAX_WIDTH = 1135; // Simon: Maximum based on PAL width

--- a/tools/ld-chroma-decoder/palcolour.h
+++ b/tools/ld-chroma-decoder/palcolour.h
@@ -43,16 +43,16 @@ public:
     // Method to perform the colour decoding
     QByteArray performDecode(QByteArray topFieldData, QByteArray bottomFieldData, qint32 brightness, qint32 saturation);
 
-    // Replacements for #DEFINE values
-    static const qint32 MAX_WIDTH = 1135; // Simon: Maximum based on PAL width
-    static const qint32 MAX_HEIGHT = 625; // Simon: Maximum based on PAL height
+    // Maximum frame size, based on PAL
+    static const qint32 MAX_WIDTH = 1135;
+    static const qint32 MAX_HEIGHT = 625;
 
 private:
     // Configuration parameters
     LdDecodeMetaData::VideoParameters videoParameters;
 
     // Look up tables array and constant definitions
-    double sine[MAX_WIDTH], cosine[MAX_WIDTH];    // formerly short int
+    double sine[MAX_WIDTH], cosine[MAX_WIDTH];
     // cfilt and yfilt are the coefficients for the chroma and luma 2D FIR filters.
     // The filters are horizontally and vertically symmetrical (with signs
     // adjusted later to deal with phase differences between lines), so each

--- a/tools/ld-chroma-decoder/paldecoder.cpp
+++ b/tools/ld-chroma-decoder/paldecoder.cpp
@@ -82,10 +82,12 @@ void PalThread::run()
         // Note: This code works as a temporary MTF compensator whilst ld-decode gets
         // real MTF compensation added to it.
         qreal tSaturation = 125.0 + ((100.0 / 20.0) * (20.0 - burstMedianIre));
+        if (config.blackAndWhite) {
+            tSaturation = 0;
+        }
 
         // Perform the PALcolour filtering
-        QByteArray outputData = palColour.performDecode(firstFieldData, secondFieldData, 100,
-                                                        static_cast<qint32>(tSaturation), config.blackAndWhite);
+        QByteArray outputData = palColour.performDecode(firstFieldData, secondFieldData, 100, static_cast<qint32>(tSaturation));
 
         // The PALcolour library outputs the whole frame, so here we have to strip all the non-visible stuff to just get the
         // actual required image - it would be better if PALcolour gave back only the required RGB, but it's not my library.

--- a/tools/ld-chroma-decoder/paldecoder.cpp
+++ b/tools/ld-chroma-decoder/paldecoder.cpp
@@ -81,7 +81,10 @@ void PalThread::run()
         // Calculate the saturation level from the burst median IRE
         // Note: This code works as a temporary MTF compensator whilst ld-decode gets
         // real MTF compensation added to it.
-        qreal tSaturation = 125.0 + ((100.0 / 20.0) * (20.0 - burstMedianIre));
+        // PAL burst is 300 mV p-p (about 43 IRE, as 100 IRE = 700 mV)
+        qreal nominalBurstIre = 300 * (100.0 / 700) / 2;
+        qreal tSaturation = 100 * (nominalBurstIre / burstMedianIre);
+
         if (config.blackAndWhite) {
             tSaturation = 0;
         }

--- a/tools/ld-chroma-decoder/paldecoder.cpp
+++ b/tools/ld-chroma-decoder/paldecoder.cpp
@@ -54,7 +54,7 @@ PalThread::PalThread(QAtomicInt& abortParam, DecoderPool& decoderPoolParam,
     : QThread(parent), abort(abortParam), decoderPool(decoderPoolParam), config(configParam)
 {
     // Configure PALcolour
-    palColour.updateConfiguration(config.videoParameters);
+    palColour.updateConfiguration(config.videoParameters, config.firstActiveScanLine, config.lastActiveScanLine);
 }
 
 void PalThread::run()
@@ -92,10 +92,7 @@ void PalThread::run()
         // Perform the PALcolour filtering
         QByteArray outputData = palColour.performDecode(firstFieldData, secondFieldData, 100, static_cast<qint32>(tSaturation));
 
-        // The PALcolour library outputs the whole frame, so here we have to strip all the non-visible stuff to just get the
-        // actual required image - it would be better if PALcolour gave back only the required RGB, but it's not my library.
-        // Since PALcolour uses +-3 scan-lines to colourise, the final lines before the non-visible area may not come out quite
-        // right, but we're including them here anyway.
+        // PALcolour outputs the whole frame; crop it to the active area
         QByteArray croppedData = PalDecoder::cropOutputFrame(config, outputData);
 
         // Write the result to the output file


### PR DESCRIPTION
The general idea here is to tidy up PALcolour by updating comments and removing hardcoded values. No difference to the performance, but there are three changes here that make small differences to the output:

- Saturation is computed for PAL based on the expected burst amplitude in IRE, which results in 1% higher saturation for PAL.
- Brightness is computed for PAL based on white16bIre/black16bIre, rather than being a hardcoded factor, which results in 0.5% lower brightness for PAL.
- The final half-line is now decoded by NTSC's 2D filter; this avoids moving dot artefacts if there's bright colour in the bottom left corner:

![magentadots](https://user-images.githubusercontent.com/436317/62418209-4c02a900-b65c-11e9-8bfc-366e65c06ba7.png)

Please check that you agree with how I've computed the brightness and saturation!