### PR TITLE
Tune Transform PAL's window function and default threshold

### DIFF
--- a/tools/ld-chroma-decoder/main.cpp
+++ b/tools/ld-chroma-decoder/main.cpp
@@ -169,7 +169,7 @@ int main(int argc, char *argv[])
 
     // Option to select the Transform PAL threshold
     QCommandLineOption transformThresholdOption(QStringList() << "transformThreshold",
-                                                QCoreApplication::translate("main", "Transform: Similarity threshold for the chroma filter (default 0.6)"),
+                                                QCoreApplication::translate("main", "Transform: Similarity threshold for the chroma filter (default 0.4)"),
                                                 QCoreApplication::translate("main", "number"));
     parser.addOption(transformThresholdOption);
 
@@ -220,7 +220,7 @@ int main(int argc, char *argv[])
     qint32 startFrame = -1;
     qint32 length = -1;
     qint32 maxThreads = QThread::idealThreadCount() + 2;
-    double transformThreshold = 0.6;
+    double transformThreshold = 0.4;
 
     if (parser.isSet(startFrameOption)) {
         startFrame = parser.value(startFrameOption).toInt();

--- a/tools/ld-chroma-decoder/palcolour.h
+++ b/tools/ld-chroma-decoder/palcolour.h
@@ -42,7 +42,7 @@ class PalColour : public QObject
 public:
     explicit PalColour(QObject *parent = nullptr);
     void updateConfiguration(LdDecodeMetaData::VideoParameters videoParameters, qint32 firstActiveLine, qint32 lastActiveLine,
-                             bool useTransformFilter = false, double transformThreshold = 0.6);
+                             bool useTransformFilter = false, double transformThreshold = 0.4);
 
     // Decode two fields to produce an interlaced frame.
     // contrast and saturation are user-adjustable controls; 100 is nominal.

