### PR TITLE
Feed 8-bit input to cv::calcOpticalFlowFarneback

### DIFF
--- a/tools/ld-chroma-decoder/opticalflow.cpp
+++ b/tools/ld-chroma-decoder/opticalflow.cpp
@@ -75,18 +75,19 @@ void OpticalFlow::denseOpticalFlow(const YiqBuffer &yiqBuffer, QVector<qreal> &k
 // Method to convert a qreal vector frame of Y values to an OpenCV n-dimensional dense array (cv::Mat)
 cv::Mat OpticalFlow::convertYtoMat(const YiqBuffer &yiqBuffer)
 {
-    quint16 frame[910 * 525];
+    quint8 frame[910 * 525];
     memset(frame, 0, sizeof(frame));
 
-    // Firstly we have to convert the Y vector of real numbers into quint16 values for OpenCV
+    // Firstly we have to convert the Y vector of real numbers into quint8
+    // values for cv::calcOpticalFlowFarneback
     for (qint32 line = 0; line < 525; line++) {
         for (qint32 pixel = 0; pixel < 910; pixel++) {
-            frame[(line * 910) + pixel] = static_cast<quint16>(yiqBuffer[line][pixel].y);
+            frame[(line * 910) + pixel] = static_cast<quint8>(yiqBuffer[line][pixel].y / 256.0);
         }
     }
 
-    // Return a Mat y * x in CV_16UC1 format
-    return cv::Mat(525, 910, CV_16UC1, frame).clone();
+    // Return a Mat y * x in CV_8UC1 format
+    return cv::Mat(525, 910, CV_8UC1, frame).clone();
 }
 
 // This method calculates the distance between points where x is the difference between the x-coordinates

--- a/tools/ld-chroma-decoder/opticalflow.cpp
+++ b/tools/ld-chroma-decoder/opticalflow.cpp
@@ -51,7 +51,7 @@ void OpticalFlow::denseOpticalFlow(const YiqBuffer &yiqBuffer, QVector<qreal> &k
         cv::GaussianBlur(flow, flow, cv::Size(21, 21), 0);
 
         // Convert to K values
-        for (qint32 y = 0; y < 524; y++) {
+        for (qint32 y = 0; y < 525; y++) {
             for (qint32 x = 0; x < 910; x++) {
                 // Get the flow velocity at the current x, y point
                 const cv::Point2f flowatxy = flow.at<cv::Point2f>(y, x);


### PR DESCRIPTION
The documentation says the input should be an 8-bit single-channel image; we were giving it 16-bit input. The output still isn't great but it's a lot better than before...

Before (the zoneplate blob is moving in this frame):
![3dmap1-output](https://user-images.githubusercontent.com/436317/62983289-bcf94c00-be26-11e9-9280-c5d26986e10e.png)

After:
![3dmap1-output](https://user-images.githubusercontent.com/436317/62983303-caaed180-be26-11e9-8dfd-7992082a6e31.png)

Thresholding velocity at 2 afterwards seems to get rid of most of the spurious motion, but that's one of many parameters that could be tweaked here...

Related to #133.