### PR TITLE
Fix problems with static constexpr on old versions of Clang

### DIFF
--- a/tools/ld-chroma-decoder/decoderpool.cpp
+++ b/tools/ld-chroma-decoder/decoderpool.cpp
@@ -24,6 +24,10 @@
 
 #include "decoderpool.h"
 
+// Definitions of static constexpr data members, for compatibility with
+// pre-C++17 compilers
+constexpr qint32 DecoderPool::DEFAULT_BATCH_SIZE;
+
 DecoderPool::DecoderPool(Decoder &_decoder, QString _inputFileName,
                          LdDecodeMetaData &_ldDecodeMetaData, QString _outputFileName,
                          qint32 _startFrame, qint32 _length, qint32 _maxThreads)

--- a/tools/ld-chroma-decoder/transformpal2d.cpp
+++ b/tools/ld-chroma-decoder/transformpal2d.cpp
@@ -42,6 +42,15 @@
     site (http://www.jim-easterbrook.me.uk/pal/).
  */
 
+// Definitions of static constexpr data members, for compatibility with
+// pre-C++17 compilers
+constexpr qint32 TransformPal2D::YTILE;
+constexpr qint32 TransformPal2D::HALFYTILE;
+constexpr qint32 TransformPal2D::XTILE;
+constexpr qint32 TransformPal2D::HALFXTILE;
+constexpr qint32 TransformPal2D::YCOMPLEX;
+constexpr qint32 TransformPal2D::XCOMPLEX;
+
 // Compute one value of the window function, applied to the data blocks before
 // the FFT to reduce edge effects. This is a symmetrical raised-cosine
 // function, which means that the overlapping inverse-FFT blocks can be summed

--- a/tools/ld-chroma-decoder/transformpal3d.cpp
+++ b/tools/ld-chroma-decoder/transformpal3d.cpp
@@ -45,6 +45,18 @@
     site (http://www.jim-easterbrook.me.uk/pal/).
  */
 
+// Definitions of static constexpr data members, for compatibility with
+// pre-C++17 compilers
+constexpr qint32 TransformPal3D::ZTILE;
+constexpr qint32 TransformPal3D::HALFZTILE;
+constexpr qint32 TransformPal3D::YTILE;
+constexpr qint32 TransformPal3D::HALFYTILE;
+constexpr qint32 TransformPal3D::XTILE;
+constexpr qint32 TransformPal3D::HALFXTILE;
+constexpr qint32 TransformPal3D::ZCOMPLEX;
+constexpr qint32 TransformPal3D::YCOMPLEX;
+constexpr qint32 TransformPal3D::XCOMPLEX;
+
 // Compute one value of the window function, applied to the data blocks before
 // the FFT to reduce edge effects. This is a symmetrical raised-cosine
 // function, which means that the overlapping inverse-FFT blocks can be summed


### PR DESCRIPTION
Prior to C++17, static constexpr data member declarations in a class needed to have a separate definition somewhere in the program, so compiling ld-chroma-decoder with Clang 3.8 produced unresolved symbols.

C++17 introduced the idea of inline data members that don't need a separate definition, and made static constexpr members implicitly inline, which matches the existing behaviour of GCC and more recent versions of Clang. Having a separate definition is now deprecated, so this may result in compiler warnings at some point in the future.