### PR TITLE
Transform PAL improvements, part 2

### DIFF
--- a/tools/ld-chroma-decoder/main.cpp
+++ b/tools/ld-chroma-decoder/main.cpp
@@ -168,7 +168,7 @@ int main(int argc, char *argv[])
     // -- PAL decoder options --
 
     // Option to select the Transform PAL threshold
-    QCommandLineOption transformThresholdOption(QStringList() << "transformThreshold",
+    QCommandLineOption transformThresholdOption(QStringList() << "transform-threshold",
                                                 QCoreApplication::translate("main", "Transform: Similarity threshold for the chroma filter (default 0.4)"),
                                                 QCoreApplication::translate("main", "number"));
     parser.addOption(transformThresholdOption);

--- a/tools/ld-chroma-decoder/transformpal.cpp
+++ b/tools/ld-chroma-decoder/transformpal.cpp
@@ -162,7 +162,7 @@ static inline double fftwAbs(const fftw_complex &value) {
 void TransformPal::applyFilter() {
     // Clear fftComplexOut. We discard values by default; the filter only
     // copies values that look like chroma.
-    for (int i = 0; i < XCOMPLEX * YCOMPLEX; i++) {
+    for (qint32 i = 0; i < XCOMPLEX * YCOMPLEX; i++) {
         fftComplexOut[i][0] = 0.0;
         fftComplexOut[i][1] = 0.0;
     }
@@ -179,9 +179,9 @@ void TransformPal::applyFilter() {
     // point that might be a chroma signal, and only keep it if it's
     // sufficiently symmetrical with its reflection.
 
-    for (int y = 0; y < YTILE; y++) {
+    for (qint32 y = 0; y < YTILE; y++) {
         // Reflect around 72 c/aph vertically.
-        const int y_ref = ((YTILE / 2) + YTILE - y) % YTILE;
+        const qint32 y_ref = ((YTILE / 2) + YTILE - y) % YTILE;
 
         // Input data for this line and its reflection
         const fftw_complex *bi = fftComplexIn + (y * XCOMPLEX);
@@ -192,9 +192,9 @@ void TransformPal::applyFilter() {
         fftw_complex *bo_ref = fftComplexOut + (y_ref * XCOMPLEX);
 
         // We only need to look at horizontal frequencies that might be chroma (0.5fSC to 2fSC).
-        for (int x = XTILE / 8; x <= XTILE / 4; x++) {
+        for (qint32 x = XTILE / 8; x <= XTILE / 4; x++) {
             // Reflect around 4fSC Hz horizontally.
-            const int x_ref = (XTILE / 2) - x;
+            const qint32 x_ref = (XTILE / 2) - x;
 
             const fftw_complex &in_val = bi[x];
             const fftw_complex &ref_val = bi_ref[x_ref];

--- a/tools/ld-chroma-decoder/transformpal.cpp
+++ b/tools/ld-chroma-decoder/transformpal.cpp
@@ -67,9 +67,8 @@ TransformPal::TransformPal()
     fftComplexOut = fftw_alloc_complex(YCOMPLEX * XCOMPLEX);
 
     // Plan FFTW operations
-    // XXX FFTW_ESTIMATE is quick but potentially produces a slower plan...
-    forwardPlan = fftw_plan_dft_r2c_2d(YTILE, XTILE, fftReal, fftComplexIn, FFTW_ESTIMATE);
-    inversePlan = fftw_plan_dft_c2r_2d(YTILE, XTILE, fftComplexOut, fftReal, FFTW_ESTIMATE);
+    forwardPlan = fftw_plan_dft_r2c_2d(YTILE, XTILE, fftReal, fftComplexIn, FFTW_MEASURE);
+    inversePlan = fftw_plan_dft_c2r_2d(YTILE, XTILE, fftComplexOut, fftReal, FFTW_MEASURE);
 }
 
 TransformPal::~TransformPal()

--- a/tools/ld-chroma-decoder/transformpal.h
+++ b/tools/ld-chroma-decoder/transformpal.h
@@ -60,22 +60,22 @@ private:
     double threshold;
 
     // Maximum field size, based on PAL
-    static constexpr int MAX_WIDTH = 1135;
+    static constexpr qint32 MAX_WIDTH = 1135;
 
     // FFT input and output sizes.
-    // The input field is divided into tiles of XSIZE x YSIZE, with adjacent
-    // tiles overlapping by HALFXSIZE/HALFYSIZE.
-    static constexpr int YTILE = 16;
-    static constexpr int HALFYTILE = YTILE / 2;
-    static constexpr int XTILE = 32;
-    static constexpr int HALFXTILE = XTILE / 2;
+    // The input field is divided into tiles of XTILE x YTILE, with adjacent
+    // tiles overlapping by HALFXTILE/HALFYTILE.
+    static constexpr qint32 YTILE = 16;
+    static constexpr qint32 HALFYTILE = YTILE / 2;
+    static constexpr qint32 XTILE = 32;
+    static constexpr qint32 HALFXTILE = XTILE / 2;
 
     // Each tile is converted to the frequency domain using forwardPlan, which
     // gives a complex result of size XCOMPLEX x YCOMPLEX (roughly half the
     // size of the input, because the input data was real, i.e. contained no
     // negative frequencies).
-    static constexpr int YCOMPLEX = YTILE;
-    static constexpr int XCOMPLEX = (XTILE / 2) + 1;
+    static constexpr qint32 YCOMPLEX = YTILE;
+    static constexpr qint32 XCOMPLEX = (XTILE / 2) + 1;
 
     // Window function applied before the FFT
     double windowFunction[YTILE][XTILE];


### PR DESCRIPTION
Two cleanups and two speedups for TransformPal. Overall this is about 20% faster.

My original intention was to make the FFT size configurable, but this has a small performance cost and I don't think it's worthwhile (I've left it on [this branch](https://github.com/atsampson/ld-decode/tree/fftsize)). Having done some experiments with the PAL reference disc images, the current default of 32 samples x 16 field lines is pretty much the sweet spot for 2D, and 24x16 would also be a reasonable choice. We should review this if we do a 3D decoder - Jim Easterbrook's page says 16x16x8 worked well for 3D.