### PR TITLE
Fix ld-analyse crash on exit while freeing QCharts

### DIFF
--- a/tools/ld-analyse/dropoutanalysisdialog.cpp
+++ b/tools/ld-analyse/dropoutanalysisdialog.cpp
@@ -32,7 +32,7 @@ DropoutAnalysisDialog::DropoutAnalysisDialog(QWidget *parent) :
     ui->setupUi(this);
     setWindowFlags(Qt::Window);
 
-    isFirstRun = true;
+    chartOwnsContents = false;
     maxY = 0;
 
     // Set up the chart view
@@ -45,23 +45,32 @@ DropoutAnalysisDialog::DropoutAnalysisDialog(QWidget *parent) :
 
 DropoutAnalysisDialog::~DropoutAnalysisDialog()
 {
+    removeChartContents();
     delete ui;
 }
 
 // Get ready for an update
 void DropoutAnalysisDialog::startUpdate()
 {
-    if (!isFirstRun) {
-        chart.removeAxis(&axisX);
-        chart.removeAxis(&axisY);
-        chart.removeSeries(&qLineSeries);
-    } else isFirstRun = false;
+    removeChartContents();
     qLineSeries.clear();
 
     // Create the QLineSeries
     qLineSeries.setColor(Qt::blue);
 
     maxY = 0;
+}
+
+// Remove the axes and series from the chart, giving ownership back to this object
+void DropoutAnalysisDialog::removeChartContents()
+{
+    if (!chartOwnsContents) return;
+
+    chart.removeAxis(&axisX);
+    chart.removeAxis(&axisY);
+    chart.removeSeries(&qLineSeries);
+
+    chartOwnsContents = false;
 }
 
 // Add a data point to the chart
@@ -101,6 +110,9 @@ void DropoutAnalysisDialog::finishUpdate(qint32 numberOfFields, qint32 fieldsPer
 
     // Attach the series to the chart
     chart.addSeries(&qLineSeries);
+
+    // The chart now owns the axes and series
+    chartOwnsContents = true;
 
     // Attach the axis to the QLineSeries
     qLineSeries.attachAxis(&axisX);

--- a/tools/ld-analyse/dropoutanalysisdialog.h
+++ b/tools/ld-analyse/dropoutanalysisdialog.h
@@ -52,6 +52,8 @@ private slots:
     void on_reset_pushButton_clicked();
 
 private:
+    void removeChartContents();
+
     Ui::DropoutAnalysisDialog *ui;
     QChartView chartView;
     QLineSeries qLineSeries;
@@ -60,8 +62,7 @@ private:
     QValueAxis axisY;
     qreal maxY;
 
-    bool isFirstRun;
-
+    bool chartOwnsContents;
 };
 
 #endif // DROPOUTANALYSISDIALOG_H

--- a/tools/ld-analyse/snranalysisdialog.cpp
+++ b/tools/ld-analyse/snranalysisdialog.cpp
@@ -32,7 +32,7 @@ SnrAnalysisDialog::SnrAnalysisDialog(QWidget *parent) :
     ui->setupUi(this);
     setWindowFlags(Qt::Window);
 
-    isFirstRun = true;
+    chartOwnsContents = false;
     maxSnr = 0;
     minSnr = 1000;
 
@@ -46,18 +46,14 @@ SnrAnalysisDialog::SnrAnalysisDialog(QWidget *parent) :
 
 SnrAnalysisDialog::~SnrAnalysisDialog()
 {
+    removeChartContents();
     delete ui;
 }
 
 // Get ready for an update
 void SnrAnalysisDialog::startUpdate()
 {
-    if (!isFirstRun) {
-        chart.removeAxis(&axisX);
-        chart.removeAxis(&axisY);
-        chart.removeSeries(&blackQLineSeries);
-        chart.removeSeries(&whiteQLineSeries);
-    } else isFirstRun = false;
+    removeChartContents();
     blackQLineSeries.clear();
     whiteQLineSeries.clear();
 
@@ -67,6 +63,19 @@ void SnrAnalysisDialog::startUpdate()
 
     maxSnr = 0;
     minSnr = 1000;
+}
+
+// Remove the axes and series from the chart, giving ownership back to this object
+void SnrAnalysisDialog::removeChartContents()
+{
+    if (!chartOwnsContents) return;
+
+    chart.removeAxis(&axisX);
+    chart.removeAxis(&axisY);
+    chart.removeSeries(&blackQLineSeries);
+    chart.removeSeries(&whiteQLineSeries);
+
+    chartOwnsContents = false;
 }
 
 // Add a data point to the chart
