### PR TITLE
Dropout correction improvements

### DIFF
--- a/tools/ld-dropout-correct/dropoutcorrect.cpp
+++ b/tools/ld-dropout-correct/dropoutcorrect.cpp
@@ -298,11 +298,9 @@ DropOutCorrect::Replacement DropOutCorrect::findReplacementLine(QVector<DropOutL
             if (firstFieldDropouts[sourceIndex].fieldLine == upSourceLine) {
                 // Does the start<->end range overlap?
                 if ((firstFieldDropouts[sourceIndex].endx - firstFieldDropouts[dropOutIndex].startx >= 0) && (firstFieldDropouts[dropOutIndex].endx - firstFieldDropouts[sourceIndex].startx >= 0)) {
-                    // Overlap
+                    // Overlap -- can't use this line
                     upSourceLine -= stepAmount;
                     upFoundSource = false;
-                } else {
-                    upFoundSource = true; // Use the current source line
                     break;
                 }
             }
@@ -319,11 +317,9 @@ DropOutCorrect::Replacement DropOutCorrect::findReplacementLine(QVector<DropOutL
             if (firstFieldDropouts[sourceIndex].fieldLine == downSourceLine) {
                 // Does the start<->end range overlap?
                 if ((firstFieldDropouts[sourceIndex].endx - firstFieldDropouts[dropOutIndex].startx >= 0) && (firstFieldDropouts[dropOutIndex].endx - firstFieldDropouts[sourceIndex].startx >= 0)) {
-                    // Overlap
+                    // Overlap -- can't use this line
                     downSourceLine += stepAmount;
                     downFoundSource = false;
-                } else {
-                    downFoundSource = true; // Use the current source line
                     break;
                 }
             }
@@ -367,19 +363,12 @@ DropOutCorrect::Replacement DropOutCorrect::findReplacementLine(QVector<DropOutL
             upFoundSource = true;
             for (qint32 sourceIndex = 0; sourceIndex < secondFieldDropouts.size(); sourceIndex++) {
                 if (secondFieldDropouts[sourceIndex].fieldLine == upSourceLine) {
-                    if (secondFieldDropouts.size() < dropOutIndex && firstFieldDropouts.size() < sourceIndex) {
-                        // Does the start<->end range overlap?
-                        if ((firstFieldDropouts[sourceIndex].endx - secondFieldDropouts[dropOutIndex].startx >= 0) &&
-                                (firstFieldDropouts[dropOutIndex].endx - secondFieldDropouts[sourceIndex].startx >= 0)) {
-                            // Overlap
-                            upSourceLine -= stepAmount;
-                            upFoundSource = false;
-                        } else {
-                            upFoundSource = true; // Use the current source line
-                            break;
-                        }
-                    } else {
-                        upFoundSource = true; // Use the current source line
+                    // Does the start<->end range overlap?
+                    if ((firstFieldDropouts[dropOutIndex].endx - secondFieldDropouts[sourceIndex].startx >= 0) &&
+                            (secondFieldDropouts[sourceIndex].endx - firstFieldDropouts[dropOutIndex].startx >= 0)) {
+                        // Overlap -- can't use this line
+                        upSourceLine -= stepAmount;
+                        upFoundSource = false;
                         break;
                     }
                 }
@@ -394,19 +383,12 @@ DropOutCorrect::Replacement DropOutCorrect::findReplacementLine(QVector<DropOutL
             downFoundSource = true;
             for (qint32 sourceIndex = 0; sourceIndex < secondFieldDropouts.size(); sourceIndex++) {
                 if (secondFieldDropouts[sourceIndex].fieldLine == downSourceLine) {
-                    if (secondFieldDropouts.size() < dropOutIndex && firstFieldDropouts.size() < sourceIndex) {
-                        // Does the start<->end range overlap?
-                        if ((firstFieldDropouts[sourceIndex].endx - secondFieldDropouts[dropOutIndex].startx >= 0) &&
-                                (firstFieldDropouts[dropOutIndex].endx - secondFieldDropouts[sourceIndex].startx >= 0)) {
-                            // Overlap
-                            downSourceLine += stepAmount;
-                            downFoundSource = false;
-                        } else {
-                            downFoundSource = true; // Use the current source line
-                            break;
-                        }
-                    } else {
-                        downFoundSource = true; // Use the current source line
+                    // Does the start<->end range overlap?
+                    if ((firstFieldDropouts[dropOutIndex].endx - secondFieldDropouts[sourceIndex].startx >= 0) &&
+                            (secondFieldDropouts[sourceIndex].endx - firstFieldDropouts[dropOutIndex].startx >= 0)) {
+                        // Overlap -- can't use this line
+                        downSourceLine += stepAmount;
+                        downFoundSource = false;
                         break;
                     }
                 }

--- a/tools/ld-dropout-correct/dropoutcorrect.cpp
+++ b/tools/ld-dropout-correct/dropoutcorrect.cpp
@@ -84,6 +84,8 @@ void DropOutCorrect::run()
                 QVector<Replacement> firstFieldReplacementLines;
                 firstFieldReplacementLines.resize(firstFieldDropouts.size());
                 for (qint32 dropoutIndex = 0; dropoutIndex < firstFieldDropouts.size(); dropoutIndex++) {
+                    firstFieldReplacementLines[dropoutIndex].fieldLine = -1;
+
                     // Is the current dropout in the colour burst?
                     if (firstFieldDropouts[dropoutIndex].location == Location::colourBurst) {
                         firstFieldReplacementLines[dropoutIndex] = findReplacementLine(firstFieldDropouts, secondFieldDropouts, dropoutIndex, true, intraField);
@@ -97,7 +99,9 @@ void DropOutCorrect::run()
 
                 // Correct the data of the first field
                 for (qint32 dropoutIndex = 0; dropoutIndex < firstFieldDropouts.size(); dropoutIndex++) {
-                    if (firstFieldReplacementLines[dropoutIndex].isFirstField) {
+                    if (firstFieldReplacementLines[dropoutIndex].fieldLine == -1) {
+                        // Doesn't need correcting
+                    } else if (firstFieldReplacementLines[dropoutIndex].isFirstField) {
                         // Correct the first field from the first field (intra-field correction)
                         correctDropOut(firstFieldDropouts[dropoutIndex], firstFieldReplacementLines[dropoutIndex], firstTargetFieldData, firstTargetFieldData);
                     } else {
@@ -113,6 +117,8 @@ void DropOutCorrect::run()
                 QVector<Replacement> secondFieldReplacementLines;
                 secondFieldReplacementLines.resize(secondFieldDropouts.size());
                 for (qint32 dropoutIndex = 0; dropoutIndex < secondFieldDropouts.size(); dropoutIndex++) {
+                    secondFieldReplacementLines[dropoutIndex].fieldLine = -1;
+
                     // Is the current dropout in the colour burst?
                     if (secondFieldDropouts[dropoutIndex].location == Location::colourBurst) {
                         secondFieldReplacementLines[dropoutIndex] = findReplacementLine(secondFieldDropouts, firstFieldDropouts, dropoutIndex, true, intraField);
@@ -126,7 +132,9 @@ void DropOutCorrect::run()
 
                 // Correct the data of the second field
                 for (qint32 dropoutIndex = 0; dropoutIndex < secondFieldDropouts.size(); dropoutIndex++) {
-                    if (secondFieldReplacementLines[dropoutIndex].isFirstField) {
+                    if (secondFieldReplacementLines[dropoutIndex].fieldLine == -1) {
+                        // Doesn't need correcting
+                    } else if (secondFieldReplacementLines[dropoutIndex].isFirstField) {
                         // Correct the second field from the second field (intra-field correction)
                         correctDropOut(secondFieldDropouts[dropoutIndex], secondFieldReplacementLines[dropoutIndex], secondTargetFieldData, secondSourceField);
                     } else {

--- a/tools/ld-dropout-correct/dropoutcorrect.cpp
+++ b/tools/ld-dropout-correct/dropoutcorrect.cpp
@@ -154,6 +154,11 @@ QVector<DropOutCorrect::DropOutLocation> DropOutCorrect::populateDropoutsVector(
         dropOutLocation.fieldLine = field.dropOuts.fieldLine[dropOutIndex];
         dropOutLocation.location = DropOutCorrect::Location::unknown;
 
+        // Ignore dropouts outside the field's data
+        if (dropOutLocation.fieldLine < 1 || dropOutLocation.fieldLine > videoParameters.fieldHeight) {
+            continue;
+        }
+
         // Is over correct mode selected?
         if (overCorrect) {
             // Here we deliberately extend the length of dropouts to ensure that the

--- a/tools/ld-dropout-correct/dropoutcorrect.h
+++ b/tools/ld-dropout-correct/dropoutcorrect.h
@@ -74,6 +74,7 @@ private:
     QVector<DropOutLocation> populateDropoutsVector(LdDecodeMetaData::Field field, bool overCorrect);
     QVector<DropOutLocation> setDropOutLocations(QVector<DropOutLocation> dropOuts);
     Replacement findReplacementLine(QVector<DropOutLocation>firstFieldDropouts, QVector<DropOutLocation> secondFieldDropouts, qint32 dropOutIndex, bool isColourBurst, bool intraField);
+    void correctDropOut(const DropOutLocation &dropOut, const Replacement &replacement, QByteArray &targetField, const QByteArray &sourceField);
 };
 
 #endif // DROPOUTCORRECT_H


### PR DESCRIPTION
The first couple of changes prevent a crash when ld-decode reports a dropout that isn't within the frame data. The last one fixes a couple of problems in the replacement line selection algorithm that meant it sometimes chose a line with an overlapping dropout.

Here's a raw frame from a very rotten copy of [1109-70](https://www.lddb.com/laserdisc/34586/1109-70/Kagemusha:-The-Shadow-Warrior):

![frame_pal_source_3821-orig](https://user-images.githubusercontent.com/436317/63726307-d487fa00-c854-11e9-871e-8203e0f757a7.png)

With dropouts corrected before the fix:

![frame_pal_source_3821-doc](https://user-images.githubusercontent.com/436317/63726323-dea9f880-c854-11e9-96eb-f60d592aa948.png)

And after the fix:

![frame_pal_source_3821-better](https://user-images.githubusercontent.com/436317/63726344-e6699d00-c854-11e9-8a2b-6d11c396f6e6.png)