### PR TITLE
Add "mono" decoder.

### DIFF
--- a/tools/ld-chroma-decoder/ld-chroma-decoder.pro
+++ b/tools/ld-chroma-decoder/ld-chroma-decoder.pro
@@ -20,6 +20,7 @@ SOURCES += \
     decoderpool.cpp \
     framecanvas.cpp \
     main.cpp \
+    monodecoder.cpp \
     ntscdecoder.cpp \
     opticalflow.cpp \
     palcolour.cpp \
@@ -39,6 +40,7 @@ HEADERS += \
     decoderpool.h \
     framecanvas.h \
     iirfilter.h \
+    monodecoder.h \
     ntscdecoder.h \
     opticalflow.h \
     palcolour.h \

--- a/tools/ld-chroma-decoder/main.cpp
+++ b/tools/ld-chroma-decoder/main.cpp
@@ -34,6 +34,7 @@
 #include "lddecodemetadata.h"
 
 #include "comb.h"
+#include "monodecoder.h"
 #include "ntscdecoder.h"
 #include "palcolour.h"
 #include "paldecoder.h"
@@ -146,7 +147,7 @@ int main(int argc, char *argv[])
 
     // Option to select which decoder to use (-f)
     QCommandLineOption decoderOption(QStringList() << "f" << "decoder",
-                                     QCoreApplication::translate("main", "Decoder to use (pal2d, transform2d, transform3d, ntsc2d, ntsc3d; default automatic)"),
+                                     QCoreApplication::translate("main", "Decoder to use (pal2d, transform2d, transform3d, ntsc2d, ntsc3d, mono; default automatic)"),
                                      QCoreApplication::translate("main", "decoder"));
     parser.addOption(decoderOption);
 
