### PR TITLE
Parallel ntsc3d and other ld-chroma-decoder refactoring

### DIFF
--- a/tools/ld-analyse/tbcsource.cpp
+++ b/tools/ld-analyse/tbcsource.cpp
@@ -520,14 +520,15 @@ QImage TbcSource::generateQImage(qint32 firstFieldNumber, qint32 secondFieldNumb
             }
         }
     } else {
-        // Set the first and last active scan line (for PAL)
-        qint32 firstActiveScanLine = 44;
-        qint32 lastActiveScanLine = 620;
+        qint32 firstActiveLine, lastActiveLine;
         QByteArray outputData;
 
         // Perform a PAL 2D comb filter on the current frame
         if (videoParameters.isSourcePal) {
             // PAL source
+
+            firstActiveLine = palColour.getConfiguration().firstActiveLine;
+            lastActiveLine = palColour.getConfiguration().lastActiveLine;
 
             // Calculate the saturation level from the burst median IRE
             // Note: This code works as a temporary MTF compensator whilst ld-decode gets
@@ -540,9 +541,8 @@ QImage TbcSource::generateQImage(qint32 firstFieldNumber, qint32 secondFieldNumb
         } else {
             // NTSC source
 
-            // Set the first and last active scan line
-            firstActiveScanLine = 40;
-            lastActiveScanLine = 525;
+            firstActiveLine = ntscColour.getConfiguration().firstActiveLine;
+            lastActiveLine = ntscColour.getConfiguration().lastActiveLine;
 
             outputData = ntscColour.process(firstFieldData, secondFieldData,
                                                             ldDecodeMetaData.getField(firstFieldNumber).medianBurstIRE,
@@ -554,7 +554,7 @@ QImage TbcSource::generateQImage(qint32 firstFieldNumber, qint32 secondFieldNumb
         frameImage.fill(Qt::black);
 
         // Copy the RGB16-16-16 data into the RGB888 QImage
-        for (qint32 y = firstActiveScanLine; y < lastActiveScanLine; y++) {
+        for (qint32 y = firstActiveLine; y < lastActiveLine; y++) {
             // Extract the current scan line data from the frame
             qint32 startPointer = y * videoParameters.fieldWidth * 6;
             qint32 length = videoParameters.fieldWidth * 6;
@@ -676,7 +676,6 @@ void TbcSource::startBackgroundLoad(QString sourceFilename)
         palColour.updateConfiguration(videoParameters, configuration);
     } else {
         Comb::Configuration configuration;
-        configuration.firstActiveLine = 40;
         ntscColour.updateConfiguration(videoParameters, configuration);
     }
 

--- a/tools/ld-analyse/tbcsource.cpp
+++ b/tools/ld-analyse/tbcsource.cpp
@@ -668,8 +668,12 @@ void TbcSource::startBackgroundLoad(QString sourceFilename)
 
     // Configure the chroma decoder
     if (videoParameters.isSourcePal) {
+        PalColour::Configuration configuration;
+
         // Default to the PAL 2D transform filter
-        palColour.updateConfiguration(videoParameters, 44, 620, true);
+        configuration.useTransformFilter = true;
+
+        palColour.updateConfiguration(videoParameters, configuration);
     } else {
         Comb::Configuration configuration;
         configuration.firstActiveLine = 40;

--- a/tools/ld-analyse/tbcsource.cpp
+++ b/tools/ld-analyse/tbcsource.cpp
@@ -671,36 +671,9 @@ void TbcSource::startBackgroundLoad(QString sourceFilename)
         // Default to the PAL 2D transform filter
         palColour.updateConfiguration(videoParameters, 44, 620, true);
     } else {
-        // Set the first active scan line
-        qint32 firstActiveScanLine = 40;
-
-        // Get the default configuration for the comb filter
-        Comb::Configuration configuration = ntscColour.getConfiguration();
-
-        // Set the comb filter configuration
-        configuration.blackAndWhite = false;
-
-        // Set the input buffer dimensions configuration
-        configuration.fieldWidth = videoParameters.fieldWidth;
-        configuration.fieldHeight = videoParameters.fieldHeight;
-
-        // Set the active video range
-        configuration.activeVideoStart = videoParameters.activeVideoStart;
-        configuration.activeVideoEnd = videoParameters.activeVideoEnd;
-
-        // Set the first frame scan line which contains active video
-        configuration.firstActiveLine = firstActiveScanLine;
-
-        // Set the IRE levels
-        configuration.blackIre = videoParameters.black16bIre;
-        configuration.whiteIre = videoParameters.white16bIre;
-
-        // Set the filter mode
-        configuration.use3D = false;
-        configuration.showOpticalFlowMap = false;
-
-        // Update the comb filter object's configuration
-        ntscColour.setConfiguration(configuration);
+        Comb::Configuration configuration;
+        configuration.firstActiveLine = 40;
+        ntscColour.updateConfiguration(videoParameters, configuration);
     }
 
     // Generate the graph data for the source

--- a/tools/ld-chroma-decoder/comb.cpp
+++ b/tools/ld-chroma-decoder/comb.cpp
@@ -63,8 +63,8 @@ void Comb::updateConfiguration(const LdDecodeMetaData::VideoParameters &_videoPa
 }
 
 // Process the input buffer into the RGB output buffer
-QByteArray Comb::process(QByteArray firstFieldInputBuffer, QByteArray secondFieldInputBuffer, qreal burstMedianIre,
-                         qint32 firstFieldPhaseID, qint32 secondFieldPhaseID)
+QByteArray Comb::decodeFrame(const LdDecodeMetaData::Field &firstField, QByteArray firstFieldInputBuffer,
+                             const LdDecodeMetaData::Field &secondField, QByteArray secondFieldInputBuffer)
 {
     // Ensure the object has been configured
     if (!configurationSet) {
@@ -92,13 +92,14 @@ QByteArray Comb::process(QByteArray firstFieldInputBuffer, QByteArray secondFiel
         fieldLine++;
     }
 
-    // Set the frames burst median (IRE) - This is used by yiqToRgbFrame to tweak the colour
-    // saturation levels (compensating for MTF issues)
-    currentFrameBuffer.burstLevel = burstMedianIre;
+    // Set the frame's burst median (IRE) from the *first* field only.
+    // This is used by yiqToRgbFrame to tweak the colour saturation levels
+    // (compensating for MTF issues)
+    currentFrameBuffer.burstLevel = firstField.medianBurstIRE;
 
     // Set the phase IDs for the frame
-    currentFrameBuffer.firstFieldPhaseID = firstFieldPhaseID;
-    currentFrameBuffer.secondFieldPhaseID = secondFieldPhaseID;
+    currentFrameBuffer.firstFieldPhaseID = firstField.fieldPhaseID;
+    currentFrameBuffer.secondFieldPhaseID = secondField.fieldPhaseID;
 
     // 2D or 3D comb filter processing?
     if (!configuration.use3D) {

--- a/tools/ld-chroma-decoder/comb.cpp
+++ b/tools/ld-chroma-decoder/comb.cpp
@@ -29,63 +29,49 @@
 
 // Public methods -----------------------------------------------------------------------------------------------------
 
-Comb::Comb() {
-    // Set default configuration
-    configuration.blackAndWhite = false;
-    configuration.whitePoint100 = false;
-
-    configuration.colorlpf = true; // Use as default
-    configuration.colorlpf_hq = true; // Use as default
-    
-    configuration.cNRLevel = 0.0;
-    configuration.yNRLevel = 1.0;
-
-    // These are the overall dimensions of the input frame
-    configuration.fieldWidth = 910;
-    configuration.fieldHeight = 263;
-
-    // These are the start and end points for the active video line
-    configuration.activeVideoStart = 40;
-    configuration.activeVideoEnd = 840;
-
-    // This sets the first active frame line
-    configuration.firstActiveLine = 43;
-
-    // Set the 16-bit IRE levels
-    configuration.blackIre = 15360;
-    configuration.whiteIre = 51200;
-
-    // Set the filter type
-    configuration.use3D = false;
-    configuration.showOpticalFlowMap = false;
-
-    postConfigurationTasks();
+Comb::Comb()
+    : configurationSet(false)
+{
 }
 
-// Get the comb filter configuration parameters
-Comb::Configuration Comb::getConfiguration()
-{
+// Return the current configuration
+const Comb::Configuration &Comb::getConfiguration() const {
     return configuration;
 }
 
 // Set the comb filter configuration parameters
-void Comb::setConfiguration(const Comb::Configuration &_configuration)
+void Comb::updateConfiguration(const LdDecodeMetaData::VideoParameters &_videoParameters, const Comb::Configuration &_configuration)
 {
+    // Copy the configuration parameters
+    videoParameters = _videoParameters;
+    configuration = _configuration;
+
     // Range check the frame dimensions
-    if (_configuration.fieldWidth > 910) qCritical() << "Comb::Comb(): Frame width exceeds allowed maximum!";
-    if (((_configuration.fieldHeight * 2) - 1) > 525) qCritical() << "Comb::Comb(): Frame height exceeds allowed maximum!";
+    if (videoParameters.fieldWidth > 910) qCritical() << "Comb::Comb(): Frame width exceeds allowed maximum!";
+    if (((videoParameters.fieldHeight * 2) - 1) > 525) qCritical() << "Comb::Comb(): Frame height exceeds allowed maximum!";
 
     // Range check the video start
-    if (_configuration.activeVideoStart < 16) qCritical() << "Comb::Comb(): activeVideoStart must be > 16!";
+    if (videoParameters.activeVideoStart < 16) qCritical() << "Comb::Comb(): activeVideoStart must be > 16!";
 
-    configuration = _configuration;
-    postConfigurationTasks();
+    // Set the IRE scale
+    irescale = (videoParameters.white16bIre - videoParameters.black16bIre) / 100;
+
+    // Set the frame height
+    frameHeight = ((videoParameters.fieldHeight * 2) - 1);
+
+    configurationSet = true;
 }
 
 // Process the input buffer into the RGB output buffer
 QByteArray Comb::process(QByteArray firstFieldInputBuffer, QByteArray secondFieldInputBuffer, qreal burstMedianIre,
                          qint32 firstFieldPhaseID, qint32 secondFieldPhaseID)
 {
+    // Ensure the object has been configured
+    if (!configurationSet) {
+        qDebug() << "Comb::process(): Called, but the object has not been configured";
+        return nullptr;
+    }
+
     // Allocate the frame buffer
     FrameBuffer currentFrameBuffer;
     currentFrameBuffer.clpbuffer.resize(3);
@@ -101,8 +87,8 @@ QByteArray Comb::process(QByteArray firstFieldInputBuffer, QByteArray secondFiel
     qint32 fieldLine = 0;
     currentFrameBuffer.rawbuffer.clear();
     for (qint32 frameLine = 0; frameLine < frameHeight; frameLine += 2) {
-        currentFrameBuffer.rawbuffer.append(firstFieldInputBuffer.mid(fieldLine * configuration.fieldWidth * 2, configuration.fieldWidth * 2));
-        currentFrameBuffer.rawbuffer.append(secondFieldInputBuffer.mid(fieldLine * configuration.fieldWidth * 2, configuration.fieldWidth * 2));
+        currentFrameBuffer.rawbuffer.append(firstFieldInputBuffer.mid(fieldLine * videoParameters.fieldWidth * 2, videoParameters.fieldWidth * 2));
+        currentFrameBuffer.rawbuffer.append(secondFieldInputBuffer.mid(fieldLine * videoParameters.fieldWidth * 2, videoParameters.fieldWidth * 2));
         fieldLine++;
     }
 
@@ -191,16 +177,6 @@ QByteArray Comb::process(QByteArray firstFieldInputBuffer, QByteArray secondFiel
 
 // Private methods ----------------------------------------------------------------------------------------------------
 
-// Tasks to be performed if the configuration changes
-void Comb::postConfigurationTasks()
-{
-    // Set the IRE scale
-    irescale = (configuration.whiteIre - configuration.blackIre) / 100;
-
-    // Set the frame height
-    frameHeight = ((configuration.fieldHeight * 2) - 1);
-}
-
 /* 
  * The color burst frequency is 227.5 cycles per line, so it flips 180 degrees for each line.
  * 
@@ -237,9 +213,9 @@ void Comb::split1D(FrameBuffer *frameBuffer)
 {
     for (qint32 lineNumber = configuration.firstActiveLine; lineNumber < frameHeight; lineNumber++) {
         // Get a pointer to the line's data
-        quint16 *line = reinterpret_cast<quint16 *>(frameBuffer->rawbuffer.data() + (lineNumber * configuration.fieldWidth) * 2);
+        quint16 *line = reinterpret_cast<quint16 *>(frameBuffer->rawbuffer.data() + (lineNumber * videoParameters.fieldWidth) * 2);
 
-        for (qint32 h = configuration.activeVideoStart; h < configuration.activeVideoEnd; h++) {
+        for (qint32 h = videoParameters.activeVideoStart; h < videoParameters.activeVideoEnd; h++) {
             qreal tc1 = (((line[h + 2] + line[h - 2]) / 2) - line[h]);
 
             // Record the 1D C value
@@ -268,7 +244,7 @@ void Comb::split2D(FrameBuffer *frameBuffer)
         }
 
         // 2D filtering.
-        for (qint32 h = configuration.activeVideoStart; h < configuration.activeVideoEnd; h++) {
+        for (qint32 h = videoParameters.activeVideoStart; h < videoParameters.activeVideoEnd; h++) {
             qreal tc1;
 
             qreal kp, kn;
@@ -322,10 +298,10 @@ void Comb::split3D(FrameBuffer *currentFrame, FrameBuffer *previousFrame)
 
     for (qint32 lineNumber = configuration.firstActiveLine; lineNumber < frameHeight; lineNumber++) {
 
-        quint16 *currentLine = reinterpret_cast<quint16 *>(currentFrame->rawbuffer.data() + (lineNumber * configuration.fieldWidth) * 2);
-        quint16 *previousLine = reinterpret_cast<quint16 *>(previousFrame->rawbuffer.data() + (lineNumber * configuration.fieldWidth) * 2);
+        quint16 *currentLine = reinterpret_cast<quint16 *>(currentFrame->rawbuffer.data() + (lineNumber * videoParameters.fieldWidth) * 2);
+        quint16 *previousLine = reinterpret_cast<quint16 *>(previousFrame->rawbuffer.data() + (lineNumber * videoParameters.fieldWidth) * 2);
 
-        for (qint32 h = configuration.activeVideoStart; h < configuration.activeVideoEnd; h++) {
+        for (qint32 h = videoParameters.activeVideoStart; h < videoParameters.activeVideoEnd; h++) {
             currentFrame->clpbuffer[2].pixel[lineNumber][h] = (previousLine[h] - currentLine[h]) / 2;
         }
     }
@@ -339,11 +315,11 @@ void Comb::splitIQ(FrameBuffer *frameBuffer)
 
     for (qint32 lineNumber = configuration.firstActiveLine; lineNumber < frameHeight; lineNumber++) {
         // Get a pointer to the line's data
-        quint16 *line = reinterpret_cast<quint16 *>(frameBuffer->rawbuffer.data() + (lineNumber * configuration.fieldWidth) * 2);
+        quint16 *line = reinterpret_cast<quint16 *>(frameBuffer->rawbuffer.data() + (lineNumber * videoParameters.fieldWidth) * 2);
         bool linePhase = GetLinePhase(frameBuffer, lineNumber);
 
         qreal si = 0, sq = 0;
-        for (qint32 h = configuration.activeVideoStart; h < configuration.activeVideoEnd; h++) {
+        for (qint32 h = videoParameters.activeVideoStart; h < videoParameters.activeVideoEnd; h++) {
             qint32 phase = h % 4;
 
             // Take the 2D C
@@ -389,7 +365,7 @@ void Comb::filterIQ(YiqBuffer &yiqBuffer)
 
         qreal filti = 0, filtq = 0;
 
-        for (qint32 h = configuration.activeVideoStart; h < configuration.activeVideoEnd; h++) {
+        for (qint32 h = videoParameters.activeVideoStart; h < videoParameters.activeVideoEnd; h++) {
             qint32 phase = h % 4;
 
             switch (phase) {
@@ -426,17 +402,17 @@ void Comb::doCNR(YiqBuffer &yiqBuffer)
     qreal nr_c = configuration.cNRLevel * irescale;
 
     QVector<YIQ> hplinef;
-    hplinef.resize(configuration.fieldWidth + 32);
+    hplinef.resize(videoParameters.fieldWidth + 32);
 
     for (qint32 lineNumber = configuration.firstActiveLine; lineNumber < frameHeight; lineNumber++) {
         // Filters not cleared from previous line
 
-        for (qint32 h = configuration.activeVideoStart; h <= configuration.activeVideoEnd; h++) {
+        for (qint32 h = videoParameters.activeVideoStart; h <= videoParameters.activeVideoEnd; h++) {
             hplinef[h].i = iFilter.feed(yiqBuffer[lineNumber][h].i);
             hplinef[h].q = qFilter.feed(yiqBuffer[lineNumber][h].q);
         }
 
-        for (qint32 h = configuration.activeVideoStart; h < configuration.activeVideoEnd; h++) {
+        for (qint32 h = videoParameters.activeVideoStart; h < videoParameters.activeVideoEnd; h++) {
             // Offset by 12 to cover the filter delay
             qreal ai = hplinef[h + 12].i;
             qreal aq = hplinef[h + 12].q;
@@ -466,16 +442,16 @@ void Comb::doYNR(YiqBuffer &yiqBuffer)
     qreal nr_y = configuration.yNRLevel * irescale;
 
     QVector<YIQ> hplinef;
-    hplinef.resize(configuration.fieldWidth + 32);
+    hplinef.resize(videoParameters.fieldWidth + 32);
 
     for (qint32 lineNumber = configuration.firstActiveLine; lineNumber < frameHeight; lineNumber++) {
         // Filter not cleared from previous line
 
-        for (qint32 h = configuration.activeVideoStart; h <= configuration.activeVideoEnd; h++) {
+        for (qint32 h = videoParameters.activeVideoStart; h <= videoParameters.activeVideoEnd; h++) {
             hplinef[h].y = yFilter.feed(yiqBuffer[lineNumber][h].y);
         }
 
-        for (qint32 h = configuration.activeVideoStart; h < configuration.activeVideoEnd; h++) {
+        for (qint32 h = videoParameters.activeVideoStart; h < videoParameters.activeVideoEnd; h++) {
             qreal a = hplinef[h + 12].y;
 
             if (fabs(a) > nr_y) {
@@ -491,28 +467,28 @@ void Comb::doYNR(YiqBuffer &yiqBuffer)
 QByteArray Comb::yiqToRgbFrame(const YiqBuffer &yiqBuffer, qreal burstLevel)
 {
     QByteArray rgbOutputFrame;
-    rgbOutputFrame.resize((configuration.fieldWidth * frameHeight * 3) * 2); // * 3 * 2 for RGB 16-16-16)
+    rgbOutputFrame.resize((videoParameters.fieldWidth * frameHeight * 3) * 2); // * 3 * 2 for RGB 16-16-16)
 
     // Initialise the output frame
     rgbOutputFrame.fill(0);
 
     // Initialise YIQ to RGB converter
-    RGB rgb(configuration.whiteIre, configuration.blackIre, configuration.whitePoint100, configuration.blackAndWhite, burstLevel);
+    RGB rgb(videoParameters.white16bIre, videoParameters.black16bIre, configuration.whitePoint100, configuration.blackAndWhite, burstLevel);
 
     // Perform YIQ to RGB conversion
     for (qint32 lineNumber = configuration.firstActiveLine; lineNumber < frameHeight; lineNumber++) {
         // Map the QByteArray data to an unsigned 16 bit pointer
-        quint16 *linePointer = reinterpret_cast<quint16 *>(rgbOutputFrame.data() + ((configuration.fieldWidth * 3 * lineNumber) * 2));
+        quint16 *linePointer = reinterpret_cast<quint16 *>(rgbOutputFrame.data() + ((videoParameters.fieldWidth * 3 * lineNumber) * 2));
 
         // Offset the output by the activeVideoStart to keep the output frame
         // in the same x position as the input video frame (the +6 realigns the output
         // to the source frame; not sure where the 2 pixel offset is coming from, but
         // it's really not important)
-        qint32 o = (configuration.activeVideoStart * 3) + 6;
+        qint32 o = (videoParameters.activeVideoStart * 3) + 6;
 
         // Fill the output line with the RGB values
-        rgb.convertLine(&yiqBuffer[lineNumber][configuration.activeVideoStart],
-                        &yiqBuffer[lineNumber][configuration.activeVideoEnd],
+        rgb.convertLine(&yiqBuffer[lineNumber][videoParameters.activeVideoStart],
+                        &yiqBuffer[lineNumber][videoParameters.activeVideoEnd],
                         &linePointer[o]);
     }
 
@@ -530,10 +506,10 @@ void Comb::overlayOpticalFlowMap(const FrameBuffer &frameBuffer, QByteArray &rgb
     // Overlay the optical flow map on the output RGB
     for (qint32 lineNumber = configuration.firstActiveLine; lineNumber < frameHeight; lineNumber++) {
         // Map the QByteArray data to an unsigned 16 bit pointer
-        quint16 *linePointer = reinterpret_cast<quint16 *>(rgbFrame.data() + ((configuration.fieldWidth * 3 * lineNumber) * 2));
+        quint16 *linePointer = reinterpret_cast<quint16 *>(rgbFrame.data() + ((videoParameters.fieldWidth * 3 * lineNumber) * 2));
 
         // Fill the output frame with the RGB values
-        for (qint32 h = configuration.activeVideoStart; h < configuration.activeVideoEnd; h++) {
+        for (qint32 h = videoParameters.activeVideoStart; h < videoParameters.activeVideoEnd; h++) {
             qint32 intensity = static_cast<qint32>(frameBuffer.kValues[(lineNumber * 910) + h] * 65535);
             // Make the RGB more purple to show where motion was detected
             qint32 red = linePointer[(h * 3)] + intensity;
@@ -558,7 +534,7 @@ void Comb::adjustY(FrameBuffer *frameBuffer, YiqBuffer &yiqBuffer)
     for (qint32 lineNumber = configuration.firstActiveLine; lineNumber < frameHeight; lineNumber++) {
         bool linePhase = GetLinePhase(frameBuffer, lineNumber);
 
-        for (qint32 h = configuration.activeVideoStart; h < configuration.activeVideoEnd; h++) {
+        for (qint32 h = videoParameters.activeVideoStart; h < videoParameters.activeVideoEnd; h++) {
             qreal comp = 0;
             qint32 phase = h % 4;
 

--- a/tools/ld-chroma-decoder/comb.cpp
+++ b/tools/ld-chroma-decoder/comb.cpp
@@ -537,7 +537,7 @@ void Comb::overlayOpticalFlowMap(const FrameBuffer &frameBuffer, QByteArray &rgb
             qint32 intensity = static_cast<qint32>(frameBuffer.kValues[(lineNumber * 910) + h] * 65535);
             // Make the RGB more purple to show where motion was detected
             qint32 red = linePointer[(h * 3)] + intensity;
-            qint32 green = linePointer[(h * 3) + 2];
+            qint32 green = linePointer[(h * 3) + 1];
             qint32 blue = linePointer[(h * 3) + 2] + intensity;
 
             if (red > 65535) red = 65535;

--- a/tools/ld-chroma-decoder/comb.h
+++ b/tools/ld-chroma-decoder/comb.h
@@ -71,7 +71,9 @@ public:
     void updateConfiguration(const LdDecodeMetaData::VideoParameters &videoParameters,
                              const Configuration &configuration);
 
-    QByteArray process(QByteArray topFieldInputBuffer, QByteArray bottomFieldInputBuffer, qreal burstMedianIre, qint32 topFieldPhaseID, qint32 bottomFieldPhaseID);
+    // Decode two fields to produce an interlaced frame.
+    QByteArray decodeFrame(const LdDecodeMetaData::Field &firstField, QByteArray firstFieldInputBuffer,
+                           const LdDecodeMetaData::Field &secondField, QByteArray secondFieldInputBuffer);
 
 protected:
 

--- a/tools/ld-chroma-decoder/comb.h
+++ b/tools/ld-chroma-decoder/comb.h
@@ -58,8 +58,11 @@ public:
         bool use3D = false;
         bool showOpticalFlowMap = false;
 
-        // Interlaced line 40 is NTSC line 21 (the closed-caption line before the first active line)
+        // Interlaced line 40 is NTSC line 21 (the closed-caption line before the first active half-line)
         qint32 firstActiveLine = 40;
+        // Interlaced line 524 is NTSC line 263 (the last active half-line).
+        // XXX The Comb code doesn't use this because it's the last line of the picture anyway.
+        qint32 lastActiveLine = 525;
 
         qreal cNRLevel = 0.0;
         qreal yNRLevel = 1.0;

--- a/tools/ld-chroma-decoder/comb.h
+++ b/tools/ld-chroma-decoder/comb.h
@@ -31,6 +31,8 @@
 #include <QFile>
 #include <QtMath>
 
+#include "lddecodemetadata.h"
+
 #include "yiq.h"
 #include "rgb.h"
 #include "opticalflow.h"
@@ -49,37 +51,33 @@ public:
 
     // Comb filter configuration parameters
     struct Configuration {
-        bool blackAndWhite;
-        bool colorlpf;
-        bool colorlpf_hq;
-        bool whitePoint100;
-        bool use3D;
-        bool showOpticalFlowMap;
+        bool blackAndWhite = false;
+        bool colorlpf = true;
+        bool colorlpf_hq = true;
+        bool whitePoint100 = false;
+        bool use3D = false;
+        bool showOpticalFlowMap = false;
 
-        qint32 fieldWidth;
-        qint32 fieldHeight;
+        // Interlaced line 40 is NTSC line 21 (the closed-caption line before the first active line)
+        qint32 firstActiveLine = 40;
 
-        qint32 activeVideoStart;
-        qint32 activeVideoEnd;
-
-        qint32 firstActiveLine;
-
-        qint32 blackIre;
-        qint32 whiteIre;
-
-        qreal cNRLevel;
-        qreal yNRLevel;
+        qreal cNRLevel = 0.0;
+        qreal yNRLevel = 1.0;
     };
 
-    Configuration getConfiguration();
-    void setConfiguration(const Configuration &configuration);
+    const Configuration &getConfiguration() const;
+    void updateConfiguration(const LdDecodeMetaData::VideoParameters &videoParameters,
+                             const Configuration &configuration);
+
     QByteArray process(QByteArray topFieldInputBuffer, QByteArray bottomFieldInputBuffer, qreal burstMedianIre, qint32 topFieldPhaseID, qint32 bottomFieldPhaseID);
 
 protected:
 
 private:
     // Comb-filter configuration parameters
+    bool configurationSet;
     Configuration configuration;
+    LdDecodeMetaData::VideoParameters videoParameters;
 
     // IRE scaling
     qreal irescale;
@@ -113,8 +111,6 @@ private:
 
     // Previous and next frame for 3D processing
     FrameBuffer previousFrameBuffer;
-
-    void postConfigurationTasks();
 
     inline qint32 GetFieldID(FrameBuffer *frameBuffer, qint32 lineNumber);
     inline bool GetLinePhase(FrameBuffer *frameBuffer, qint32 lineNumber);

--- a/tools/ld-chroma-decoder/comb.h
+++ b/tools/ld-chroma-decoder/comb.h
@@ -61,7 +61,6 @@ public:
         // Interlaced line 40 is NTSC line 21 (the closed-caption line before the first active half-line)
         qint32 firstActiveLine = 40;
         // Interlaced line 524 is NTSC line 263 (the last active half-line).
-        // XXX The Comb code doesn't use this because it's the last line of the picture anyway.
         qint32 lastActiveLine = 525;
 
         qreal cNRLevel = 0.0;

--- a/tools/ld-chroma-decoder/decoder.cpp
+++ b/tools/ld-chroma-decoder/decoder.cpp
@@ -109,21 +109,19 @@ void DecoderThread::run()
 {
     qint32 frameNumber;
 
-    // Input field metadata and data
-    LdDecodeMetaData::Field firstField;
-    QByteArray firstFieldData;
-    LdDecodeMetaData::Field secondField;
-    QByteArray secondFieldData;
+    // Input fields
+    Decoder::InputField firstField;
+    Decoder::InputField secondField;
 
     while(!abort) {
         // Get the next frame to process from the input file
-        if (!decoderPool.getInputFrame(frameNumber, firstField, firstFieldData, secondField, secondFieldData)) {
+        if (!decoderPool.getInputFrame(frameNumber, firstField, secondField)) {
             // No more input frames -- exit
             break;
         }
 
         // Decode and crop the frame
-        QByteArray frameData = decodeFrame(firstField, firstFieldData, secondField, secondFieldData);
+        QByteArray frameData = decodeFrame(firstField, secondField);
 
         // Write the result to the output file
         if (!decoderPool.putOutputFrame(frameNumber, frameData)) {

--- a/tools/ld-chroma-decoder/decoder.cpp
+++ b/tools/ld-chroma-decoder/decoder.cpp
@@ -26,6 +26,16 @@
 
 #include "decoderpool.h"
 
+qint32 Decoder::getLookBehind()
+{
+    return 0;
+}
+
+qint32 Decoder::getLookAhead()
+{
+    return 0;
+}
+
 void Decoder::setVideoParameters(Decoder::Configuration &config, const LdDecodeMetaData::VideoParameters &videoParameters,
                                  qint32 firstActiveLine, qint32 lastActiveLine) {
 
@@ -107,24 +117,31 @@ DecoderThread::DecoderThread(QAtomicInt& _abort, DecoderPool& _decoderPool, QObj
 
 void DecoderThread::run()
 {
-    qint32 frameNumber;
+    // Input and output data
+    QVector<Decoder::InputField> inputFields;
+    QVector<QByteArray> outputFrames;
 
-    // Input fields
-    Decoder::InputField firstField;
-    Decoder::InputField secondField;
-
-    while(!abort) {
-        // Get the next frame to process from the input file
-        if (!decoderPool.getInputFrame(frameNumber, firstField, secondField)) {
+    while (!abort) {
+        // Get the next batch of fields to process
+        qint32 startFrameNumber, startIndex, endIndex;
+        if (!decoderPool.getInputFrames(startFrameNumber, inputFields, startIndex, endIndex)) {
             // No more input frames -- exit
             break;
         }
 
-        // Decode and crop the frame
-        QByteArray frameData = decodeFrame(firstField, secondField);
+        // Decode lookahead fields, discarding the result
+        for (qint32 i = 0; i < startIndex; i += 2) {
+            decodeFrame(inputFields[i], inputFields[i + 1]);
+        }
 
-        // Write the result to the output file
-        if (!decoderPool.putOutputFrame(frameNumber, frameData)) {
+        // Decode real fields to frames
+        outputFrames.resize((endIndex - startIndex) / 2);
+        for (qint32 i = startIndex, j = 0; i < endIndex; i += 2, j++) {
+            outputFrames[j] = decodeFrame(inputFields[i], inputFields[i + 1]);
+        }
+
+        // Write the frames to the output file
+        if (!decoderPool.putOutputFrames(startFrameNumber, outputFrames)) {
             abort = true;
             break;
         }

--- a/tools/ld-chroma-decoder/decoder.h
+++ b/tools/ld-chroma-decoder/decoder.h
@@ -61,6 +61,16 @@ public:
     // If the video is not compatible, print an error message and return false.
     virtual bool configure(const LdDecodeMetaData::VideoParameters &videoParameters) = 0;
 
+    // After configuration, return the number of frames that the decoder needs
+    // to be able to see into the past (each frame being two InputFields).
+    // The default implementation returns 0, which is appropriate for 1D/2D decoders.
+    virtual qint32 getLookBehind();
+
+    // After configuration, return the number of frames that the decoder needs
+    // to be able to see into the future (each frame being two InputFields).
+    // The default implementation returns 0, which is appropriate for 1D/2D decoders.
+    virtual qint32 getLookAhead();
+
     // Construct a new worker thread
     virtual QThread *makeThread(QAtomicInt& abort, DecoderPool& decoderPool) = 0;
 

--- a/tools/ld-chroma-decoder/decoder.h
+++ b/tools/ld-chroma-decoder/decoder.h
@@ -80,7 +80,7 @@ public:
                                    qint32 firstActiveLine, qint32 lastActiveLine);
 
     // Crop a full decoded frame to the output frame size
-    static QByteArray cropOutputFrame(const Decoder::Configuration &config, QByteArray outputData);
+    static QByteArray cropOutputFrame(const Configuration &config, QByteArray outputData);
 };
 
 #endif

--- a/tools/ld-chroma-decoder/decoder.h
+++ b/tools/ld-chroma-decoder/decoder.h
@@ -75,6 +75,12 @@ public:
         qint32 bottomPadLines;
     };
 
+    // A field read from the input file
+    struct InputField {
+        LdDecodeMetaData::Field field;
+        QByteArray data;
+    };
+
     // Compute the output frame size in Configuration, adjusting the active
     // video region as required
     static void setVideoParameters(Configuration &config, const LdDecodeMetaData::VideoParameters &videoParameters,
@@ -94,8 +100,7 @@ protected:
     void run() override;
 
     // Decode two fields into an interlaced, cropped frame
-    virtual QByteArray decodeFrame(const LdDecodeMetaData::Field &firstField, QByteArray firstFieldData,
-                                   const LdDecodeMetaData::Field &secondField, QByteArray secondFieldData) = 0;
+    virtual QByteArray decodeFrame(const Decoder::InputField &firstField, const Decoder::InputField &secondField) = 0;
 
     // Decoder pool
     QAtomicInt& abort;

--- a/tools/ld-chroma-decoder/decoderpool.cpp
+++ b/tools/ld-chroma-decoder/decoderpool.cpp
@@ -145,9 +145,9 @@ bool DecoderPool::process()
 //
 // Returns true if a frame was returned, false if the end of the input has been
 // reached.
-bool DecoderPool::getInputFrame(qint32 &frameNumber, QByteArray &firstFieldData, QByteArray &secondFieldData,
-                                qint32 &firstFieldPhaseID, qint32 &secondFieldPhaseID,
-                                qreal& burstMedianIre)
+bool DecoderPool::getInputFrame(qint32 &frameNumber,
+                                LdDecodeMetaData::Field &firstField, QByteArray &firstFieldData,
+                                LdDecodeMetaData::Field &secondField, QByteArray &secondFieldData)
 {
     QMutexLocker locker(&inputMutex);
 
@@ -168,11 +168,10 @@ bool DecoderPool::getInputFrame(qint32 &frameNumber, QByteArray &firstFieldData,
                 "and a second field of" << secondFieldNumber;
 
     // Fetch the input data
+    firstField = ldDecodeMetaData.getField(firstFieldNumber);
     firstFieldData = sourceVideo.getVideoField(firstFieldNumber);
+    secondField = ldDecodeMetaData.getField(secondFieldNumber);
     secondFieldData = sourceVideo.getVideoField(secondFieldNumber);
-    burstMedianIre = ldDecodeMetaData.getField(firstFieldNumber).medianBurstIRE;
-    firstFieldPhaseID = ldDecodeMetaData.getField(firstFieldNumber).fieldPhaseID;
-    secondFieldPhaseID = ldDecodeMetaData.getField(secondFieldNumber).fieldPhaseID;
 
     return true;
 }

--- a/tools/ld-chroma-decoder/decoderpool.cpp
+++ b/tools/ld-chroma-decoder/decoderpool.cpp
@@ -145,9 +145,7 @@ bool DecoderPool::process()
 //
 // Returns true if a frame was returned, false if the end of the input has been
 // reached.
-bool DecoderPool::getInputFrame(qint32 &frameNumber,
-                                LdDecodeMetaData::Field &firstField, QByteArray &firstFieldData,
-                                LdDecodeMetaData::Field &secondField, QByteArray &secondFieldData)
+bool DecoderPool::getInputFrame(qint32 &frameNumber, Decoder::InputField &firstField, Decoder::InputField &secondField)
 {
     QMutexLocker locker(&inputMutex);
 
@@ -168,10 +166,10 @@ bool DecoderPool::getInputFrame(qint32 &frameNumber,
                 "and a second field of" << secondFieldNumber;
 
     // Fetch the input data
-    firstField = ldDecodeMetaData.getField(firstFieldNumber);
-    firstFieldData = sourceVideo.getVideoField(firstFieldNumber);
-    secondField = ldDecodeMetaData.getField(secondFieldNumber);
-    secondFieldData = sourceVideo.getVideoField(secondFieldNumber);
+    firstField.field = ldDecodeMetaData.getField(firstFieldNumber);
+    firstField.data = sourceVideo.getVideoField(firstFieldNumber);
+    secondField.field = ldDecodeMetaData.getField(secondFieldNumber);
+    secondField.data = sourceVideo.getVideoField(secondFieldNumber);
 
     return true;
 }

--- a/tools/ld-chroma-decoder/decoderpool.cpp
+++ b/tools/ld-chroma-decoder/decoderpool.cpp
@@ -43,6 +43,10 @@ bool DecoderPool::process()
         return false;
     }
 
+    // Get the decoder's lookbehind/lookahead requirements
+    decoderLookBehind = decoder.getLookBehind();
+    decoderLookAhead = decoder.getLookAhead();
+
     // Open the source video file
     if (!sourceVideo.open(inputFileName, videoParameters.fieldWidth * videoParameters.fieldHeight)) {
         // Could not open source video file
@@ -141,40 +145,78 @@ bool DecoderPool::process()
     return true;
 }
 
-// Get the next frame that needs processing from the input.
-//
-// Returns true if a frame was returned, false if the end of the input has been
-// reached.
-bool DecoderPool::getInputFrame(qint32 &frameNumber, Decoder::InputField &firstField, Decoder::InputField &secondField)
+bool DecoderPool::getInputFrames(qint32 &startFrameNumber, QVector<Decoder::InputField> &fields, qint32 &startIndex, qint32 &endIndex)
 {
     QMutexLocker locker(&inputMutex);
 
-    if (inputFrameNumber > lastFrameNumber) {
+    // Work out a reasonable batch size to provide work for all threads.
+    // This assumes that the synchronisation to get a new batch is less
+    // expensive than computing a single frame, so a batch size of 1 is
+    // reasonable.
+    const qint32 maxBatchSize = qMin(DEFAULT_BATCH_SIZE, qMax(1, length / maxThreads));
+
+    // Work out how many frames will be in this batch
+    qint32 batchFrames = qMin(maxBatchSize, lastFrameNumber + 1 - inputFrameNumber);
+    if (batchFrames == 0) {
         // No more input frames
         return false;
     }
 
-    frameNumber = inputFrameNumber;
-    inputFrameNumber++;
+    // Advance the frame number
+    startFrameNumber = inputFrameNumber;
+    inputFrameNumber += batchFrames;
 
-    // Determine the first and second fields for the frame number
-    qint32 firstFieldNumber = ldDecodeMetaData.getFirstFieldNumber(frameNumber);
-    qint32 secondFieldNumber = ldDecodeMetaData.getSecondFieldNumber(frameNumber);
+    // Work out indexes.
+    // fields will contain {lookbehind fields... [startIndex] real fields... [endIndex] lookahead fields...}.
+    startIndex = 2 * decoderLookBehind;
+    endIndex = startIndex + (2 * batchFrames);
+    fields.resize(endIndex + (2 * decoderLookAhead));
 
-    // Show what we are about to process
-    qDebug() << "DecoderPool::process(): Frame number" << frameNumber << "has a first-field of" << firstFieldNumber <<
-                "and a second field of" << secondFieldNumber;
+    // Populate fields
+    const qint32 numInputFrames = ldDecodeMetaData.getNumberOfFrames();
+    qint32 frameNumber = startFrameNumber - decoderLookBehind;
+    for (qint32 i = 0; i < fields.size(); i += 2) {
 
-    // Fetch the input data
-    firstField.field = ldDecodeMetaData.getField(firstFieldNumber);
-    firstField.data = sourceVideo.getVideoField(firstFieldNumber);
-    secondField.field = ldDecodeMetaData.getField(secondFieldNumber);
-    secondField.data = sourceVideo.getVideoField(secondFieldNumber);
+        // Is this frame outside the bounds of the input file?
+        // If so, use real metadata (from frame 1) and black fields.
+        const bool useBlankFrame = frameNumber < 1 || frameNumber > numInputFrames;
+
+        // Get the first frame from the file (using frame 1 if outside bounds)
+        qint32 firstFieldNumber = ldDecodeMetaData.getFirstFieldNumber(useBlankFrame ? 1 : frameNumber);
+        qint32 secondFieldNumber = ldDecodeMetaData.getSecondFieldNumber(useBlankFrame ? 1 : frameNumber);
+
+        // Fetch the input metadata
+        fields[i].field = ldDecodeMetaData.getField(firstFieldNumber);
+        fields[i].data = sourceVideo.getVideoField(firstFieldNumber);
+        fields[i + 1].field = ldDecodeMetaData.getField(secondFieldNumber);
+        fields[i + 1].data = sourceVideo.getVideoField(secondFieldNumber);
+
+        if (useBlankFrame) {
+            // Fill both fields with black
+            fields[i].data.fill(0);
+            fields[i + 1].data.fill(0);
+        }
+
+        frameNumber++;
+    }
 
     return true;
 }
 
-// Put a decoded frame into the output stream.
+bool DecoderPool::putOutputFrames(qint32 startFrameNumber, const QVector<QByteArray> &outputFrames)
+{
+    QMutexLocker locker(&outputMutex);
+
+    for (qint32 i = 0; i < outputFrames.size(); i++) {
+        if (!putOutputFrame(startFrameNumber + i, outputFrames[i])) {
+            return false;
+        }
+    }
+
+    return true;
+}
+
+// Write one output frame. You must hold outputMutex to call this.
 //
 // The worker threads will complete frames in an arbitrary order, so we can't
 // just write the frames to the output file directly. Instead, we keep a map of
@@ -182,12 +224,10 @@ bool DecoderPool::getInputFrame(qint32 &frameNumber, Decoder::InputField &firstF
 // whether we can now write some of them out.
 //
 // Returns true on success, false on failure.
-bool DecoderPool::putOutputFrame(qint32 frameNumber, QByteArray &rgbOutput)
+bool DecoderPool::putOutputFrame(qint32 frameNumber, const QByteArray &outputFrame)
 {
-    QMutexLocker locker(&outputMutex);
-
     // Put this frame into the map
-    pendingOutputFrames[frameNumber] = rgbOutput;
+    pendingOutputFrames[frameNumber] = outputFrame;
 
     // Write out as many frames as possible
     while (pendingOutputFrames.contains(outputFrameNumber)) {

--- a/tools/ld-chroma-decoder/decoderpool.cpp
+++ b/tools/ld-chroma-decoder/decoderpool.cpp
@@ -26,9 +26,8 @@
 
 DecoderPool::DecoderPool(Decoder &_decoder, QString _inputFileName,
                          LdDecodeMetaData &_ldDecodeMetaData, QString _outputFileName,
-                         qint32 _startFrame, qint32 _length, qint32 _maxThreads,
-                         QObject *parent)
-    : QObject(parent), decoder(_decoder), inputFileName(_inputFileName),
+                         qint32 _startFrame, qint32 _length, qint32 _maxThreads)
+    : decoder(_decoder), inputFileName(_inputFileName),
       outputFileName(_outputFileName), startFrame(_startFrame),
       length(_length), maxThreads(_maxThreads),
       abort(false), ldDecodeMetaData(_ldDecodeMetaData)

--- a/tools/ld-chroma-decoder/decoderpool.h
+++ b/tools/ld-chroma-decoder/decoderpool.h
@@ -47,9 +47,7 @@ public:
     bool process();
 
     // Member functions used by worker threads
-    bool getInputFrame(qint32 &frameNumber,
-                       LdDecodeMetaData::Field &firstField, QByteArray &firstFieldData,
-                       LdDecodeMetaData::Field &secondField, QByteArray &secondFieldData);
+    bool getInputFrame(qint32 &frameNumber, Decoder::InputField &firstField, Decoder::InputField &secondField);
     bool putOutputFrame(qint32 frameNumber, QByteArray &rgbOutput);
 
 private:

--- a/tools/ld-chroma-decoder/decoderpool.h
+++ b/tools/ld-chroma-decoder/decoderpool.h
@@ -32,6 +32,7 @@
 #include <QMap>
 #include <QMutex>
 #include <QThread>
+#include <QVector>
 
 #include "lddecodemetadata.h"
 #include "sourcevideo.h"
@@ -44,13 +45,41 @@ public:
     explicit DecoderPool(Decoder &decoder, QString inputFileName,
                          LdDecodeMetaData &ldDecodeMetaData, QString outputFileName,
                          qint32 startFrame, qint32 length, qint32 maxThreads);
+
+    // Decode fields to frames as specified by the constructor args.
+    // Returns true on success; on failure, prints a message and returns false.
     bool process();
 
-    // Member functions used by worker threads
-    bool getInputFrame(qint32 &frameNumber, Decoder::InputField &firstField, Decoder::InputField &secondField);
-    bool putOutputFrame(qint32 frameNumber, QByteArray &rgbOutput);
+    // For worker threads: get the next batch of data from the input file.
+    //
+    // fields will be resized and filled with pairs of InputFields; entries
+    // from startIndex to endIndex are those that should be processed into
+    // output frames, with startIndex corresponding to the first field of frame
+    // startFrameNumber.
+    //
+    // If the Decoder requested lookahead or lookbehind, an appropriate number
+    // of additional fields will be provided before startIndex and after
+    // endIndex. Dummy black frames (with metadata copied from a real frame)
+    // will be provided when going beyond the bounds of the input file.
+    //
+    // Returns true if a frame was returned, false if the end of the input has
+    // been reached.
+    bool getInputFrames(qint32 &startFrameNumber, QVector<Decoder::InputField> &fields, qint32 &startIndex, qint32 &endIndex);
+
+    // For worker threads: return decoded frames to write to the output file.
+    //
+    // outputFrames should contain RGB16-16-16 output frames, with the first
+    // frame being startFrameNumber.
+    //
+    // Returns true on success, false on failure.
+    bool putOutputFrames(qint32 startFrameNumber, const QVector<QByteArray> &outputFrames);
 
 private:
+    bool putOutputFrame(qint32 frameNumber, const QByteArray &outputFrame);
+
+    // Default batch size, in frames
+    static constexpr qint32 DEFAULT_BATCH_SIZE = 16;
+
     // Parameters
     Decoder& decoder;
     QString inputFileName;
@@ -65,6 +94,8 @@ private:
 
     // Input stream information (all guarded by inputMutex while threads are running)
     QMutex inputMutex;
+    qint32 decoderLookBehind;
+    qint32 decoderLookAhead;
     qint32 inputFrameNumber;
     qint32 lastFrameNumber;
     LdDecodeMetaData &ldDecodeMetaData;

--- a/tools/ld-chroma-decoder/decoderpool.h
+++ b/tools/ld-chroma-decoder/decoderpool.h
@@ -38,26 +38,18 @@
 
 #include "decoder.h"
 
-class DecoderPool : public QObject
+class DecoderPool
 {
-    Q_OBJECT
 public:
     explicit DecoderPool(Decoder &decoder, QString inputFileName,
                          LdDecodeMetaData &ldDecodeMetaData, QString outputFileName,
-                         qint32 startFrame, qint32 length, qint32 maxThreads,
-                         QObject *parent = nullptr);
+                         qint32 startFrame, qint32 length, qint32 maxThreads);
     bool process();
 
     // Member functions used by worker threads
     bool getInputFrame(qint32& frameNumber, QByteArray& firstFieldData, QByteArray& secondFieldData,
                        qint32& firstFieldPhaseID, qint32& secondFieldPhaseID, qreal& burstMedianIre);
     bool putOutputFrame(qint32 frameNumber, QByteArray& rgbOutput);
-
-signals:
-
-public slots:
-
-private slots:
 
 private:
     // Parameters

--- a/tools/ld-chroma-decoder/decoderpool.h
+++ b/tools/ld-chroma-decoder/decoderpool.h
@@ -47,9 +47,10 @@ public:
     bool process();
 
     // Member functions used by worker threads
-    bool getInputFrame(qint32& frameNumber, QByteArray& firstFieldData, QByteArray& secondFieldData,
-                       qint32& firstFieldPhaseID, qint32& secondFieldPhaseID, qreal& burstMedianIre);
-    bool putOutputFrame(qint32 frameNumber, QByteArray& rgbOutput);
+    bool getInputFrame(qint32 &frameNumber,
+                       LdDecodeMetaData::Field &firstField, QByteArray &firstFieldData,
+                       LdDecodeMetaData::Field &secondField, QByteArray &secondFieldData);
+    bool putOutputFrame(qint32 frameNumber, QByteArray &rgbOutput);
 
 private:
     // Parameters

--- a/tools/ld-chroma-decoder/main.cpp
+++ b/tools/ld-chroma-decoder/main.cpp
@@ -298,9 +298,6 @@ int main(int argc, char *argv[])
         decoder.reset(new NtscDecoder(blackAndWhite, whitePoint, false, false));
     } else if (decoderName == "ntsc3d") {
         decoder.reset(new NtscDecoder(blackAndWhite, whitePoint, true, showOpticalFlow));
-
-        // In 3D mode, NtscDecoder keeps state between frames, so it can't be parallelised.
-        maxThreads = 1;
     } else {
         qCritical() << "Unknown decoder " << decoderName;
         return -1;

--- a/tools/ld-chroma-decoder/main.cpp
+++ b/tools/ld-chroma-decoder/main.cpp
@@ -149,7 +149,7 @@ int main(int argc, char *argv[])
 
     // Option to select the number of threads (-t)
     QCommandLineOption threadsOption(QStringList() << "t" << "threads",
-                                        QCoreApplication::translate("main", "Specify the number of concurrent threads (default number of logical CPUs plus 2)"),
+                                        QCoreApplication::translate("main", "Specify the number of concurrent threads (default number of logical CPUs)"),
                                         QCoreApplication::translate("main", "number"));
     parser.addOption(threadsOption);
 
@@ -219,7 +219,7 @@ int main(int argc, char *argv[])
 
     qint32 startFrame = -1;
     qint32 length = -1;
-    qint32 maxThreads = QThread::idealThreadCount() + 2;
+    qint32 maxThreads = QThread::idealThreadCount();
     double transformThreshold = 0.4;
 
     if (parser.isSet(startFrameOption)) {

--- a/tools/ld-chroma-decoder/ntscdecoder.cpp
+++ b/tools/ld-chroma-decoder/ntscdecoder.cpp
@@ -51,6 +51,16 @@ bool NtscDecoder::configure(const LdDecodeMetaData::VideoParameters &videoParame
     return true;
 }
 
+qint32 NtscDecoder::getLookBehind()
+{
+    if (config.combConfig.use3D) {
+        // In 3D mode, we need to see the previous frame
+        return 1;
+    }
+
+    return 0;
+}
+
 QThread *NtscDecoder::makeThread(QAtomicInt& abort, DecoderPool& decoderPool)
 {
     return new NtscThread(abort, decoderPool, config);

--- a/tools/ld-chroma-decoder/ntscdecoder.cpp
+++ b/tools/ld-chroma-decoder/ntscdecoder.cpp
@@ -68,26 +68,21 @@ void NtscThread::run()
 {
     qint32 frameNumber;
 
-    // Input data buffers
+    // Input field metadata and data
+    LdDecodeMetaData::Field firstField;
     QByteArray firstFieldData;
+    LdDecodeMetaData::Field secondField;
     QByteArray secondFieldData;
-
-    // Frame metadata
-    qint32 firstFieldPhaseID;
-    qint32 secondFieldPhaseID;
-    qreal burstMedianIre;
 
     while(!abort) {
         // Get the next frame to process from the input file
-        if (!decoderPool.getInputFrame(frameNumber, firstFieldData, secondFieldData,
-                                       firstFieldPhaseID, secondFieldPhaseID, burstMedianIre)) {
+        if (!decoderPool.getInputFrame(frameNumber, firstField, firstFieldData, secondField, secondFieldData)) {
             // No more input frames -- exit
             break;
         }
 
         // Filter the frame
-        QByteArray outputData = comb.process(firstFieldData, secondFieldData, burstMedianIre,
-                                             firstFieldPhaseID, secondFieldPhaseID);
+        QByteArray outputData = comb.decodeFrame(firstField, firstFieldData, secondField, secondFieldData);
 
         // The NTSC filter outputs the whole frame, so here we crop it to the required dimensions
         QByteArray croppedData = NtscDecoder::cropOutputFrame(config, outputData);

--- a/tools/ld-chroma-decoder/ntscdecoder.cpp
+++ b/tools/ld-chroma-decoder/ntscdecoder.cpp
@@ -64,11 +64,10 @@ NtscThread::NtscThread(QAtomicInt& _abort, DecoderPool &_decoderPool,
     comb.updateConfiguration(config.videoParameters, config.combConfig);
 }
 
-QByteArray NtscThread::decodeFrame(const LdDecodeMetaData::Field &firstField, QByteArray firstFieldData,
-                                   const LdDecodeMetaData::Field &secondField, QByteArray secondFieldData)
+QByteArray NtscThread::decodeFrame(const Decoder::InputField &firstField, const Decoder::InputField &secondField)
 {
     // Filter the frame
-    QByteArray outputData = comb.decodeFrame(firstField, firstFieldData, secondField, secondFieldData);
+    QByteArray outputData = comb.decodeFrame(firstField.field, firstField.data, secondField.field, secondField.data);
 
     // The NTSC filter outputs the whole frame, so here we crop it to the required dimensions
     return NtscDecoder::cropOutputFrame(config, outputData);

--- a/tools/ld-chroma-decoder/ntscdecoder.cpp
+++ b/tools/ld-chroma-decoder/ntscdecoder.cpp
@@ -46,8 +46,7 @@ bool NtscDecoder::configure(const LdDecodeMetaData::VideoParameters &videoParame
     }
 
     // Compute cropping parameters
-    config.combConfig.firstActiveLine = 40;
-    setVideoParameters(config, videoParameters, config.combConfig.firstActiveLine, 525);
+    setVideoParameters(config, videoParameters, config.combConfig.firstActiveLine, config.combConfig.lastActiveLine);
 
     return true;
 }

--- a/tools/ld-chroma-decoder/ntscdecoder.h
+++ b/tools/ld-chroma-decoder/ntscdecoder.h
@@ -65,8 +65,7 @@ public:
                         QObject *parent = nullptr);
 
 protected:
-    QByteArray decodeFrame(const LdDecodeMetaData::Field &firstField, QByteArray firstFieldData,
-                           const LdDecodeMetaData::Field &secondField, QByteArray secondFieldData) override;
+    QByteArray decodeFrame(const Decoder::InputField &firstField, const Decoder::InputField &secondField) override;
 
 private:
     // Settings

--- a/tools/ld-chroma-decoder/ntscdecoder.h
+++ b/tools/ld-chroma-decoder/ntscdecoder.h
@@ -56,7 +56,7 @@ private:
     Configuration config;
 };
 
-class NtscThread : public QThread
+class NtscThread : public DecoderThread
 {
     Q_OBJECT
 public:
@@ -65,13 +65,10 @@ public:
                         QObject *parent = nullptr);
 
 protected:
-    void run() override;
+    QByteArray decodeFrame(const LdDecodeMetaData::Field &firstField, QByteArray firstFieldData,
+                           const LdDecodeMetaData::Field &secondField, QByteArray secondFieldData) override;
 
 private:
-    // Decoder pool
-    QAtomicInt& abort;
-    DecoderPool& decoderPool;
-
     // Settings
     const NtscDecoder::Configuration &config;
 

--- a/tools/ld-chroma-decoder/ntscdecoder.h
+++ b/tools/ld-chroma-decoder/ntscdecoder.h
@@ -74,6 +74,9 @@ private:
 
     // Settings
     const NtscDecoder::Configuration &config;
+
+    // NTSC decoder
+    Comb comb;
 };
 
 #endif // NTSCDECODER_H

--- a/tools/ld-chroma-decoder/ntscdecoder.h
+++ b/tools/ld-chroma-decoder/ntscdecoder.h
@@ -45,6 +45,7 @@ class NtscDecoder : public Decoder {
 public:
     NtscDecoder(bool blackAndWhite, bool whitePoint, bool use3D, bool showOpticalFlowMap);
     bool configure(const LdDecodeMetaData::VideoParameters &videoParameters) override;
+    qint32 getLookBehind() override;
     QThread *makeThread(QAtomicInt& abort, DecoderPool& decoderPool) override;
 
     // Parameters used by NtscDecoder and NtscThread

--- a/tools/ld-chroma-decoder/palcolour.cpp
+++ b/tools/ld-chroma-decoder/palcolour.cpp
@@ -77,9 +77,7 @@ void PalColour::updateConfiguration(const LdDecodeMetaData::VideoParameters &_vi
 
     if (configuration.useTransformFilter) {
         // Configure Transform PAL
-        transformPal.updateConfiguration(videoParameters,
-                                         configuration.firstActiveLine, configuration.lastActiveLine,
-                                         configuration.transformThreshold);
+        transformPal.updateConfiguration(videoParameters, configuration.transformThreshold);
     }
 
     configurationSet = true;
@@ -247,7 +245,7 @@ void PalColour::decodeField(const FieldInfo &field, const QByteArray &fieldData)
     const double *chromaData = nullptr;
     if (configuration.useTransformFilter) {
         // Use Transform PAL filter to extract chroma
-        chromaData = transformPal.filterField(field.number, fieldData);
+        chromaData = transformPal.filterField(field.firstLine, field.lastLine, fieldData);
     }
 
     for (qint32 fieldLine = field.firstLine; fieldLine < field.lastLine; fieldLine++) {

--- a/tools/ld-chroma-decoder/palcolour.cpp
+++ b/tools/ld-chroma-decoder/palcolour.cpp
@@ -272,10 +272,10 @@ void PalColour::decodeField(const LdDecodeMetaData::Field &field, const QByteArr
 
         if (configuration.useTransformFilter) {
             // Decode chroma and luma from the Transform PAL output
-            decodeLine(fieldInfo, line, chromaData, inputData);
+            decodeLine<double, true>(fieldInfo, line, chromaData, inputData);
         } else {
             // Decode chroma and luma from the composite signal
-            decodeLine(fieldInfo, line, inputData, inputData);
+            decodeLine<quint16, false>(fieldInfo, line, inputData, inputData);
         }
     }
 }
@@ -350,7 +350,7 @@ void PalColour::detectBurst(LineInfo &line, const quint16 *inputData)
     line.burstNorm = qMax(sqrt(line.bp * line.bp + line.bq * line.bq), 130000.0 / 128);
 }
 
-template <typename InputSample>
+template <typename InputSample, bool useTransformFilter>
 void PalColour::decodeLine(const FieldInfo &fieldInfo, const LineInfo &line, const InputSample *inputData, const quint16 *compData)
 {
     // Dummy black line, used when the filter needs to look outside the active region.
@@ -453,7 +453,7 @@ void PalColour::decodeLine(const FieldInfo &fieldInfo, const LineInfo &line, con
     for (qint32 i = videoParameters.activeVideoStart; i < videoParameters.activeVideoEnd; i++) {
         // Compute luma by...
         double rY;
-        if (configuration.useTransformFilter) {
+        if (useTransformFilter) {
             // ... subtracting pre-filtered chroma from the composite input
             rY = comp[i] - in0[i];
         } else {

--- a/tools/ld-chroma-decoder/palcolour.cpp
+++ b/tools/ld-chroma-decoder/palcolour.cpp
@@ -202,7 +202,8 @@ void PalColour::buildLookUpTables()
 
 // Performs a decode of the 16-bit greyscale input frame and produces a RGB 16-16-16-bit output frame
 // with 16 bit processing
-QByteArray PalColour::performDecode(QByteArray firstFieldData, QByteArray secondFieldData, qint32 contrast, qint32 saturation)
+QByteArray PalColour::decodeFrame(const LdDecodeMetaData::Field &firstField, QByteArray firstFieldData,
+                                  const LdDecodeMetaData::Field &secondField, QByteArray secondFieldData)
 {
     // Ensure the object has been configured
     if (!configurationSet) {
@@ -214,41 +215,56 @@ QByteArray PalColour::performDecode(QByteArray firstFieldData, QByteArray second
     // is no picture data
     outputFrame.fill(0);
 
+    // Calculate the chroma gain from the burst median IRE, using the *first*
+    // field's burst amplitude to compensate both fields.
+    // Note: This code works as a temporary MTF compensator whilst ld-decode gets
+    // real MTF compensation added to it.
+    // PAL burst is 300 mV p-p (about 43 IRE, as 100 IRE = 700 mV)
+    const double nominalBurstIRE = 300 * (100.0 / 700) / 2;
+    double chromaGain = nominalBurstIRE / firstField.medianBurstIRE;
+
+    if (configuration.blackAndWhite) {
+        chromaGain = 0.0;
+    }
+
     if (!firstFieldData.isNull()) {
-        FieldInfo field(0, contrast, saturation, configuration.firstActiveLine, configuration.lastActiveLine);
-        decodeField(field, firstFieldData);
+        decodeField(firstField, firstFieldData, chromaGain);
     }
     if (!secondFieldData.isNull()) {
-        FieldInfo field(1, contrast, saturation, configuration.firstActiveLine, configuration.lastActiveLine);
-        decodeField(field, secondFieldData);
+        decodeField(secondField, secondFieldData, chromaGain);
     }
 
     return outputFrame;
 }
 
-PalColour::FieldInfo::FieldInfo(qint32 _number, qint32 _contrast, qint32 _saturation, qint32 firstActiveLine, qint32 lastActiveLine)
-    : number(_number), contrast(_contrast), saturation(_saturation)
+PalColour::FieldInfo::FieldInfo(const LdDecodeMetaData::Field &field, const Configuration &configuration, double _chromaGain)
+    : chromaGain(_chromaGain)
 {
+    // The second field's lines start at 1 in the output frame
+    offset = field.isFirstField ? 0 : 1;
+
     // Work out the active lines to be decoded within this field.
     // If firstActiveLine or lastActiveLine is odd, we can end up with
     // different ranges for top/bottom fields, so we need to be careful
     // about how this is rounded.
-    firstLine = (firstActiveLine + 1 - number) / 2;
-    lastLine = (lastActiveLine + 1 - number) / 2;
+    firstLine = (configuration.firstActiveLine + 1 - offset) / 2;
+    lastLine = (configuration.lastActiveLine + 1 - offset) / 2;
 }
 
-void PalColour::decodeField(const FieldInfo &field, const QByteArray &fieldData)
+void PalColour::decodeField(const LdDecodeMetaData::Field &field, const QByteArray &fieldData, double chromaGain)
 {
+    FieldInfo fieldInfo(field, configuration, chromaGain);
+
     // Pointer to the input field data
     const quint16 *inputData = reinterpret_cast<const quint16 *>(fieldData.data());
 
     const double *chromaData = nullptr;
     if (configuration.useTransformFilter) {
         // Use Transform PAL filter to extract chroma
-        chromaData = transformPal.filterField(field.firstLine, field.lastLine, fieldData);
+        chromaData = transformPal.filterField(fieldInfo.firstLine, fieldInfo.lastLine, fieldData);
     }
 
-    for (qint32 fieldLine = field.firstLine; fieldLine < field.lastLine; fieldLine++) {
+    for (qint32 fieldLine = fieldInfo.firstLine; fieldLine < fieldInfo.lastLine; fieldLine++) {
         LineInfo line(fieldLine);
 
         // Detect the colourburst from the composite signal
@@ -256,10 +272,10 @@ void PalColour::decodeField(const FieldInfo &field, const QByteArray &fieldData)
 
         if (configuration.useTransformFilter) {
             // Decode chroma and luma from the Transform PAL output
-            decodeLine(field, line, chromaData, inputData);
+            decodeLine(fieldInfo, line, chromaData, inputData);
         } else {
             // Decode chroma and luma from the composite signal
-            decodeLine(field, line, inputData, inputData);
+            decodeLine(fieldInfo, line, inputData, inputData);
         }
     }
 }
@@ -335,7 +351,7 @@ void PalColour::detectBurst(LineInfo &line, const quint16 *inputData)
 }
 
 template <typename InputSample>
-void PalColour::decodeLine(const FieldInfo &field, const LineInfo &line, const InputSample *inputData, const quint16 *compData)
+void PalColour::decodeLine(const FieldInfo &fieldInfo, const LineInfo &line, const InputSample *inputData, const quint16 *compData)
 {
     // Dummy black line, used when the filter needs to look outside the active region.
     static constexpr InputSample blackLine[MAX_WIDTH] = {0};
@@ -343,13 +359,13 @@ void PalColour::decodeLine(const FieldInfo &field, const LineInfo &line, const I
     // Get pointers to the surrounding lines of input data.
     // If a line we need is outside the active area, use blackLine instead.
     const InputSample *in0, *in1, *in2, *in3, *in4, *in5, *in6;
-    in0 =                                                     inputData +  (line.number      * videoParameters.fieldWidth);
-    in1 = (line.number - 1) <  field.firstLine ? blackLine : (inputData + ((line.number - 1) * videoParameters.fieldWidth));
-    in2 = (line.number + 1) >= field.lastLine  ? blackLine : (inputData + ((line.number + 1) * videoParameters.fieldWidth));
-    in3 = (line.number - 2) <  field.firstLine ? blackLine : (inputData + ((line.number - 2) * videoParameters.fieldWidth));
-    in4 = (line.number + 2) >= field.lastLine  ? blackLine : (inputData + ((line.number + 2) * videoParameters.fieldWidth));
-    in5 = (line.number - 2) <  field.firstLine ? blackLine : (inputData + ((line.number - 3) * videoParameters.fieldWidth));
-    in6 = (line.number + 3) >= field.lastLine  ? blackLine : (inputData + ((line.number + 3) * videoParameters.fieldWidth));
+    in0 =                                                         inputData +  (line.number      * videoParameters.fieldWidth);
+    in1 = (line.number - 1) <  fieldInfo.firstLine ? blackLine : (inputData + ((line.number - 1) * videoParameters.fieldWidth));
+    in2 = (line.number + 1) >= fieldInfo.lastLine  ? blackLine : (inputData + ((line.number + 1) * videoParameters.fieldWidth));
+    in3 = (line.number - 2) <  fieldInfo.firstLine ? blackLine : (inputData + ((line.number - 2) * videoParameters.fieldWidth));
+    in4 = (line.number + 2) >= fieldInfo.lastLine  ? blackLine : (inputData + ((line.number + 2) * videoParameters.fieldWidth));
+    in5 = (line.number - 2) <  fieldInfo.firstLine ? blackLine : (inputData + ((line.number - 3) * videoParameters.fieldWidth));
+    in6 = (line.number + 3) >= fieldInfo.lastLine  ? blackLine : (inputData + ((line.number + 3) * videoParameters.fieldWidth));
 
     // Check that the filter isn't going to run out of data horizontally.
     assert(videoParameters.activeVideoStart - FILTER_SIZE >= videoParameters.colourBurstEnd);
@@ -426,13 +442,13 @@ void PalColour::decodeLine(const FieldInfo &field, const LineInfo &line, const I
 
     // Define scan line pointer to output buffer using 16 bit unsigned words
     quint16 *ptr = reinterpret_cast<quint16 *>(outputFrame.data()
-                                               + (((line.number * 2) + field.number) * videoParameters.fieldWidth * 6));
+                                               + (((line.number * 2) + fieldInfo.offset) * videoParameters.fieldWidth * 6));
 
     // Gain for the Y component, to put black at 0 and peak white at 65535
-    const double scaledContrast = (65535.0 / (videoParameters.white16bIre - videoParameters.black16bIre)) * field.contrast / 100.0;
+    const double scaledContrast = 65535.0 / (videoParameters.white16bIre - videoParameters.black16bIre);
 
     // Gain for the U/V components
-    const double scaledSaturation = (field.saturation / 50.0) / line.burstNorm;
+    const double scaledSaturation = (2.0 / line.burstNorm) * fieldInfo.chromaGain;
 
     for (qint32 i = videoParameters.activeVideoStart; i < videoParameters.activeVideoEnd; i++) {
         // Compute luma by...

--- a/tools/ld-chroma-decoder/palcolour.cpp
+++ b/tools/ld-chroma-decoder/palcolour.cpp
@@ -60,7 +60,7 @@ PalColour::PalColour(QObject *parent)
 {
 }
 
-void PalColour::updateConfiguration(LdDecodeMetaData::VideoParameters _videoParameters,
+void PalColour::updateConfiguration(const LdDecodeMetaData::VideoParameters &_videoParameters,
                                     qint32 _firstActiveLine, qint32 _lastActiveLine,
                                     bool _useTransformFilter, double transformThreshold)
 {

--- a/tools/ld-chroma-decoder/palcolour.h
+++ b/tools/ld-chroma-decoder/palcolour.h
@@ -41,9 +41,20 @@ class PalColour : public QObject
 
 public:
     explicit PalColour(QObject *parent = nullptr);
+
+    struct Configuration {
+        bool useTransformFilter = false;
+        double transformThreshold = 0.4;
+
+        // Interlaced line 44 is PAL line 23 (the first active half-line)
+        qint32 firstActiveLine = 44;
+        // Interlaced line 619 is PAL line 623 (the last active half-line)
+        qint32 lastActiveLine = 620;
+    };
+
+    const Configuration &getConfiguration() const;
     void updateConfiguration(const LdDecodeMetaData::VideoParameters &videoParameters,
-                             qint32 firstActiveLine, qint32 lastActiveLine,
-                             bool useTransformFilter = false, double transformThreshold = 0.4);
+                             const Configuration &configuration);
 
     // Decode two fields to produce an interlaced frame.
     // contrast and saturation are user-adjustable controls; 100 is nominal.
@@ -94,10 +105,8 @@ private:
 
     // Configuration parameters
     bool configurationSet;
+    Configuration configuration;
     LdDecodeMetaData::VideoParameters videoParameters;
-    qint32 firstActiveLine;
-    qint32 lastActiveLine;
-    bool useTransformFilter;
 
     // Transform PAL filter
     TransformPal transformPal;

--- a/tools/ld-chroma-decoder/palcolour.h
+++ b/tools/ld-chroma-decoder/palcolour.h
@@ -43,6 +43,7 @@ public:
     explicit PalColour(QObject *parent = nullptr);
 
     struct Configuration {
+        bool blackAndWhite = false;
         bool useTransformFilter = false;
         double transformThreshold = 0.4;
 
@@ -57,8 +58,8 @@ public:
                              const Configuration &configuration);
 
     // Decode two fields to produce an interlaced frame.
-    // contrast and saturation are user-adjustable controls; 100 is nominal.
-    QByteArray performDecode(QByteArray topFieldData, QByteArray bottomFieldData, qint32 contrast, qint32 saturation);
+    QByteArray decodeFrame(const LdDecodeMetaData::Field &topField, QByteArray topFieldData,
+                           const LdDecodeMetaData::Field &bottomField, QByteArray bottomFieldData);
 
     // Maximum frame size, based on PAL
     static const qint32 MAX_WIDTH = 1135;
@@ -67,19 +68,22 @@ public:
 private:
     // Information about a field we're decoding.
     struct FieldInfo {
-        explicit FieldInfo(qint32 number, qint32 contrast, qint32 saturation, qint32 firstActiveLine, qint32 lastActiveLine);
+        explicit FieldInfo(const LdDecodeMetaData::Field &field, const Configuration &configuration, double chromaGain);
 
-        // number is 0 for the top field, 1 for the bottom field.
-        qint32 number;
-        qint32 contrast;
-        qint32 saturation;
+        // Chroma gain factor, based on colourburst amplitude.
+        double chromaGain;
+
+        // Vertical pixels to offset this field within the interlaced frame --
+        // i.e. 0 for the top field, 1 for the bottom field.
+        qint32 offset;
+
         // firstLine/lastLine are the range of active lines within the field.
         qint32 firstLine;
         qint32 lastLine;
     };
 
     // Decode one field into outputFrame.
-    void decodeField(const FieldInfo &field, const QByteArray &fieldData);
+    void decodeField(const LdDecodeMetaData::Field &field, const QByteArray &fieldData, double chromaGain);
 
     // Information about a line we're decoding.
     struct LineInfo {
@@ -101,7 +105,7 @@ private:
     // to chroma.
     // compData is the composite signal, used for reconstructing Y at the end.
     template <typename InputSample>
-    void decodeLine(const FieldInfo &field, const LineInfo &line, const InputSample *inputData, const quint16 *compData);
+    void decodeLine(const FieldInfo &fieldInfo, const LineInfo &line, const InputSample *inputData, const quint16 *compData);
 
     // Configuration parameters
     bool configurationSet;

--- a/tools/ld-chroma-decoder/palcolour.h
+++ b/tools/ld-chroma-decoder/palcolour.h
@@ -104,7 +104,7 @@ private:
     // filter; this may be the composite signal, or it may be pre-filtered down
     // to chroma.
     // compData is the composite signal, used for reconstructing Y at the end.
-    template <typename InputSample>
+    template <typename InputSample, bool useTransformFilter>
     void decodeLine(const FieldInfo &fieldInfo, const LineInfo &line, const InputSample *inputData, const quint16 *compData);
 
     // Configuration parameters

--- a/tools/ld-chroma-decoder/palcolour.h
+++ b/tools/ld-chroma-decoder/palcolour.h
@@ -41,7 +41,8 @@ class PalColour : public QObject
 
 public:
     explicit PalColour(QObject *parent = nullptr);
-    void updateConfiguration(LdDecodeMetaData::VideoParameters videoParameters, qint32 firstActiveLine, qint32 lastActiveLine,
+    void updateConfiguration(const LdDecodeMetaData::VideoParameters &videoParameters,
+                             qint32 firstActiveLine, qint32 lastActiveLine,
                              bool useTransformFilter = false, double transformThreshold = 0.4);
 
     // Decode two fields to produce an interlaced frame.

--- a/tools/ld-chroma-decoder/paldecoder.cpp
+++ b/tools/ld-chroma-decoder/paldecoder.cpp
@@ -53,39 +53,18 @@ QThread *PalDecoder::makeThread(QAtomicInt& abort, DecoderPool& decoderPool) {
 
 PalThread::PalThread(QAtomicInt& _abort, DecoderPool& _decoderPool,
                      const PalDecoder::Configuration &_config, QObject *parent)
-    : QThread(parent), abort(_abort), decoderPool(_decoderPool), config(_config)
+    : DecoderThread(_abort, _decoderPool, parent), config(_config)
 {
     // Configure PALcolour
     palColour.updateConfiguration(config.videoParameters, config.pal);
 }
 
-void PalThread::run()
+QByteArray PalThread::decodeFrame(const LdDecodeMetaData::Field &firstField, QByteArray firstFieldData,
+                                  const LdDecodeMetaData::Field &secondField, QByteArray secondFieldData)
 {
-    qint32 frameNumber;
+    // Perform the PALcolour filtering
+    QByteArray outputData = palColour.decodeFrame(firstField, firstFieldData, secondField, secondFieldData);
 
-    // Input field metadata and data
-    LdDecodeMetaData::Field firstField;
-    QByteArray firstFieldData;
-    LdDecodeMetaData::Field secondField;
-    QByteArray secondFieldData;
-
-    while(!abort) {
-        // Get the next frame to process from the input file
-        if (!decoderPool.getInputFrame(frameNumber, firstField, firstFieldData, secondField, secondFieldData)) {
-            // No more input frames -- exit
-            break;
-        }
-
-        // Perform the PALcolour filtering
-        QByteArray outputData = palColour.decodeFrame(firstField, firstFieldData, secondField, secondFieldData);
-
-        // PALcolour outputs the whole frame; crop it to the active area
-        QByteArray croppedData = PalDecoder::cropOutputFrame(config, outputData);
-
-        // Write the result to the output file
-        if (!decoderPool.putOutputFrame(frameNumber, croppedData)) {
-            abort = true;
-            break;
-        }
-    }
+    // Crop the frame to just the active area
+    return PalDecoder::cropOutputFrame(config, outputData);
 }

--- a/tools/ld-chroma-decoder/paldecoder.cpp
+++ b/tools/ld-chroma-decoder/paldecoder.cpp
@@ -59,11 +59,10 @@ PalThread::PalThread(QAtomicInt& _abort, DecoderPool& _decoderPool,
     palColour.updateConfiguration(config.videoParameters, config.pal);
 }
 
-QByteArray PalThread::decodeFrame(const LdDecodeMetaData::Field &firstField, QByteArray firstFieldData,
-                                  const LdDecodeMetaData::Field &secondField, QByteArray secondFieldData)
+QByteArray PalThread::decodeFrame(const Decoder::InputField &firstField, const Decoder::InputField &secondField)
 {
     // Perform the PALcolour filtering
-    QByteArray outputData = palColour.decodeFrame(firstField, firstFieldData, secondField, secondFieldData);
+    QByteArray outputData = palColour.decodeFrame(firstField.field, firstField.data, secondField.field, secondField.data);
 
     // Crop the frame to just the active area
     return PalDecoder::cropOutputFrame(config, outputData);

--- a/tools/ld-chroma-decoder/paldecoder.cpp
+++ b/tools/ld-chroma-decoder/paldecoder.cpp
@@ -30,8 +30,8 @@
 PalDecoder::PalDecoder(bool _blackAndWhite, bool _useTransformFilter, double _transformThreshold)
 {
     config.blackAndWhite = _blackAndWhite;
-    config.useTransformFilter = _useTransformFilter;
-    config.transformThreshold = _transformThreshold;
+    config.pal.useTransformFilter = _useTransformFilter;
+    config.pal.transformThreshold = _transformThreshold;
 }
 
 bool PalDecoder::configure(const LdDecodeMetaData::VideoParameters &videoParameters) {
@@ -42,7 +42,7 @@ bool PalDecoder::configure(const LdDecodeMetaData::VideoParameters &videoParamet
     }
 
     // Compute cropping parameters
-    setVideoParameters(config, videoParameters, 44, 620);
+    setVideoParameters(config, videoParameters, config.pal.firstActiveLine, config.pal.lastActiveLine);
 
     return true;
 }
@@ -56,8 +56,7 @@ PalThread::PalThread(QAtomicInt& _abort, DecoderPool& _decoderPool,
     : QThread(parent), abort(_abort), decoderPool(_decoderPool), config(_config)
 {
     // Configure PALcolour
-    palColour.updateConfiguration(config.videoParameters, config.firstActiveLine, config.lastActiveLine,
-                                  config.useTransformFilter, config.transformThreshold);
+    palColour.updateConfiguration(config.videoParameters, config.pal);
 }
 
 void PalThread::run()

--- a/tools/ld-chroma-decoder/paldecoder.h
+++ b/tools/ld-chroma-decoder/paldecoder.h
@@ -49,8 +49,7 @@ public:
     // Parameters used by PalDecoder and PalThread
     struct Configuration : public Decoder::Configuration {
         bool blackAndWhite;
-        bool useTransformFilter;
-        double transformThreshold;
+        PalColour::Configuration pal;
     };
 
 private:

--- a/tools/ld-chroma-decoder/paldecoder.h
+++ b/tools/ld-chroma-decoder/paldecoder.h
@@ -78,9 +78,6 @@ private:
 
     // PAL colour object
     PalColour palColour;
-
-    // Temporary output buffer
-    QByteArray outputData;
 };
 
 #endif // PALDECODER

--- a/tools/ld-chroma-decoder/paldecoder.h
+++ b/tools/ld-chroma-decoder/paldecoder.h
@@ -64,8 +64,7 @@ public:
                        QObject *parent = nullptr);
 
 protected:
-    QByteArray decodeFrame(const LdDecodeMetaData::Field &firstField, QByteArray firstFieldData,
-                           const LdDecodeMetaData::Field &secondField, QByteArray secondFieldData) override;
+    QByteArray decodeFrame(const Decoder::InputField &firstField, const Decoder::InputField &secondField) override;
 
 private:
     // Settings

--- a/tools/ld-chroma-decoder/paldecoder.h
+++ b/tools/ld-chroma-decoder/paldecoder.h
@@ -55,7 +55,7 @@ private:
     Configuration config;
 };
 
-class PalThread : public QThread
+class PalThread : public DecoderThread
 {
     Q_OBJECT
 public:
@@ -64,13 +64,10 @@ public:
                        QObject *parent = nullptr);
 
 protected:
-    void run() override;
+    QByteArray decodeFrame(const LdDecodeMetaData::Field &firstField, QByteArray firstFieldData,
+                           const LdDecodeMetaData::Field &secondField, QByteArray secondFieldData) override;
 
 private:
-    // Decoder pool
-    QAtomicInt& abort;
-    DecoderPool& decoderPool;
-
     // Settings
     const PalDecoder::Configuration &config;
 

--- a/tools/ld-chroma-decoder/paldecoder.h
+++ b/tools/ld-chroma-decoder/paldecoder.h
@@ -48,7 +48,6 @@ public:
 
     // Parameters used by PalDecoder and PalThread
     struct Configuration : public Decoder::Configuration {
-        bool blackAndWhite;
         PalColour::Configuration pal;
     };
 

--- a/tools/ld-chroma-decoder/transformpal.cpp
+++ b/tools/ld-chroma-decoder/transformpal.cpp
@@ -84,12 +84,9 @@ TransformPal::~TransformPal()
 }
 
 void TransformPal::updateConfiguration(const LdDecodeMetaData::VideoParameters &_videoParameters,
-                                       qint32 _firstActiveLine, qint32 _lastActiveLine,
                                        double _threshold)
 {
     videoParameters = _videoParameters;
-    firstActiveLine = _firstActiveLine;
-    lastActiveLine = _lastActiveLine;
     threshold = _threshold;
 
     // Resize the chroma buffer
@@ -98,18 +95,10 @@ void TransformPal::updateConfiguration(const LdDecodeMetaData::VideoParameters &
     configurationSet = true;
 }
 
-const double *TransformPal::filterField(qint32 fieldNumber, const QByteArray &fieldData)
+const double *TransformPal::filterField(qint32 firstFieldLine, qint32 lastFieldLine, const QByteArray &fieldData)
 {
     assert(configurationSet);
-    assert(fieldNumber == 0 || fieldNumber == 1);
     assert(!fieldData.isNull());
-
-    // Work out the active lines to be decoded within this field.
-    // If firstActiveLine or lastActiveLine is odd, we can end up with
-    // different ranges for the two fields, so we need to be careful
-    // about how this is rounded.
-    const qint32 firstFieldLine = (firstActiveLine + 1 - fieldNumber) / 2;
-    const qint32 lastFieldLine = (lastActiveLine + 1 - fieldNumber) / 2;
 
     // Pointers to the input and output data
     const quint16 *inputPtr = reinterpret_cast<const quint16 *>(fieldData.data());

--- a/tools/ld-chroma-decoder/transformpal.cpp
+++ b/tools/ld-chroma-decoder/transformpal.cpp
@@ -83,7 +83,7 @@ TransformPal::~TransformPal()
     fftw_free(fftComplexOut);
 }
 
-void TransformPal::updateConfiguration(LdDecodeMetaData::VideoParameters _videoParameters,
+void TransformPal::updateConfiguration(const LdDecodeMetaData::VideoParameters &_videoParameters,
                                        qint32 _firstActiveLine, qint32 _lastActiveLine,
                                        double _threshold)
 {

--- a/tools/ld-chroma-decoder/transformpal.h
+++ b/tools/ld-chroma-decoder/transformpal.h
@@ -43,13 +43,12 @@ public:
     // threshold is the similarity threshold for the filter (values from 0-1
     // are meaningful; 0.6 is pyctools-pal's default)
     void updateConfiguration(const LdDecodeMetaData::VideoParameters &videoParameters,
-                             qint32 firstActiveLine, qint32 lastActiveLine,
                              double threshold);
 
     // Filter an input field.
     // Returns a pointer to an array of the same size (owned by this object)
     // containing the chroma signal.
-    const double *filterField(qint32 fieldNumber, const QByteArray &fieldData);
+    const double *filterField(qint32 firstFieldLine, qint32 lastFieldLine, const QByteArray &fieldData);
 
 private:
     // Apply the frequency-domain filter
@@ -58,8 +57,6 @@ private:
     // Configuration parameters
     bool configurationSet;
     LdDecodeMetaData::VideoParameters videoParameters;
-    qint32 firstActiveLine;
-    qint32 lastActiveLine;
     double threshold;
 
     // Maximum field size, based on PAL

--- a/tools/ld-chroma-decoder/transformpal.h
+++ b/tools/ld-chroma-decoder/transformpal.h
@@ -42,7 +42,7 @@ public:
 
     // threshold is the similarity threshold for the filter (values from 0-1
     // are meaningful; 0.6 is pyctools-pal's default)
-    void updateConfiguration(LdDecodeMetaData::VideoParameters videoParameters,
+    void updateConfiguration(const LdDecodeMetaData::VideoParameters &videoParameters,
                              qint32 firstActiveLine, qint32 lastActiveLine,
                              double threshold);
 


### PR DESCRIPTION
See the commits for full details, but the highlights are:

- DecoderPool now issues batches of fields rather than individual frames, and 3D decoders can request additional past/future fields at the ends of each batch. This means ntsc3d can now take advantage of parallelisation, and using a 3D decoder with --start produces a 3D result for the first frame. This would also allow a 3D FFT in the future. Fixes #123.

- Refactor configuration in Comb and PalColour, combining the best bits of both. The two classes now present effectively identical interfaces, which simplifies the code that drives them in ld-chroma-decoder and ld-analyse.

- As a result of the above, NTSC decodes are now padded with actual data (like PAL) rather than  black pixels at the left and right.

- Fix what I think was a copy-paste error in the NTSC 3D map code, so the image under the map keeps its original colours.

- Fix a performance regression introduced during the Transform work, making both pal2d and transform2d a bit faster.

Performance on a 4 core machine - current rev6 on the left, this branch on the right; in each group, the four sets of results are ntsc2d, ntsc3d, pal2d, transform2d:

![Figure_1](https://user-images.githubusercontent.com/436317/63168289-a112c780-c02b-11e9-8108-cd93d3dd92f5.png)