### PR TITLE
Avoid frames containing skips when selecting which duplicate to use.

### DIFF
--- a/tools/ld-discmap/vbimapper.cpp
+++ b/tools/ld-discmap/vbimapper.cpp
@@ -399,9 +399,20 @@ void VbiMapper::removeDuplicateFrames()
                 qint32 maxSnr = -1;
                 qint32 selection = -1;
                 for (qint32 i = 0; i < duplicates.size(); i++) {
-                    if (frames[duplicates[i]].bSnr > maxSnr) {
+                    qint32 frameNumber = duplicates[i];
+                    qint32 snr = frames[frameNumber].bSnr;
+
+                    // If there is a following frame with the same or lower frame number, the player
+                    // must have skipped during this frame -- give it a big SNR penalty so it's
+                    // unlikely to be selected
+                    if (frameNumber + 1 < frames.size() &&
+                        frames[frameNumber + 1].vbiFrameNumber <= frames[frameNumber].vbiFrameNumber) {
+                        snr -= 20;
+                    }
+
+                    if (snr > maxSnr) {
                         selection = i;
-                        maxSnr = frames[duplicates[i]].bSnr;
+                        maxSnr = snr;
                     }
                 }
 


### PR DESCRIPTION
If a frame is followed by another frame that has the same VBI frame number, the player must have skipped somewhere in the middle of the frame:

![jurassicskip](https://user-images.githubusercontent.com/436317/63657672-59fba380-c79c-11e9-88fc-4e868059cf45.png)

So give the frame an SNR penalty. It can't discard the frame entirely because there might be no better options (e.g. if the input contains a sequence of frames in reverse order).