### PR TITLE
Basic 2D Transform PAL filter

### DIFF
--- a/tools/ld-chroma-decoder/comb.cpp
+++ b/tools/ld-chroma-decoder/comb.cpp
@@ -284,8 +284,8 @@ void Comb::split2D(FrameBuffer *frameBuffer)
             kn /= 2;
 
             qreal p_2drange = 45 * irescale;
-            kp = clamp(1 - (kp / p_2drange), 0.0, 1.0);
-            kn = clamp(1 - (kn / p_2drange), 0.0, 1.0);
+            kp = qBound(0.0, 1 - (kp / p_2drange), 1.0);
+            kn = qBound(0.0, 1 - (kn / p_2drange), 1.0);
 
             qreal sc = 1.0;
 

--- a/tools/ld-chroma-decoder/comb.cpp
+++ b/tools/ld-chroma-decoder/comb.cpp
@@ -69,16 +69,16 @@ Comb::Configuration Comb::getConfiguration()
 }
 
 // Set the comb filter configuration parameters
-void Comb::setConfiguration(const Comb::Configuration &configurationParam)
+void Comb::setConfiguration(const Comb::Configuration &_configuration)
 {
     // Range check the frame dimensions
-    if (configuration.fieldWidth > 910) qCritical() << "Comb::Comb(): Frame width exceeds allowed maximum!";
-    if (((configuration.fieldHeight * 2) - 1) > 525) qCritical() << "Comb::Comb(): Frame height exceeds allowed maximum!";
+    if (_configuration.fieldWidth > 910) qCritical() << "Comb::Comb(): Frame width exceeds allowed maximum!";
+    if (((_configuration.fieldHeight * 2) - 1) > 525) qCritical() << "Comb::Comb(): Frame height exceeds allowed maximum!";
 
     // Range check the video start
-    if (configurationParam.activeVideoStart < 16) qCritical() << "Comb::Comb(): activeVideoStart must be > 16!";
+    if (_configuration.activeVideoStart < 16) qCritical() << "Comb::Comb(): activeVideoStart must be > 16!";
 
-    configuration = configurationParam;
+    configuration = _configuration;
     postConfigurationTasks();
 }
 

--- a/tools/ld-chroma-decoder/comb.h
+++ b/tools/ld-chroma-decoder/comb.h
@@ -62,7 +62,7 @@ public:
         qint32 activeVideoStart;
         qint32 activeVideoEnd;
 
-        qint32 firstVisibleFrameLine;
+        qint32 firstActiveLine;
 
         qint32 blackIre;
         qint32 whiteIre;

--- a/tools/ld-chroma-decoder/comb.h
+++ b/tools/ld-chroma-decoder/comb.h
@@ -72,7 +72,7 @@ public:
     };
 
     Configuration getConfiguration();
-    void setConfiguration(const Configuration &configurationParam);
+    void setConfiguration(const Configuration &configuration);
     QByteArray process(QByteArray topFieldInputBuffer, QByteArray bottomFieldInputBuffer, qreal burstMedianIre, qint32 topFieldPhaseID, qint32 bottomFieldPhaseID);
 
 protected:

--- a/tools/ld-chroma-decoder/decoder.cpp
+++ b/tools/ld-chroma-decoder/decoder.cpp
@@ -25,11 +25,11 @@
 #include "decoder.h"
 
 void Decoder::setVideoParameters(Decoder::Configuration &config, const LdDecodeMetaData::VideoParameters &videoParameters,
-                                 qint32 firstActiveScanLine, qint32 lastActiveScanLine) {
+                                 qint32 firstActiveLine, qint32 lastActiveLine) {
 
     config.videoParameters = videoParameters;
-    config.firstActiveScanLine = firstActiveScanLine;
-    config.lastActiveScanLine = lastActiveScanLine;
+    config.firstActiveLine = firstActiveLine;
+    config.lastActiveLine = lastActiveLine;
     config.topPadLines = 0;
     config.bottomPadLines = 0;
 
@@ -53,7 +53,7 @@ void Decoder::setVideoParameters(Decoder::Configuration &config, const LdDecodeM
     // Insert empty padding lines so the height is divisible by 8
     qint32 outputHeight;
     while (true) {
-        outputHeight = config.topPadLines + (config.lastActiveScanLine - config.firstActiveScanLine) + config.bottomPadLines;
+        outputHeight = config.topPadLines + (config.lastActiveLine - config.firstActiveLine) + config.bottomPadLines;
         if ((outputHeight % 8) == 0) {
             break;
         }
@@ -85,7 +85,7 @@ QByteArray Decoder::cropOutputFrame(const Decoder::Configuration &config, QByteA
     }
 
     // Copy the active region from the decoded image
-    for (qint32 y = config.firstActiveScanLine; y < config.lastActiveScanLine; y++) {
+    for (qint32 y = config.firstActiveLine; y < config.lastActiveLine; y++) {
         croppedData.append(outputData.mid((y * config.videoParameters.fieldWidth * 6) + (activeVideoStart * 6),
                                           outputLineBytes));
     }

--- a/tools/ld-chroma-decoder/decoder.h
+++ b/tools/ld-chroma-decoder/decoder.h
@@ -68,8 +68,8 @@ public:
     struct Configuration {
         // Parameters computed from the video metadata
         LdDecodeMetaData::VideoParameters videoParameters;
-        qint32 firstActiveScanLine;
-        qint32 lastActiveScanLine;
+        qint32 firstActiveLine;
+        qint32 lastActiveLine;
         qint32 topPadLines;
         qint32 bottomPadLines;
     };
@@ -77,7 +77,7 @@ public:
     // Compute the output frame size in Configuration, adjusting the active
     // video region as required
     static void setVideoParameters(Configuration &config, const LdDecodeMetaData::VideoParameters &videoParameters,
-                                   qint32 firstActiveScanLine, qint32 lastActiveScanLine);
+                                   qint32 firstActiveLine, qint32 lastActiveLine);
 
     // Crop a full decoded frame to the output frame size
     static QByteArray cropOutputFrame(const Decoder::Configuration &config, QByteArray outputData);

--- a/tools/ld-chroma-decoder/decoderpool.cpp
+++ b/tools/ld-chroma-decoder/decoderpool.cpp
@@ -24,14 +24,14 @@
 
 #include "decoderpool.h"
 
-DecoderPool::DecoderPool(Decoder &decoderParam, QString inputFileNameParam,
-                         LdDecodeMetaData &ldDecodeMetaDataParam, QString outputFileNameParam,
-                         qint32 startFrameParam, qint32 lengthParam, qint32 maxThreadsParam,
+DecoderPool::DecoderPool(Decoder &_decoder, QString _inputFileName,
+                         LdDecodeMetaData &_ldDecodeMetaData, QString _outputFileName,
+                         qint32 _startFrame, qint32 _length, qint32 _maxThreads,
                          QObject *parent)
-    : QObject(parent), decoder(decoderParam), inputFileName(inputFileNameParam),
-      outputFileName(outputFileNameParam), startFrame(startFrameParam),
-      length(lengthParam), maxThreads(maxThreadsParam),
-      abort(false), ldDecodeMetaData(ldDecodeMetaDataParam)
+    : QObject(parent), decoder(_decoder), inputFileName(_inputFileName),
+      outputFileName(_outputFileName), startFrame(_startFrame),
+      length(_length), maxThreads(_maxThreads),
+      abort(false), ldDecodeMetaData(_ldDecodeMetaData)
 {
 }
 

--- a/tools/ld-chroma-decoder/decoderpool.h
+++ b/tools/ld-chroma-decoder/decoderpool.h
@@ -42,9 +42,9 @@ class DecoderPool : public QObject
 {
     Q_OBJECT
 public:
-    explicit DecoderPool(Decoder &decoderParam, QString inputFileNameParam,
-                         LdDecodeMetaData &ldDecodeMetaDataParam, QString outputFileNameParam,
-                         qint32 startFrameParam, qint32 lengthParam, qint32 maxThreadsParam,
+    explicit DecoderPool(Decoder &decoder, QString inputFileName,
+                         LdDecodeMetaData &ldDecodeMetaData, QString outputFileName,
+                         qint32 startFrame, qint32 length, qint32 maxThreads,
                          QObject *parent = nullptr);
     bool process();
 

--- a/tools/ld-chroma-decoder/ld-chroma-decoder.pro
+++ b/tools/ld-chroma-decoder/ld-chroma-decoder.pro
@@ -20,6 +20,7 @@ SOURCES += \
     decoderpool.cpp \
     palcolour.cpp \
     paldecoder.cpp \
+    transformpal.cpp \
     comb.cpp \
     rgb.cpp \
     yiq.cpp \
@@ -33,6 +34,7 @@ HEADERS += \
     decoderpool.h \
     palcolour.h \
     paldecoder.h \
+    transformpal.h \
     comb.h \
     rgb.h \
     yiq.h \
@@ -59,4 +61,4 @@ LIBS += -L"/usr/local/opt/opencv@2/lib"
 # Normal open-source OS goodness
 INCLUDEPATH += "/usr/local/include/opencv"
 LIBS += -L"/usr/local/lib"
-LIBS += -lopencv_core -lopencv_imgproc -lopencv_video
+LIBS += -lopencv_core -lopencv_imgproc -lopencv_video -lfftw3

--- a/tools/ld-chroma-decoder/ntscdecoder.cpp
+++ b/tools/ld-chroma-decoder/ntscdecoder.cpp
@@ -62,7 +62,7 @@ bool NtscDecoder::configure(const LdDecodeMetaData::VideoParameters &videoParame
     config.combConfig.activeVideoEnd = videoParameters.activeVideoEnd;
 
     // Set the first frame scan line which contains active video
-    config.combConfig.firstVisibleFrameLine = config.firstActiveScanLine;
+    config.combConfig.firstActiveLine = config.firstActiveLine;
 
     // Set the IRE levels
     config.combConfig.blackIre = videoParameters.black16bIre;

--- a/tools/ld-chroma-decoder/ntscdecoder.cpp
+++ b/tools/ld-chroma-decoder/ntscdecoder.cpp
@@ -76,9 +76,9 @@ QThread *NtscDecoder::makeThread(QAtomicInt& abort, DecoderPool& decoderPool)
     return new NtscThread(abort, decoderPool, config);
 }
 
-NtscThread::NtscThread(QAtomicInt& abortParam, DecoderPool &decoderPoolParam,
-                       const NtscDecoder::Configuration &configParam, QObject *parent)
-    : QThread(parent), abort(abortParam), decoderPool(decoderPoolParam), config(configParam)
+NtscThread::NtscThread(QAtomicInt& _abort, DecoderPool &_decoderPool,
+                       const NtscDecoder::Configuration &_config, QObject *parent)
+    : QThread(parent), abort(_abort), decoderPool(_decoderPool), config(_config)
 {
 }
 

--- a/tools/ld-chroma-decoder/ntscdecoder.h
+++ b/tools/ld-chroma-decoder/ntscdecoder.h
@@ -60,8 +60,8 @@ class NtscThread : public QThread
 {
     Q_OBJECT
 public:
-    explicit NtscThread(QAtomicInt &abortParam, DecoderPool &decoderPoolParam,
-                        const NtscDecoder::Configuration &configParam,
+    explicit NtscThread(QAtomicInt &abort, DecoderPool &decoderPool,
+                        const NtscDecoder::Configuration &config,
                         QObject *parent = nullptr);
 
 protected:

--- a/tools/ld-chroma-decoder/ntscdecoder.h
+++ b/tools/ld-chroma-decoder/ntscdecoder.h
@@ -44,7 +44,7 @@ class DecoderPool;
 class NtscDecoder : public Decoder {
 public:
     NtscDecoder(bool blackAndWhite, bool whitePoint, bool use3D, bool showOpticalFlowMap);
-    bool configure(const LdDecodeMetaData::VideoParameters &videoParameters);
+    bool configure(const LdDecodeMetaData::VideoParameters &videoParameters) override;
     QThread *makeThread(QAtomicInt& abort, DecoderPool& decoderPool) override;
 
     // Parameters used by NtscDecoder and NtscThread

--- a/tools/ld-chroma-decoder/opticalflow.cpp
+++ b/tools/ld-chroma-decoder/opticalflow.cpp
@@ -26,8 +26,8 @@
 #include "opticalflow.h"
 
 OpticalFlow::OpticalFlow()
+    : framesProcessed(0)
 {
-    framesProcessed = 0;
 }
 
 // Perform a dense optical flow analysis

--- a/tools/ld-chroma-decoder/opticalflow.cpp
+++ b/tools/ld-chroma-decoder/opticalflow.cpp
@@ -61,7 +61,7 @@ void OpticalFlow::denseOpticalFlow(const YiqBuffer &yiqBuffer, QVector<qreal> &k
                 // in the X direction than the y
                 qreal velocity = calculateDistance(static_cast<qreal>(flowatxy.y), static_cast<qreal>(flowatxy.x) * 2);
 
-                kValues[(910 * y) + x] = clamp(velocity, 0.0, 1.0);
+                kValues[(910 * y) + x] = qBound(0.0, velocity, 1.0);
             }
         }
     } else kValues.fill(1);

--- a/tools/ld-chroma-decoder/opticalflow.h
+++ b/tools/ld-chroma-decoder/opticalflow.h
@@ -34,7 +34,6 @@
 #include <opencv2/core/core.hpp>
 #include <opencv2/video/tracking.hpp>
 
-#include "rgb.h"
 #include "yiqbuffer.h"
 
 class OpticalFlow

--- a/tools/ld-chroma-decoder/palcolour.cpp
+++ b/tools/ld-chroma-decoder/palcolour.cpp
@@ -55,18 +55,18 @@
     filters with more complex coefficients than the report describes.
  */
 
-PalColour::PalColour(QObject *parent) : QObject(parent)
+PalColour::PalColour(QObject *parent)
+    : QObject(parent), configurationSet(false)
 {
-    configurationSet = false;
 }
 
-void PalColour::updateConfiguration(LdDecodeMetaData::VideoParameters videoParametersParam,
-                                    qint32 firstActiveLineParam, qint32 lastActiveLineParam)
+void PalColour::updateConfiguration(LdDecodeMetaData::VideoParameters _videoParameters,
+                                    qint32 _firstActiveLine, qint32 _lastActiveLine)
 {
     // Copy the configuration parameters
-    videoParameters = videoParametersParam;
-    firstActiveLine = firstActiveLineParam;
-    lastActiveLine = lastActiveLineParam;
+    videoParameters = _videoParameters;
+    firstActiveLine = _firstActiveLine;
+    lastActiveLine = _lastActiveLine;
 
     // Build the look-up tables
     buildLookUpTables();

--- a/tools/ld-chroma-decoder/palcolour.cpp
+++ b/tools/ld-chroma-decoder/palcolour.cpp
@@ -157,7 +157,7 @@ void PalColour::buildLookUpTables()
 
 // Performs a decode of the 16-bit greyscale input frame and produces a RGB 16-16-16-bit output frame
 // with 16 bit processing
-QByteArray PalColour::performDecode(QByteArray firstFieldData, QByteArray secondFieldData, qint32 brightness, qint32 saturation)
+QByteArray PalColour::performDecode(QByteArray firstFieldData, QByteArray secondFieldData, qint32 contrast, qint32 saturation)
 {
     // Ensure the object has been configured
     if (!configurationSet) {
@@ -170,7 +170,7 @@ QByteArray PalColour::performDecode(QByteArray firstFieldData, QByteArray second
     outputFrame.fill(0);
 
     // Scaling factor to put black at 0 and peak white at 65535
-    double scaledBrightness = (65535.0 / (videoParameters.white16bIre - videoParameters.black16bIre)) * brightness / 100.0;
+    double scaledContrast = (65535.0 / (videoParameters.white16bIre - videoParameters.black16bIre)) * contrast / 100.0;
 
     // Dummy black line, used when the 2D filter needs to look outside the active region.
     static constexpr quint16 blackLine[MAX_WIDTH] = {0};
@@ -307,7 +307,7 @@ QByteArray PalColour::performDecode(QByteArray firstFieldData, QByteArray second
                 {
                     // Generate the luminance (Y), by filtering out Fsc (by re-synthesising the detected py qy and subtracting), and subtracting the black-level
                     rY = b0[i] - ((py[i]*sine[i]+qy[i]*cosine[i]) / normalise) - videoParameters.black16bIre;
-                    rY *= scaledBrightness;
+                    rY *= scaledContrast;
                     if (rY < 0) rY = 0;
                     if (rY > 65535) rY = 65535;
 

--- a/tools/ld-chroma-decoder/palcolour.cpp
+++ b/tools/ld-chroma-decoder/palcolour.cpp
@@ -7,6 +7,7 @@
 
     Copyright (C) 2018  William Andrew Steer
     Copyright (C) 2018-2019 Simon Inns
+    Copyright (C) 2019 Adam Sampson
 
     This file is part of ld-decode-tools.
 
@@ -31,6 +32,29 @@
 
 #include "palcolour.h"
 
+/*!
+    \class PalColour
+
+    PALcolour, originally written by William Andrew Steer, is a line-locked PAL
+    decoder using 2D FIR filters.
+
+    For a good overview of line-locked PAL decoding techniques, see
+    BBC Research Department Report 1986/02 (https://www.bbc.co.uk/rd/publications/rdreport_1986_02),
+    "Colour encoding and decoding techniques for line-locked sampled PAL and
+    NTSC television signals" by C.K.P. Clark. PALcolour uses the architecture
+    shown in Figure 23(c), except that it has three separate baseband filters,
+    one each for Y, U and V, with different characteristics. Rather than
+    tracking the colour subcarrier using a PLL, PALcolour detects the phase of
+    the subcarrier at the colourburst, and rotates the U/V output to
+    compensate when decoding.
+
+    BBC Research Department Report 1988/11 (https://www.bbc.co.uk/rd/publications/rdreport_1988_11),
+    "PAL decoding: Multi-dimensional filter design for chrominance-luminance
+    separation", also by C.K.P. Clark, describes the design concerns behind
+    these filters. As PALcolour is a software implementation, it can use larger
+    filters with more complex coefficients than the report describes.
+ */
+
 PalColour::PalColour(QObject *parent) : QObject(parent)
 {
     configurationSet = false;
@@ -54,8 +78,8 @@ void PalColour::updateConfiguration(LdDecodeMetaData::VideoParameters videoParam
 // must be called by the constructor when the object is created
 void PalColour::buildLookUpTables()
 {
-    // Generate quadrature samples of a sine wave at the subcarrier frequency.
-    // We'll use this for two purposes below:
+    // Generate the reference carrier: quadrature samples of a sine wave at the
+    // subcarrier frequency. We'll use this for two purposes below:
     // - product-detecting the line samples, to give us quadrature samples of
     //   the chroma information centred on 0 Hz
     // - working out what the phase of the subcarrier is on each line,
@@ -72,49 +96,57 @@ void PalColour::buildLookUpTables()
         cosine[i] = refAmpl * cos(rad);
     }
 
-    // Next create filter-profiles for colour filtering.
-    //  One can argue over merits of different filters, but I stick with simple raised cosine
-    //  unless there's compelling reason to do otherwise.
-    // PAL-I colour bandwidth should be around 1.1 or 1.2 MHz
-    //  acc to Rec.470, +1066 or -1300kHz span of colour sidebands!
-
-    // width of filter-window should therefore scale with samplerate
-
-    // Create filter-profile lookup
-    // chromaBandwidthHz values between 1.1MHz and 1.3MHz can be tried. Some specific values in that range may work best at minimising residual
-    // dot pattern at given sample rates due to the discrete nature of the filters. It'd be good to find ways to optimise this more rigourously.
-    // Note in principle you could have different bandwidths for extracting the luma and chroma, according to aesthetic tradeoffs. Not really very justifyable though.
-    double chromaBandwidthHz=1100000.0 /0.93; // the 0.93 is a bit empirical for the 4Fsc sampled LaserDisc scans
+    // Create filter profiles for colour filtering.
+    //
+    // One can argue over merits of different filters, but I stick with simple
+    // raised cosine unless there's compelling reason to do otherwise.
+    // PAL-I colour bandwidth should be around 1.1 or 1.2 MHz:
+    // acc to Rec.470, +1066 or -1300kHz span of colour sidebands!
+    // The width of the filter window should scale with the sample rate.
+    //
+    // chromaBandwidthHz values between 1.1MHz and 1.3MHz can be tried. Some
+    // specific values in that range may work best at minimising residual dot
+    // pattern at given sample rates due to the discrete nature of the filters.
+    // It'd be good to find ways to optimise this more rigourously.
+    //
+    // Note in principle you could have different bandwidths for extracting the
+    // luma and chroma, according to aesthetic tradeoffs. Not really very
+    // justifyable though. Keeping the Y and C bandwidth the same (or at least
+    // similar enough for the filters to be the same size) allows them to be
+    // computed together later.
+    //
+    // The 0.93 is a bit empirical for the 4Fsc sampled LaserDisc scans.
+    const double chromaBandwidthHz = 1100000.0 / 0.93;
 
     // Compute filter widths based on chroma bandwidth.
     // FILTER_SIZE must be wide enough to hold both filters (and ideally no
     // wider, else we're doing more computation than we need to).
-    double ca=0.5*videoParameters.sampleRate/chromaBandwidthHz, ya=0.5*videoParameters.sampleRate/chromaBandwidthHz; // where does the 0.5* come from?
+    // XXX where does the 0.5* come from?
+    const double ca = 0.5 * videoParameters.sampleRate / chromaBandwidthHz;
+    const double ya = 0.5 * videoParameters.sampleRate / chromaBandwidthHz;
     assert(FILTER_SIZE >= static_cast<qint32>(ca));
     assert(FILTER_SIZE >= static_cast<qint32>(ya));
 
-    double cdiv=0;
-    double ydiv=0;
+    // Note that we choose to make the y-filter *much* less selective in the
+    // vertical direction: this is to prevent castellation on horizontal colour
+    // boundaries.
+    //
+    // We may wish to broaden vertical bandwidth *slightly* so as to better
+    // pass one- or two-line colour bars - underlines/graphics etc.
 
-    // Note that we choose to make the y-filter *much* less selective in the vertical direction:
-    // - this is to prevent castellation on horizontal colour boundaries.
-
-    // may wish to broaden vertical bandwidth *slightly* so as to better pass
-    // one- or two-line colour bars - underlines/graphics etc.
-
-    // Note also that if Y-bandwidth was made the same as C,
-    // and that 'lines' of the masks were equivalent, then
-    // significant time-savings could be made.
-
+    double cdiv = 0, ydiv = 0;
     for (qint32 f = 0; f <= FILTER_SIZE; f++) {
         double  fc=f; if (fc>ca) fc=ca;
         double  ff=sqrt(f*f+2*2); if ( ff>ca)  ff=ca;  // 2 -- 4 -- 6 sequence
         double fff=sqrt(f*f+4*4); if (fff>ca) fff=ca;  // because only one FIELD!
         double ffff=sqrt(f*f+6*6); if (ffff>ca) ffff=ca;
 
+        // Divider because we're only making half a filter-kernel and the
+        // zero-th point is counted twice later
         qint32 d;
-        if (f==0) d=2; else d=1; // divider because we're only making half a filter-kernel and the zero-th poqint32 is counted twice later.
+        if (f==0) d=2; else d=1;
 
+        // For U/V.
         // 0, 2, 1, 3 are vertical taps 0, +/- 1, +/- 2, +/- 3 (see filter loop below).
         cfilt[f][0]=256*(1+cos(M_PI*fc/ca))/d;
         cfilt[f][2]=256*(1+cos(M_PI*ff/ca))/d;
@@ -131,10 +163,14 @@ void PalColour::buildLookUpTables()
         //  introduces *phase-sensitivity* to the filter -> leaks too much
         //  subcarrier if *any* phase-shifts!
         // note omission of yfilt taps 1 and 3 for PAL
-
+        //
+        // Tap 2 is only used for PAL; 0.2 factor makes it much less sensitive
+        // to adjacent lines and reduces castellations and residual dot
+        // patterning.
+        //
         // 0, 1 are vertical taps 0, +/- 2 (see filter loop below).
         yfilt[f][0]=256*(1+cos(M_PI*fy/ya))/d;
-        yfilt[f][1]=0.2*256*(1+cos(M_PI*fffy/ya))/d;  // only used for PAL NB 0.2 makes much less sensitive to adjacent lines and reduces castellations and residual dot patterning
+        yfilt[f][1]=0.2*256*(1+cos(M_PI*fffy/ya))/d;
 
         ydiv+=yfilt[f][0]+2*0+2*yfilt[f][1]+2*0;
     }
@@ -207,6 +243,10 @@ void PalColour::decodeField(qint32 fieldNumber, const QByteArray &fieldData, qin
 
         // Multiply the composite input signal by the reference carrier, giving
         // quadrature samples where the colour subcarrier is now at 0 Hz.
+        // (There will be a considerable amount of energy at higher frequencies
+        // resulting from the luma information and aliases of the signal, so
+        // we need to low-pass filter it before extracting the colour
+        // components.)
         //
         // As the 2D filters are vertically symmetrical, we can pre-compute the
         // sums of pairs of lines above and below fieldLine to save some work
@@ -227,15 +267,18 @@ void PalColour::decodeField(qint32 fieldNumber, const QByteArray &fieldData, qin
             n[3][i] = -in5[i] * cosine[i] + in6[i] * cosine[i];
         }
 
-        // Find absolute burst phase
-
-        //  To avoid hue-shifts on alternate lines, the phase is determined by averaging the phase on the current-line with the average of
-        //  two other lines, one above and one below the current line.
-        //   For NTSC we use the scan-lines immediately above and below (in the field), which we know have exactly 180 degrees burst phase shift to the present line
-        //   For PAL we use the next-but-one line above and below (in the field), which will have the same V-switch phase as the current-line (and 180 degree change of phase)
-        //    but for PAL we also analyse the average (bpo,bqo 'old') of the line immediately above and below, which have the opposite V-switch phase (and a 90 degree subcarrier phase shift)
-
-        // this is a classic "product-" or "synchronous demodulation" operation. We "detect" the burst relative to the arbitrary sine[] and cosine[] reference phases
+        // Find absolute burst phase relative to the reference carrier by
+        // product detection.
+        //
+        // To avoid hue-shifts on alternate lines, the phase is determined by
+        // averaging the phase on the current-line with the average of two
+        // other lines, one above and one below the current line.
+        //
+        // For PAL we use the next-but-one line above and below (in the field),
+        // which will have the same V-switch phase as the current-line (and 180
+        // degree change of phase), and we also analyse the average (bpo/bqo
+        // 'old') of the line immediately above and below, which have the
+        // opposite V-switch phase (and a 90 degree subcarrier phase shift).
         double bp=0, bq=0, bpo=0, bqo=0;
         for (qint32 i=videoParameters.colourBurstStart; i<videoParameters.colourBurstEnd; i++) {
             bp+=(m[0][i]+(m[1][i]/2))/2;
@@ -244,25 +287,32 @@ void PalColour::decodeField(qint32 fieldNumber, const QByteArray &fieldData, qin
             bqo-=n[2][i]/2;
         }
 
-        bp/=(videoParameters.colourBurstEnd-videoParameters.colourBurstStart);  bq/=(videoParameters.colourBurstEnd-videoParameters.colourBurstStart);  // normalises those sums
-        bpo/=(videoParameters.colourBurstEnd-videoParameters.colourBurstStart); bqo/=(videoParameters.colourBurstEnd-videoParameters.colourBurstStart); // normalises those sums
+        // Normalise the sums above
+        const qint32 colourBurstLength = videoParameters.colourBurstEnd - videoParameters.colourBurstStart;
+        bp /= colourBurstLength;
+        bq /= colourBurstLength;
+        bpo /= colourBurstLength;
+        bqo /= colourBurstLength;
 
-        // Generate V-switch phase - I forget exactly why this works, but it's essentially comparing the vector magnitude /difference/ between the
-        // phases of the burst on the present line and previous line to the magnitude of the burst. This may effectively be a dot-product operation...
+        // Detect the V-switch state on this line.
+        //
+        // I forget exactly why this works, but it's essentially comparing the
+        // vector magnitude /difference/ between the phases of the burst on the
+        // present line and previous line to the magnitude of the burst. This
+        // may effectively be a dot-product operation...
         double Vsw;
         if (((bp-bpo)*(bp-bpo)+(bq-bqo)*(bq-bqo))<(bp*bp+bq*bq)*2) Vsw=1; else Vsw=-1;
 
-        // NB bp and bq will be of the order of 1000. CHECK!!
+        // Average the burst phase to get -U (reference) phase out -- burst
+        // phase is (-U +/-V). bp and bq will be of the order of 1000.
         bp=(bp-bqo)/2;
         bq=(bq+bpo)/2;
 
-        // ave the phase of burst from two lines to get -U (reference) phase out (burst phase is (-U +/-V)
-        // if NTSC then leave bp as-is, we take bp,bq as the underlying -U (reference) phase.
-
-        // burstNorm normalises bp and bq to 1
+        // burstNorm normalises bp and bq to 1.
         double burstNorm = sqrt(bp*bp+bq*bq);
 
-        // kill colour if burst too weak!  magic number 130000 !!! check!
+        // Kill colour if burst too weak.
+        // XXX magic number 130000 !!! check!
         if (burstNorm < (130000.0 / 128)) {
             burstNorm = 130000.0 / 128;
         }
@@ -277,10 +327,11 @@ void PalColour::decodeField(qint32 fieldNumber, const QByteArray &fieldData, qin
             PU=QU=0; PV=QV=0; PY=QY=0;
 
             // Carry out 2D filtering. P and Q are the two arbitrary SINE & COS
-            // phases components. U filters for U, V for V, and Y for Y
+            // phases components. U filters for U, V for V, and Y for Y.
+            //
             // U and V are the same for lines n ([0]), n+/-2 ([1]), but
             // differ in sign for n+/-1 ([2]), n+/-3 ([3]) owing to the
-            // forward/backward axis slant
+            // forward/backward axis slant.
 
             qint32 l,r;
 
@@ -303,10 +354,10 @@ void PalColour::decodeField(qint32 fieldNumber, const QByteArray &fieldData, qin
         // Define scan line pointer to output buffer using 16 bit unsigned words
         quint16 *ptr = reinterpret_cast<quint16*>(outputFrame.data() + (((fieldLine * 2) + fieldNumber) * videoParameters.fieldWidth * 6));
 
-        // Scaling factor to put black at 0 and peak white at 65535
+        // Gain for the Y component, to put black at 0 and peak white at 65535
         double scaledContrast = (65535.0 / (videoParameters.white16bIre - videoParameters.black16bIre)) * contrast / 100.0;
 
-        // 'saturation' is a user saturation control, nom. 100%
+        // Gain for the U/V components
         double scaledSaturation = (saturation / 50.0) / burstNorm;
 
         double R, G, B;
@@ -314,17 +365,24 @@ void PalColour::decodeField(qint32 fieldNumber, const QByteArray &fieldData, qin
 
         for (qint32 i = videoParameters.activeVideoStart; i < videoParameters.activeVideoEnd; i++)
         {
-            // Generate the luminance (Y), by filtering out Fsc (by re-synthesising the detected py qy and subtracting), and subtracting the black-level
-            rY = in0[i] - ((py[i] * sine[i] + qy[i] * cosine[i]) / refNorm) - videoParameters.black16bIre;
-            rY *= scaledContrast;
+            // Compute luma by resynthesising the chroma signal that the Y
+            // filter extracted, and subtracting it from the original composite
+            // signal
+            rY = in0[i] - ((py[i] * sine[i] + qy[i] * cosine[i]) / refNorm);
+
+            // Scale to 16-bit output
+            rY = (rY - videoParameters.black16bIre) * scaledContrast;
             if (rY < 0) rY = 0;
             if (rY > 65535) rY = 65535;
 
-            // the next two lines "rotate" the p&q components (at the arbitrary sine/cosine reference phase) backwards by the
-            // burst phase (relative to the arb phase), in order to recover U and V. The Vswitch is applied to flip the V-phase on alternate lines for PAL
+            // Rotate the p&q components (at the arbitrary sine/cosine
+            // reference phase) backwards by the burst phase (relative to the
+            // reference phase), in order to recover U and V. The Vswitch is
+            // applied to flip the V-phase on alternate lines for PAL.
             rU = (-((pu[i]*bp+qu[i]*bq)) * scaledSaturation);
             rV = (-(Vsw*(qv[i]*bp-pv[i]*bq)) * scaledSaturation);
 
+            // Convert YUV to RGB.
             // This conversion is taken from Video Demystified (5th edition) page 18
             R = ( rY + (1.140 * rV) );
             G = ( rY - (0.395 * rU) - (0.581 * rV) );

--- a/tools/ld-chroma-decoder/palcolour.h
+++ b/tools/ld-chroma-decoder/palcolour.h
@@ -60,13 +60,13 @@ private:
     // adjusted later to deal with phase differences between lines), so each
     // 2D array represents one quarter of a filter. The zeroth horizontal
     // element is included in the sum twice, so the coefficient is halved to
-    // compensate. Each filter is (2 * arraySize) + 1 elements wide.
-    static const qint32 arraySize = 7;
-    double cfilt[arraySize + 1][4];
-    double yfilt[arraySize + 1][2];
+    // compensate. Each filter is (2 * FILTER_SIZE) + 1 elements wide.
+    static const qint32 FILTER_SIZE = 7;
+    double cfilt[FILTER_SIZE + 1][4];
+    double yfilt[FILTER_SIZE + 1][2];
 
     double refAmpl;
-    double normalise;
+    double refNorm;
     QByteArray outputFrame;
 
     bool configurationSet;

--- a/tools/ld-chroma-decoder/palcolour.h
+++ b/tools/ld-chroma-decoder/palcolour.h
@@ -66,8 +66,21 @@ private:
     // Decode one field into outputFrame.
     void decodeField(const FieldInfo &field, const QByteArray &fieldData);
 
+    // Information about a line we're decoding.
+    struct LineInfo {
+        explicit LineInfo(qint32 number);
+
+        qint32 number;
+        double bp, bq;
+        double Vsw;
+        double burstNorm;
+    };
+
+    // Detect the colourburst on a line.
+    void detectBurst(LineInfo &line, const quint16 *inputData);
+
     // Decode one line into outputFrame.
-    void decodeLine(const FieldInfo &field, qint32 fieldLine, const quint16 *inputData);
+    void decodeLine(const FieldInfo &field, const LineInfo &line, const quint16 *inputData);
 
     // Configuration parameters
     bool configurationSet;

--- a/tools/ld-chroma-decoder/palcolour.h
+++ b/tools/ld-chroma-decoder/palcolour.h
@@ -41,7 +41,7 @@ public:
     void updateConfiguration(LdDecodeMetaData::VideoParameters videoParameters, qint32 firstActiveLine, qint32 lastActiveLine);
 
     // Method to perform the colour decoding
-    QByteArray performDecode(QByteArray topFieldData, QByteArray bottomFieldData, qint32 brightness, qint32 saturation);
+    QByteArray performDecode(QByteArray topFieldData, QByteArray bottomFieldData, qint32 contrast, qint32 saturation);
 
     // Maximum frame size, based on PAL
     static const qint32 MAX_WIDTH = 1135;

--- a/tools/ld-chroma-decoder/palcolour.h
+++ b/tools/ld-chroma-decoder/palcolour.h
@@ -48,6 +48,10 @@ public:
     static const qint32 MAX_HEIGHT = 625;
 
 private:
+    // Decode one field into outputFrame.
+    // fieldNumber is 0 for the top field, 1 for the bottom field.
+    void decodeField(qint32 fieldNumber, const QByteArray &fieldData, qint32 contrast, qint32 saturation);
+
     // Configuration parameters
     LdDecodeMetaData::VideoParameters videoParameters;
     qint32 firstActiveLine;

--- a/tools/ld-chroma-decoder/palcolour.h
+++ b/tools/ld-chroma-decoder/palcolour.h
@@ -50,9 +50,24 @@ public:
     static const qint32 MAX_HEIGHT = 625;
 
 private:
+    // Information about a field we're decoding.
+    struct FieldInfo {
+        explicit FieldInfo(qint32 number, qint32 contrast, qint32 saturation, qint32 firstActiveLine, qint32 lastActiveLine);
+
+        // number is 0 for the top field, 1 for the bottom field.
+        qint32 number;
+        qint32 contrast;
+        qint32 saturation;
+        // firstLine/lastLine are the range of active lines within the field.
+        qint32 firstLine;
+        qint32 lastLine;
+    };
+
     // Decode one field into outputFrame.
-    // fieldNumber is 0 for the top field, 1 for the bottom field.
-    void decodeField(qint32 fieldNumber, const QByteArray &fieldData, qint32 contrast, qint32 saturation);
+    void decodeField(const FieldInfo &field, const QByteArray &fieldData);
+
+    // Decode one line into outputFrame.
+    void decodeLine(const FieldInfo &field, qint32 fieldLine, const quint16 *inputData);
 
     // Configuration parameters
     bool configurationSet;

--- a/tools/ld-chroma-decoder/paldecoder.cpp
+++ b/tools/ld-chroma-decoder/paldecoder.cpp
@@ -27,9 +27,11 @@
 
 #include "decoderpool.h"
 
-PalDecoder::PalDecoder(bool _blackAndWhite)
+PalDecoder::PalDecoder(bool _blackAndWhite, bool _useTransformFilter, double _transformThreshold)
 {
     config.blackAndWhite = _blackAndWhite;
+    config.useTransformFilter = _useTransformFilter;
+    config.transformThreshold = _transformThreshold;
 }
 
 bool PalDecoder::configure(const LdDecodeMetaData::VideoParameters &videoParameters) {
@@ -54,7 +56,8 @@ PalThread::PalThread(QAtomicInt& _abort, DecoderPool& _decoderPool,
     : QThread(parent), abort(_abort), decoderPool(_decoderPool), config(_config)
 {
     // Configure PALcolour
-    palColour.updateConfiguration(config.videoParameters, config.firstActiveLine, config.lastActiveLine);
+    palColour.updateConfiguration(config.videoParameters, config.firstActiveLine, config.lastActiveLine,
+                                  config.useTransformFilter, config.transformThreshold);
 }
 
 void PalThread::run()

--- a/tools/ld-chroma-decoder/paldecoder.cpp
+++ b/tools/ld-chroma-decoder/paldecoder.cpp
@@ -54,7 +54,7 @@ PalThread::PalThread(QAtomicInt& _abort, DecoderPool& _decoderPool,
     : QThread(parent), abort(_abort), decoderPool(_decoderPool), config(_config)
 {
     // Configure PALcolour
-    palColour.updateConfiguration(config.videoParameters, config.firstActiveScanLine, config.lastActiveScanLine);
+    palColour.updateConfiguration(config.videoParameters, config.firstActiveLine, config.lastActiveLine);
 }
 
 void PalThread::run()

--- a/tools/ld-chroma-decoder/paldecoder.cpp
+++ b/tools/ld-chroma-decoder/paldecoder.cpp
@@ -27,9 +27,9 @@
 
 #include "decoderpool.h"
 
-PalDecoder::PalDecoder(bool blackAndWhiteParam)
+PalDecoder::PalDecoder(bool _blackAndWhite)
 {
-    config.blackAndWhite = blackAndWhiteParam;
+    config.blackAndWhite = _blackAndWhite;
 }
 
 bool PalDecoder::configure(const LdDecodeMetaData::VideoParameters &videoParameters) {
@@ -49,9 +49,9 @@ QThread *PalDecoder::makeThread(QAtomicInt& abort, DecoderPool& decoderPool) {
     return new PalThread(abort, decoderPool, config);
 }
 
-PalThread::PalThread(QAtomicInt& abortParam, DecoderPool& decoderPoolParam,
-                     const PalDecoder::Configuration &configParam, QObject *parent)
-    : QThread(parent), abort(abortParam), decoderPool(decoderPoolParam), config(configParam)
+PalThread::PalThread(QAtomicInt& _abort, DecoderPool& _decoderPool,
+                     const PalDecoder::Configuration &_config, QObject *parent)
+    : QThread(parent), abort(_abort), decoderPool(_decoderPool), config(_config)
 {
     // Configure PALcolour
     palColour.updateConfiguration(config.videoParameters, config.firstActiveScanLine, config.lastActiveScanLine);

--- a/tools/ld-chroma-decoder/paldecoder.h
+++ b/tools/ld-chroma-decoder/paldecoder.h
@@ -42,13 +42,15 @@ class DecoderPool;
 // 2D PAL decoder using PALcolour
 class PalDecoder : public Decoder {
 public:
-    PalDecoder(bool blackAndWhite);
+    PalDecoder(bool blackAndWhite, bool useTransformFilter = false, double transformThreshold = 0.6);
     bool configure(const LdDecodeMetaData::VideoParameters &videoParameters) override;
     QThread *makeThread(QAtomicInt& abort, DecoderPool& decoderPool) override;
 
     // Parameters used by PalDecoder and PalThread
     struct Configuration : public Decoder::Configuration {
         bool blackAndWhite;
+        bool useTransformFilter;
+        double transformThreshold;
     };
 
 private:

--- a/tools/ld-chroma-decoder/paldecoder.h
+++ b/tools/ld-chroma-decoder/paldecoder.h
@@ -42,7 +42,7 @@ class DecoderPool;
 // 2D PAL decoder using PALcolour
 class PalDecoder : public Decoder {
 public:
-    PalDecoder(bool blackAndWhiteParam);
+    PalDecoder(bool blackAndWhite);
     bool configure(const LdDecodeMetaData::VideoParameters &videoParameters) override;
     QThread *makeThread(QAtomicInt& abort, DecoderPool& decoderPool) override;
 
@@ -59,8 +59,8 @@ class PalThread : public QThread
 {
     Q_OBJECT
 public:
-    explicit PalThread(QAtomicInt &abortParam, DecoderPool &decoderPoolParam,
-                       const PalDecoder::Configuration &configParam,
+    explicit PalThread(QAtomicInt &abort, DecoderPool &decoderPool,
+                       const PalDecoder::Configuration &config,
                        QObject *parent = nullptr);
 
 protected:

--- a/tools/ld-chroma-decoder/rgb.cpp
+++ b/tools/ld-chroma-decoder/rgb.cpp
@@ -25,13 +25,10 @@
 
 #include "rgb.h"
 
-RGB::RGB(double whiteIreParam, double blackIreParam, bool whitePoint100Param, bool blackAndWhiteParam, double colourBurstMedianParam)
+RGB::RGB(double _whiteIreLevel, double _blackIreLevel, bool _whitePoint75, bool _blackAndWhite, double _colourBurstMedian)
+    : whiteIreLevel(_whiteIreLevel), blackIreLevel(_blackIreLevel), whitePoint75(_whitePoint75),
+      blackAndWhite(_blackAndWhite), colourBurstMedian(_colourBurstMedian)
 {
-    blackIreLevel = blackIreParam; // 0 or 7.5 IRE 16-bit level
-    whiteIreLevel = whiteIreParam; // 100 IRE 16-bit level
-    whitePoint75 = whitePoint100Param; // false = using 100% white point, true = 75%
-    blackAndWhite = blackAndWhiteParam; // true = output in black and white only
-    colourBurstMedian = colourBurstMedianParam; // 40 IRE burst amplitude measured by ld-decode
 }
 
 void RGB::convertLine(const YIQ *begin, const YIQ *end, quint16 *out)

--- a/tools/ld-chroma-decoder/rgb.cpp
+++ b/tools/ld-chroma-decoder/rgb.cpp
@@ -67,7 +67,7 @@ void RGB::convertLine(const YIQ *begin, const YIQ *end, quint16 *out)
 
         // Scale the Y to 0-65535 where 0 = blackIreLevel and 65535 = whiteIreLevel
         y = (y - yBlackLevel) * yScale;
-        y = clamp(y, 0.0, 65535.0);
+        y = qBound(0.0, y, 65535.0);
 
         // Scale the I & Q components according to the colourburstMedian
         i *= iqScale;
@@ -81,9 +81,9 @@ void RGB::convertLine(const YIQ *begin, const YIQ *end, quint16 *out)
         double g = y - (0.272 * i) - (0.647 * q);
         double b = y - (1.107 * i) + (1.704 * q);
 
-        r = clamp(r, 0.0, 65535.0);
-        g = clamp(g, 0.0, 65535.0);
-        b = clamp(b, 0.0, 65535.0);
+        r = qBound(0.0, r, 65535.0);
+        g = qBound(0.0, g, 65535.0);
+        b = qBound(0.0, b, 65535.0);
 
         // Place the 16-bit RGB values in the output array
         *out++ = static_cast<quint16>(r);

--- a/tools/ld-chroma-decoder/rgb.h
+++ b/tools/ld-chroma-decoder/rgb.h
@@ -51,14 +51,4 @@ private:
     double colourBurstMedian;
 };
 
-// Clamp a value to within a fixed range.
-// (Equivalent to C++17's std::clamp.)
-template <typename T>
-static inline const T& clamp(const T& v, const T& low, const T& high)
-{
-    if (v < low) return low;
-    else if (v > high) return high;
-    else return v;
-}
-
 #endif // RGB_H

--- a/tools/ld-chroma-decoder/rgb.h
+++ b/tools/ld-chroma-decoder/rgb.h
@@ -34,13 +34,18 @@
 class RGB
 {
 public:
-    RGB(double whiteIreParam, double blackIreParam, bool whitePoint100Param, bool blackAndWhiteParam, double colourBurstMedianParam);
+    // whiteIreLevel: 100 IRE 16-bit level
+    // blackIreLevel: 0 or 7.5 IRE 16-bit level
+    // whitePoint75: false = using 100% white point, true = 75%
+    // blackAndWhite: true = output in black and white only
+    // colourBurstMedian: 40 IRE burst amplitude measured by ld-decode
+    RGB(double whiteIreLevel, double blackIreLevel, bool whitePoint75, bool blackAndWhite, double colourBurstMedian);
 
     void convertLine(const YIQ *begin, const YIQ *end, quint16 *out);
 
 private:
-    double blackIreLevel;
     double whiteIreLevel;
+    double blackIreLevel;
     bool whitePoint75;
     bool blackAndWhite;
     double colourBurstMedian;

--- a/tools/ld-chroma-decoder/transformpal.cpp
+++ b/tools/ld-chroma-decoder/transformpal.cpp
@@ -1,0 +1,235 @@
+/************************************************************************
+
+    transformpal.cpp
+
+    ld-chroma-decoder - Colourisation filter for ld-decode
+    Copyright (C) 2019 Adam Sampson
+
+    Reusing code from pyctools-pal, which is:
+    Copyright (C) 2014 Jim Easterbrook
+
+    This file is part of ld-decode-tools.
+
+    ld-chroma-decoder is free software: you can redistribute it and/or
+    modify it under the terms of the GNU General Public License as
+    published by the Free Software Foundation, either version 3 of the
+    License, or (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+************************************************************************/
+
+#include "transformpal.h"
+
+#include <cassert>
+#include <complex>
+
+/*!
+    \class TransformPal
+
+    Transform PAL filter, based on Jim Easterbrook's implementation in
+    pyctools-pal. Given a composite signal, this extracts a chroma signal from
+    it using frequency-domain processing.
+
+    For a description of the algorithm with examples, see Transform PAL web
+    site (http://www.jim-easterbrook.me.uk/pal/).
+
+    Note that this is only a 2D implementation at the moment, which limits the
+    quality of the output; it would be possible to extend it to 3D given access
+    to multiple fields.
+ */
+
+TransformPal::TransformPal()
+    : configurationSet(false)
+{
+    // Compute the window function for combining FFT results.
+    // XXX This is wasteful because the edges are 0... use raised cosine instead?
+    for (qint32 y = 0; y < YTILE; y++) {
+        const double windowY = ((y < HALFYTILE) ? y : (YTILE - 1 - y)) / (HALFYTILE - 1.0);
+        for (qint32 x = 0; x < XTILE; x++) {
+            const double windowX = ((x < HALFXTILE) ? x : (XTILE - 1 - x)) / (HALFXTILE - 1.0);
+            // Divide by number of elements too to normalise the FFTW result
+            windowFunction[y][x] = windowY * windowX / (YTILE * XTILE);
+        }
+    }
+
+    // Allocate buffers for FFTW. These must be allocated using FFTW's own
+    // functions so they're properly aligned for SIMD operations.
+    fftReal = fftw_alloc_real(YTILE * XTILE);
+    fftComplexIn = fftw_alloc_complex(YCOMPLEX * XCOMPLEX);
+    fftComplexOut = fftw_alloc_complex(YCOMPLEX * XCOMPLEX);
+
+    // Plan FFTW operations
+    // XXX FFTW_ESTIMATE is quick but potentially produces a slower plan...
+    forwardPlan = fftw_plan_dft_r2c_2d(YTILE, XTILE, fftReal, fftComplexIn, FFTW_ESTIMATE);
+    inversePlan = fftw_plan_dft_c2r_2d(YTILE, XTILE, fftComplexOut, fftReal, FFTW_ESTIMATE);
+}
+
+TransformPal::~TransformPal()
+{
+    // Free FFTW plans and buffers
+    fftw_destroy_plan(forwardPlan);
+    fftw_destroy_plan(inversePlan);
+    fftw_free(fftReal);
+    fftw_free(fftComplexIn);
+    fftw_free(fftComplexOut);
+}
+
+void TransformPal::updateConfiguration(LdDecodeMetaData::VideoParameters _videoParameters,
+                                       qint32 _firstActiveLine, qint32 _lastActiveLine,
+                                       double _threshold)
+{
+    videoParameters = _videoParameters;
+    firstActiveLine = _firstActiveLine;
+    lastActiveLine = _lastActiveLine;
+    threshold = _threshold;
+
+    // Resize the chroma buffer
+    chromaBuf.resize(videoParameters.fieldWidth * videoParameters.fieldHeight);
+
+    configurationSet = true;
+}
+
+const double *TransformPal::filterField(qint32 fieldNumber, const QByteArray &fieldData)
+{
+    assert(configurationSet);
+    assert(fieldNumber == 0 || fieldNumber == 1);
+    assert(!fieldData.isNull());
+
+    // Work out the active lines to be decoded within this field.
+    // If firstActiveLine or lastActiveLine is odd, we can end up with
+    // different ranges for the two fields, so we need to be careful
+    // about how this is rounded.
+    const qint32 firstFieldLine = (firstActiveLine + 1 - fieldNumber) / 2;
+    const qint32 lastFieldLine = (lastActiveLine + 1 - fieldNumber) / 2;
+
+    // Pointers to the input and output data
+    const quint16 *inputPtr = reinterpret_cast<const quint16 *>(fieldData.data());
+    double *outputPtr = chromaBuf.data();
+
+    // Clear chromaBuf
+    chromaBuf.fill(0.0);
+
+    // Iterate through the overlapping tile positions, covering the active area.
+    // (See TransformThread member variable documentation for how the tiling works.)
+    for (qint32 tileY = firstFieldLine - HALFYTILE; tileY < lastFieldLine; tileY += HALFYTILE) {
+        for (qint32 tileX = videoParameters.activeVideoStart - HALFXTILE; tileX < videoParameters.activeVideoEnd; tileX += HALFXTILE) {
+            // Work out what portion of this tile is inside the active area
+            const qint32 startX = qMax(videoParameters.activeVideoStart - tileX, 0);
+            const qint32 endX = qMin(videoParameters.activeVideoEnd - tileX, XTILE);
+            const qint32 startY = qMax(firstFieldLine - tileY, 0);
+            const qint32 endY = qMin(lastFieldLine - tileY, YTILE);
+
+            // If we aren't going to fill in the whole tile, zero it first
+            if (startX != 0 || endX != XTILE || startY != 0 || endY != YTILE) {
+                for (qint32 i = 0; i < YTILE * XTILE; i++) {
+                    fftReal[i] = 0.0;
+                }
+            }
+
+            // Copy the input signal into fftReal
+            for (qint32 y = startY; y < endY; y++) {
+                const quint16 *b = inputPtr + ((tileY + y) * videoParameters.fieldWidth);
+                for (qint32 x = startX; x < endX; x++) {
+                    fftReal[(y * XTILE) + x] = b[tileX + x];
+                }
+            }
+
+            // Convert time domain in fftReal to frequency domain in fftComplexIn
+            fftw_execute(forwardPlan);
+
+            // Apply the frequency-domain filter
+            applyFilter();
+
+            // Convert frequency domain in fftComplexOut back to time domain in fftReal
+            fftw_execute(inversePlan);
+
+            // Overlay the result, with windowing and normalisation, into chromaBuf
+            for (qint32 y = startY; y < endY; y++) {
+                double *b = outputPtr + ((tileY + y) * videoParameters.fieldWidth);
+                for (qint32 x = startX; x < endX; x++) {
+                    b[tileX + x] += fftReal[(y * XTILE) + x] * windowFunction[y][x];
+                }
+            }
+        }
+    }
+
+    return chromaBuf.data();
+}
+
+// Return the absolute value of an fftw_complex
+static inline double fftwAbs(const fftw_complex &value) {
+    return std::abs(std::complex<double>(value[0], value[1]));
+}
+
+void TransformPal::applyFilter() {
+    // Clear fftComplexOut. We discard values by default; the filter only
+    // copies values that look like chroma.
+    for (int i = 0; i < XCOMPLEX * YCOMPLEX; i++) {
+        fftComplexOut[i][0] = 0.0;
+        fftComplexOut[i][1] = 0.0;
+    }
+
+    // This is a direct translation of transform_filter from pyctools-pal.
+    // The main simplification is that we don't need to worry about
+    // conjugates, because FFTW only returns half the result in the first
+    // place. We've also only implemented "threshold" mode for now.
+    //
+    // The general idea is that a real modulated chroma signal will be
+    // symmetrical around the U carrier, which is at fSC Hz and 72 c/aph -- and
+    // because we're sampling at 4fSC, this is handily equivalent to being
+    // symmetrical around the V carrier owing to wraparound. We look at every
+    // point that might be a chroma signal, and only keep it if it's
+    // sufficiently symmetrical with its reflection.
+
+    for (int y = 0; y < YTILE; y++) {
+        // Reflect around 72 c/aph vertically.
+        const int y_ref = ((YTILE / 2) + YTILE - y) % YTILE;
+
+        // Input data for this line and its reflection
+        const fftw_complex *bi = fftComplexIn + (y * XCOMPLEX);
+        const fftw_complex *bi_ref = fftComplexIn + (y_ref * XCOMPLEX);
+
+        // Output data for this line and its reflection
+        fftw_complex *bo = fftComplexOut + (y * XCOMPLEX);
+        fftw_complex *bo_ref = fftComplexOut + (y_ref * XCOMPLEX);
+
+        // We only need to look at horizontal frequencies that might be chroma (0.5fSC to 2fSC).
+        for (int x = XTILE / 8; x <= XTILE / 4; x++) {
+            // Reflect around 4fSC Hz horizontally.
+            const int x_ref = (XTILE / 2) - x;
+
+            const fftw_complex &in_val = bi[x];
+            const fftw_complex &ref_val = bi_ref[x_ref];
+
+            if (x == x_ref && y == y_ref) {
+                // This point is its own reflection (i.e. it's a carrier). Keep it!
+                bo[x][0] = in_val[0];
+                bo[x][1] = in_val[1];
+                continue;
+            }
+
+            // Compare the magnitudes of the two values.
+            // XXX This does a sqrt which we don't strictly need for the comparison below
+            // XXX Implement other comparison modes
+            const double m_in = fftwAbs(in_val);
+            const double m_ref = fftwAbs(ref_val);
+            if (m_in < m_ref * threshold || m_ref < m_in * threshold) {
+                // They're different. Probably not a chroma signal; throw it away.
+                continue;
+            }
+
+            // They're similar. Keep it!
+            bo[x][0] = in_val[0];
+            bo[x][1] = in_val[1];
+            bo_ref[x_ref][0] = ref_val[0];
+            bo_ref[x_ref][1] = ref_val[1];
+        }
+    }
+}

--- a/tools/ld-chroma-decoder/transformpal.h
+++ b/tools/ld-chroma-decoder/transformpal.h
@@ -1,0 +1,97 @@
+/************************************************************************
+
+    transformpal.h
+
+    ld-chroma-decoder - Colourisation filter for ld-decode
+    Copyright (C) 2019 Adam Sampson
+
+    Reusing code from pyctools-pal, which is:
+    Copyright (C) 2014 Jim Easterbrook
+
+    This file is part of ld-decode-tools.
+
+    ld-chroma-decoder is free software: you can redistribute it and/or
+    modify it under the terms of the GNU General Public License as
+    published by the Free Software Foundation, either version 3 of the
+    License, or (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+************************************************************************/
+
+#ifndef TRANSFORMPAL_H
+#define TRANSFORMPAL_H
+
+#include <QByteArray>
+#include <QDebug>
+#include <QObject>
+#include <fftw3.h>
+
+#include "lddecodemetadata.h"
+
+class TransformPal {
+public:
+    TransformPal();
+    ~TransformPal();
+
+    // threshold is the similarity threshold for the filter (0.6 is pyctools-pal's default)
+    void updateConfiguration(LdDecodeMetaData::VideoParameters videoParameters,
+                             qint32 firstActiveLine, qint32 lastActiveLine,
+                             double threshold);
+
+    // Filter an input field.
+    // Returns a pointer to an array of the same size (owned by this object)
+    // containing the chroma signal.
+    const double *filterField(qint32 fieldNumber, const QByteArray &fieldData);
+
+private:
+    // Apply the frequency-domain filter
+    void applyFilter();
+
+    // Configuration parameters
+    bool configurationSet;
+    LdDecodeMetaData::VideoParameters videoParameters;
+    qint32 firstActiveLine;
+    qint32 lastActiveLine;
+    double threshold;
+
+    // Maximum field size, based on PAL
+    static constexpr int MAX_WIDTH = 1135;
+
+    // FFT input and output sizes.
+    // The input field is divided into tiles of XSIZE x YSIZE, with adjacent
+    // tiles overlapping by HALFXSIZE/HALFYSIZE.
+    static constexpr int YTILE = 16;
+    static constexpr int HALFYTILE = YTILE / 2;
+    static constexpr int XTILE = 32;
+    static constexpr int HALFXTILE = XTILE / 2;
+
+    // Each tile is converted to the frequency domain using forwardPlan, which
+    // gives a complex result of size XCOMPLEX x YCOMPLEX (roughly half the
+    // size of the input, because the input data was real, i.e. contained no
+    // negative frequencies).
+    static constexpr int YCOMPLEX = YTILE;
+    static constexpr int XCOMPLEX = (XTILE / 2) + 1;
+
+    // FFT input/output buffers
+    double *fftReal;
+    fftw_complex *fftComplexIn;
+    fftw_complex *fftComplexOut;
+
+    // FFT plans
+    fftw_plan forwardPlan, inversePlan;
+
+    // The combined result of all the FFT processing.
+    // Inverse-FFT results are accumulated into this buffer, multiplied by
+    // windowFunction to "crossfade" between the overlapping tiles.
+    QVector<double> chromaBuf;
+    double windowFunction[YTILE][XTILE];
+};
+
+#endif

--- a/tools/ld-chroma-decoder/yiq.cpp
+++ b/tools/ld-chroma-decoder/yiq.cpp
@@ -26,8 +26,8 @@
 #include "yiq.h"
 
 YIQ::YIQ(qreal _y, qreal _i, qreal _q)
+    : y(_y), i(_i), q(_q)
 {
-    y = _y; i = _i; q = _q;
 }
 
 YIQ YIQ::operator*=(qreal x)

--- a/tools/ld-chroma-decoder/yiq.h
+++ b/tools/ld-chroma-decoder/yiq.h
@@ -33,7 +33,7 @@ class YIQ
 public:
     qreal y, i, q;
 
-    YIQ(qreal _y = 0.0, qreal _i = 0.0, qreal _q = 0.0);
+    YIQ(qreal y = 0.0, qreal i = 0.0, qreal q = 0.0);
     YIQ operator*=(qreal x);
     YIQ operator+=(const YIQ &p);
 


### PR DESCRIPTION
Refactor PalColour to be more modular (and better-documented), and then implement a basic 2D Transform PAL decoder using a translation of [the frequency-domain filter from pyctools-pal](https://github.com/jim-easterbrook/pyctools-pal/blob/master/src/pyctools/components/pal/transformcore.pyx), with PalColour's chroma LPF and demodulator, and the FFTW library to compute the FFTs.

I first tried doing this as a completely separate Decoder, but I found that I'd duplicated nearly all of PalColour in the process -- so this way is simpler!

Here's how it all fits together, with the switches representing the difference between pal2d and transform2d mode:

![transformpal](https://user-images.githubusercontent.com/436317/62841028-087eef00-bc9b-11e9-9f9e-ac975b442eb6.jpg)

The output is pretty encouraging given how simple the filter is - it does a good job of getting rid of cross-colour, but produces some luma artefacts. Here's a scene from GGV1011 that it handles well - first pal2d, then transform2d:

![pr-motion123-output](https://user-images.githubusercontent.com/436317/62841066-b12d4e80-bc9b-11e9-9d0f-ad61b4fb31dd.png)
![pr-motion123-t2d-output](https://user-images.githubusercontent.com/436317/62841067-b4c0d580-bc9b-11e9-833b-b1cb89a59f32.png)

I've put more examples [here](https://stuff.offog.org/ld/transform/).

I imagine some tuning of the FFT size and comparison algorithm would improve matters - I've just implemented it exactly as in pyctools-pal for now.

Related to #211.