@@ -111,6 +120,9 @@ void SnrAnalysisDialog::finishUpdate(qint32 numberOfFields, qint32 fieldsPerData
     // Attach the series to the chart
     chart.addSeries(&blackQLineSeries);
     chart.addSeries(&whiteQLineSeries);
+
+    // The chart now owns the axes and series
+    chartOwnsContents = true;
 
     // Attach the axis to the QLineSeries
     blackQLineSeries.attachAxis(&axisX);

--- a/tools/ld-analyse/snranalysisdialog.h
+++ b/tools/ld-analyse/snranalysisdialog.h
@@ -52,6 +52,8 @@ private slots:
     void on_whiteSNR_checkBox_clicked();
 
 private:
+    void removeChartContents();
+
     Ui::SnrAnalysisDialog *ui;
     QChartView chartView;
     QLineSeries blackQLineSeries;
@@ -60,7 +62,7 @@ private:
     QValueAxis axisX;
     QValueAxis axisY;
 
-    bool isFirstRun;
+    bool chartOwnsContents;
     qreal maxSnr;
     qreal minSnr;
 };


### PR DESCRIPTION
QChart::addAxis and QChart::addSeries take ownership of the pointers they're given. However, in the dropout and SNR dialog code, the pointers being used are to member variables of the dialog classes -- which caused a crash when QChart's destructor tried to free the axes and series that it thought it had ownership of:

```
=================================================================
==16023==ERROR: AddressSanitizer: attempting free on address which was not malloc()-ed: 0x61100020ed70 in thread T0
    #0 0x7f10bf743585 in operator delete(void*, unsigned long) /src/devel/gcc/work/gcc-9.2.0/libsanitizer/asan/asan_new_delete.cc:177
    #1 0x7f10be91318c in QtCharts::ChartDataSet::deleteAllSeries() (/gar/lib/libQt5Charts.so.5+0xb718c)
    #2 0x7f10be9135a6 in QtCharts::ChartDataSet::~ChartDataSet() (/gar/lib/libQt5Charts.so.5+0xb75a6)
    #3 0x7f10be9135d8 in QtCharts::ChartDataSet::~ChartDataSet() (/gar/lib/libQt5Charts.so.5+0xb75d8)
    #4 0x7f10be91e5f0 in QtCharts::QChart::~QChart() (/gar/lib/libQt5Charts.so.5+0xc25f0)
    #5 0x4bcd3a in DropoutAnalysisDialog::~DropoutAnalysisDialog() /home/ats/src/ld-decode/tools/ld-analyse/dropoutanalysisdialog.cpp:46
    #6 0x4bcd78 in DropoutAnalysisDialog::~DropoutAnalysisDialog() /home/ats/src/ld-decode/tools/ld-analyse/dropoutanalysisdialog.cpp:49
    #7 0x7f10bd8916c7 in QObjectPrivate::deleteChildren() (/gar/lib/libQt5Core.so.5+0x2e46c7)
    #8 0x7f10be365dd0 in QWidget::~QWidget() (/gar/lib/libQt5Widgets.so.5+0x1d5dd0)
    #9 0x42f2db in MainWindow::~MainWindow() /home/ats/src/ld-decode/tools/ld-analyse/mainwindow.cpp:87
    #10 0x4199be in main /home/ats/src/ld-decode/tools/ld-analyse/main.cpp:119
    #11 0x7f10bd02cdea in __libc_start_main ../csu/libc-start.c:308
    #12 0x4214e9 in _start (/home/ats/src/ld-decode/tools/ld-analyse/ld-analyse+0x4214e9)

0x61100020ed70 is located 112 bytes inside of 256-byte region [0x61100020ed00,0x61100020ee00)
allocated by thread T0 here:
    #0 0x7f10bf7420ff in operator new(unsigned long) /src/devel/gcc/work/gcc-9.2.0/libsanitizer/asan/asan_new_delete.cc:104
    #1 0x42d4cc in MainWindow::MainWindow(QString, QWidget*) /home/ats/src/ld-decode/tools/ld-analyse/mainwindow.cpp:38
    #2 0x419994 in main /home/ats/src/ld-decode/tools/ld-analyse/main.cpp:119

SUMMARY: AddressSanitizer: bad-free /src/devel/gcc/work/gcc-9.2.0/libsanitizer/asan/asan_new_delete.cc:177 in operator delete(void*, unsigned long)
==16023==ABORTING
```

Avoid this by explicitly taking ownership back in the dialogues' destructors.