--- a/tools/ld-chroma-decoder/paldecoder.h
+++ b/tools/ld-chroma-decoder/paldecoder.h
@@ -42,7 +42,7 @@ class DecoderPool;
 // 2D PAL decoder using PALcolour
 class PalDecoder : public Decoder {
 public:
-    PalDecoder(bool blackAndWhite, bool useTransformFilter = false, double transformThreshold = 0.6);
+    PalDecoder(bool blackAndWhite, bool useTransformFilter = false, double transformThreshold = 0.4);
     bool configure(const LdDecodeMetaData::VideoParameters &videoParameters) override;
     QThread *makeThread(QAtomicInt& abort, DecoderPool& decoderPool) override;
 

--- a/tools/ld-chroma-decoder/transformpal.cpp
+++ b/tools/ld-chroma-decoder/transformpal.cpp
@@ -27,7 +27,9 @@
 
 #include "transformpal.h"
 
+#include <QtMath>
 #include <cassert>
+#include <cmath>
 #include <complex>
 
 /*!
@@ -49,13 +51,12 @@ TransformPal::TransformPal()
     : configurationSet(false)
 {
     // Compute the window function applied to the data blocks before the FFT to
-    // reduce edge effects. This function is chosen so that the overlapping
-    // inverse-FFT blocks can be summed directly.
-    // XXX This is wasteful because the edges are 0... use raised cosine instead?
+    // reduce edge effects. A symmetrical raised-cosine function is chosen so
+    // that the overlapping inverse-FFT blocks can be summed directly.
     for (qint32 y = 0; y < YTILE; y++) {
-        const double windowY = ((y < HALFYTILE) ? y : (YTILE - 1 - y)) / (HALFYTILE - 1.0);
+        const double windowY = (1 - cos((2 * M_PI * (y + 0.5)) / YTILE)) / 2;
         for (qint32 x = 0; x < XTILE; x++) {
-            const double windowX = ((x < HALFXTILE) ? x : (XTILE - 1 - x)) / (HALFXTILE - 1.0);
+            const double windowX = (1 - cos((2 * M_PI * (x + 0.5)) / XTILE)) / 2;
             windowFunction[y][x] = windowY * windowX;
         }
     }

--- a/tools/ld-chroma-decoder/transformpal.cpp
+++ b/tools/ld-chroma-decoder/transformpal.cpp
@@ -48,14 +48,15 @@
 TransformPal::TransformPal()
     : configurationSet(false)
 {
-    // Compute the window function for combining FFT results.
+    // Compute the window function applied to the data blocks before the FFT to
+    // reduce edge effects. This function is chosen so that the overlapping
+    // inverse-FFT blocks can be summed directly.
     // XXX This is wasteful because the edges are 0... use raised cosine instead?
     for (qint32 y = 0; y < YTILE; y++) {
         const double windowY = ((y < HALFYTILE) ? y : (YTILE - 1 - y)) / (HALFYTILE - 1.0);
         for (qint32 x = 0; x < XTILE; x++) {
             const double windowX = ((x < HALFXTILE) ? x : (XTILE - 1 - x)) / (HALFXTILE - 1.0);
-            // Divide by number of elements too to normalise the FFTW result
-            windowFunction[y][x] = windowY * windowX / (YTILE * XTILE);
+            windowFunction[y][x] = windowY * windowX;
         }
     }
 
@@ -133,11 +134,11 @@ const double *TransformPal::filterField(qint32 fieldNumber, const QByteArray &fi
                 }
             }
 
-            // Copy the input signal into fftReal
+            // Copy the input signal into fftReal, applying the window function
             for (qint32 y = startY; y < endY; y++) {
                 const quint16 *b = inputPtr + ((tileY + y) * videoParameters.fieldWidth);
                 for (qint32 x = startX; x < endX; x++) {
-                    fftReal[(y * XTILE) + x] = b[tileX + x];
+                    fftReal[(y * XTILE) + x] = b[tileX + x] * windowFunction[y][x];
                 }
             }
 
@@ -150,11 +151,11 @@ const double *TransformPal::filterField(qint32 fieldNumber, const QByteArray &fi
             // Convert frequency domain in fftComplexOut back to time domain in fftReal
             fftw_execute(inversePlan);
 
-            // Overlay the result, with windowing and normalisation, into chromaBuf
+            // Overlay the result, normalising the FFTW output, into chromaBuf
             for (qint32 y = startY; y < endY; y++) {
                 double *b = outputPtr + ((tileY + y) * videoParameters.fieldWidth);
                 for (qint32 x = startX; x < endX; x++) {
-                    b[tileX + x] += fftReal[(y * XTILE) + x] * windowFunction[y][x];
+                    b[tileX + x] += fftReal[(y * XTILE) + x] / (YTILE * XTILE);
                 }
             }
         }

--- a/tools/ld-chroma-decoder/transformpal.h
+++ b/tools/ld-chroma-decoder/transformpal.h
@@ -79,6 +79,9 @@ private:
     static constexpr int YCOMPLEX = YTILE;
     static constexpr int XCOMPLEX = (XTILE / 2) + 1;
 
+    // Window function applied before the FFT
+    double windowFunction[YTILE][XTILE];
+
     // FFT input/output buffers
     double *fftReal;
     fftw_complex *fftComplexIn;
@@ -88,10 +91,8 @@ private:
     fftw_plan forwardPlan, inversePlan;
 
     // The combined result of all the FFT processing.
-    // Inverse-FFT results are accumulated into this buffer, multiplied by
-    // windowFunction to "crossfade" between the overlapping tiles.
+    // Inverse-FFT results are accumulated into this buffer.
     QVector<double> chromaBuf;
-    double windowFunction[YTILE][XTILE];
 };
 
 #endif

--- a/tools/ld-chroma-decoder/transformpal.h
+++ b/tools/ld-chroma-decoder/transformpal.h
@@ -40,7 +40,8 @@ public:
     TransformPal();
     ~TransformPal();
 
-    // threshold is the similarity threshold for the filter (0.6 is pyctools-pal's default)
+    // threshold is the similarity threshold for the filter (values from 0-1
+    // are meaningful; 0.6 is pyctools-pal's default)
     void updateConfiguration(LdDecodeMetaData::VideoParameters videoParameters,
                              qint32 firstActiveLine, qint32 lastActiveLine,
                              double threshold);


### PR DESCRIPTION
Apply the window function correctly, use a better window function, and reduce the default similarity threshold after tests with the reference disc video.

testcardg before and after:

![testcardg-transform2d](https://user-images.githubusercontent.com/436317/62891832-b2fc1e00-bd3e-11e9-9cc3-e0d45ad4feec.png)
![testcardg-thresh0 4](https://user-images.githubusercontent.com/436317/62891850-b98a9580-bd3e-11e9-8588-1a969dc14d68.png)