@@ -358,6 +359,8 @@ int main(int argc, char *argv[])
     } else if (decoderName == "ntsc3d") {
         combConfig.use3D = true;
         decoder.reset(new NtscDecoder(combConfig));
+    } else if (decoderName == "mono") {
+        decoder.reset(new MonoDecoder);
     } else {
         qCritical() << "Unknown decoder " << decoderName;
         return -1;

--- a/tools/ld-chroma-decoder/monodecoder.cpp
+++ b/tools/ld-chroma-decoder/monodecoder.cpp
@@ -1,0 +1,97 @@
+/************************************************************************
+
+    monodecoder.cpp
+
+    ld-chroma-decoder - Colourisation filter for ld-decode
+    Copyright (C) 2019 Adam Sampson
+
+    This file is part of ld-decode-tools.
+
+    ld-chroma-decoder is free software: you can redistribute it and/or
+    modify it under the terms of the GNU General Public License as
+    published by the Free Software Foundation, either version 3 of the
+    License, or (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+************************************************************************/
+
+#include "monodecoder.h"
+
+#include "comb.h"
+#include "decoderpool.h"
+#include "palcolour.h"
+
+bool MonoDecoder::configure(const LdDecodeMetaData::VideoParameters &videoParameters) {
+    // This decoder works for both PAL and NTSC.
+    // Get the active line range from either Comb or PalColour.
+    qint32 firstActiveLine, lastActiveLine;
+    if (videoParameters.isSourcePal) {
+        PalColour::Configuration palConfig;
+        firstActiveLine = palConfig.firstActiveLine;
+        lastActiveLine = palConfig.lastActiveLine;
+    } else {
+        Comb::Configuration combConfig;
+        firstActiveLine = combConfig.firstActiveLine;
+        lastActiveLine = combConfig.lastActiveLine;
+    }
+
+    // Compute cropping parameters
+    setVideoParameters(config, videoParameters, firstActiveLine, lastActiveLine);
+
+    return true;
+}
+
+QThread *MonoDecoder::makeThread(QAtomicInt& abort, DecoderPool& decoderPool) {
+    return new MonoThread(abort, decoderPool, config);
+}
+
+MonoThread::MonoThread(QAtomicInt& _abort, DecoderPool& _decoderPool,
+                     const MonoDecoder::Configuration &_config, QObject *parent)
+    : DecoderThread(_abort, _decoderPool, parent), config(_config)
+{
+    // Resize and clear the output buffer
+    const qint32 frameHeight = (config.videoParameters.fieldHeight * 2) - 1;
+    outputFrame.resize(config.videoParameters.fieldWidth * frameHeight * 6);
+    outputFrame.fill(0);
+}
+
+void MonoThread::decodeFrames(const QVector<SourceField> &inputFields, qint32 startIndex, qint32 endIndex,
+                             QVector<QByteArray> &outputFrames)
+{
+    // Work out black-white scaling factors
+    const LdDecodeMetaData::VideoParameters &videoParameters = config.videoParameters;
+    const quint16 blackOffset = videoParameters.black16bIre;
+    const double whiteScale = 65535.0 / (videoParameters.white16bIre - videoParameters.black16bIre);
+
+    for (qint32 fieldIndex = startIndex, frameIndex = 0; fieldIndex < endIndex; fieldIndex += 2, frameIndex++) {
+        // Interlace the active lines of the two input fields to produce an output frame
+        for (qint32 y = config.firstActiveLine; y < config.lastActiveLine; y++) {
+            const QByteArray &inputFieldData = (y % 2) == 0 ? inputFields[fieldIndex].data : inputFields[fieldIndex + 1].data;
+
+            // Each quint16 input becomes three quint16 outputs
+            const quint16 *inputLine = reinterpret_cast<const quint16 *>(inputFieldData.data())
+                                       + ((y / 2) * videoParameters.fieldWidth);
+            quint16 *outputLine =      reinterpret_cast<quint16 *>(outputFrame.data())
+                                       + (y * videoParameters.fieldWidth * 3);
+
+            for (qint32 x = videoParameters.activeVideoStart; x < videoParameters.activeVideoEnd; x++) {
+                const quint16 value = static_cast<quint16>(qBound(0.0, (inputLine[x] - blackOffset) * whiteScale, 65535.0));
+
+                const qint32 outputPos = x * 3;
+                outputLine[outputPos] = value;
+                outputLine[outputPos + 1] = value;
+                outputLine[outputPos + 2] = value;
+            }
+        }
+
+        // Crop the frame to just the active area
+        outputFrames[frameIndex] = MonoDecoder::cropOutputFrame(config, outputFrame);
+    }
+}

--- a/tools/ld-chroma-decoder/monodecoder.h
+++ b/tools/ld-chroma-decoder/monodecoder.h
@@ -1,0 +1,71 @@
+/************************************************************************
+
+    monodecoder.h
+
+    ld-chroma-decoder - Colourisation filter for ld-decode
+    Copyright (C) 2019 Adam Sampson
+
+    This file is part of ld-decode-tools.
+
+    ld-chroma-decoder is free software: you can redistribute it and/or
+    modify it under the terms of the GNU General Public License as
+    published by the Free Software Foundation, either version 3 of the
+    License, or (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+************************************************************************/
+
+#ifndef MONODECODER_H
+#define MONODECODER_H
+
+#include <QObject>
+#include <QAtomicInt>
+#include <QThread>
+#include <QDebug>
+
+#include "lddecodemetadata.h"
+#include "sourcevideo.h"
+
+#include "decoder.h"
+#include "sourcefield.h"
+
+class DecoderPool;
+
+// Decoder that passes all input through as luma, for purely monochrome sources
+class MonoDecoder : public Decoder {
+public:
+    bool configure(const LdDecodeMetaData::VideoParameters &videoParameters) override;
+    QThread *makeThread(QAtomicInt& abort, DecoderPool& decoderPool) override;
+
+private:
+    Configuration config;
+};
+
+class MonoThread : public DecoderThread
+{
+    Q_OBJECT
+public:
+    explicit MonoThread(QAtomicInt &abort, DecoderPool &decoderPool,
+                       const MonoDecoder::Configuration &config,
+                       QObject *parent = nullptr);
+
+protected:
+    void decodeFrames(const QVector<SourceField> &inputFields, qint32 startIndex, qint32 endIndex,
+                      QVector<QByteArray> &outputFrames) override;
+
+private:
+    // Settings
+    const MonoDecoder::Configuration &config;
+
+    // The frame being assembled
+    QByteArray outputFrame;
+};
+
+#endif // MONODECODER


### PR DESCRIPTION
This decoder works with both PAL and NTSC, and passes the entire signal through as luma. This is intended for sources that are entirely monochrome to start with. It's distinct from the existing --blackandwhite option, which separates chroma as usual and then discards it.

Results will be considerably sharper than ntsc2d/pal2d with --blackandwhite, and noisier as a result -- but you can address that with post-processing.