### PR TITLE
Use fabs rather than abs in FFT visualisation code.

### DIFF
--- a/tools/ld-chroma-decoder/transformpal.cpp
+++ b/tools/ld-chroma-decoder/transformpal.cpp
@@ -74,8 +74,8 @@ void TransformPal::overlayFFTArrays(const fftw_complex *fftIn, const fftw_comple
     // Work out a scaling factor to make all values visible.
     double maxValue = 0;
     for (qint32 i = 0; i < xSize * ySize * zSize; i++) {
-        maxValue = qMax(maxValue, abs(fftIn[i][0]));
-        maxValue = qMax(maxValue, abs(fftOut[i][0]));
+        maxValue = qMax(maxValue, fabs(fftIn[i][0]));
+        maxValue = qMax(maxValue, fabs(fftOut[i][0]));
     }
     const double valueScale = 65535.0 / log2(maxValue);
 
@@ -94,7 +94,7 @@ void TransformPal::overlayFFTArrays(const fftw_complex *fftIn, const fftw_comple
             // Draw the elements in the array
             for (qint32 y = 0; y < ySize; y++) {
                 for (qint32 x = 0; x < xSize; x++) {
-                    const double value = abs(fftData[(((z * ySize) + y) * xSize) + x][0]);
+                    const double value = fabs(fftData[(((z * ySize) + y) * xSize) + x][0]);
                     const double shade = value <= 0 ? 0 : log2(value) * valueScale;
                     const quint16 shade16 = static_cast<quint16>(qBound(0.0, shade, 65535.0));
                     canvas.fillRectangle(xStart + (x * xScale) + 1, yStart + (y * yScale) + 1, xScale, yScale, canvas.grey(shade16));


### PR DESCRIPTION
This fixes a build breakage with older GCC (abs happened to work for me because it was including something with an appropriate overload).