### PR TITLE
Configurable chroma gain, and add ld-chroma-encoder

### DIFF
--- a/tools/.gitignore
+++ b/tools/.gitignore
@@ -42,6 +42,7 @@ target_wrapper.*
 # QtCreator CMake
 CMakeLists.txt.user*
 /ld-analyse/ld-analyse
+/ld-chroma-decoder/encoder/ld-chroma-encoder
 /ld-chroma-decoder/ld-chroma-decoder
 /ld-chroma-decoder/testfilter/testfilter
 /ld-dropout-correct/ld-dropout-correct

--- a/tools/ld-chroma-decoder/encoder/encoder.pro
+++ b/tools/ld-chroma-decoder/encoder/encoder.pro
@@ -1,0 +1,34 @@
+QT -= gui
+
+CONFIG += c++11 console
+CONFIG -= app_bundle
+
+TARGET = ld-chroma-encoder
+
+# The following define makes your compiler emit warnings if you use
+# any feature of Qt which as been marked deprecated (the exact warnings
+# depend on your compiler). Please consult the documentation of the
+# deprecated API in order to know how to port your code away from it.
+DEFINES += QT_DEPRECATED_WARNINGS
+
+# You can also make your code fail to compile if you use deprecated APIs.
+# In order to do so, uncomment the following line.
+# You can also select to disable deprecated APIs only up to a certain version of Qt.
+#DEFINES += QT_DISABLE_DEPRECATED_BEFORE=0x060000    # disables all the APIs deprecated before Qt 6.0.0
+
+SOURCES += \
+    main.cpp \
+    palencoder.cpp \
+    ../../library/tbc/lddecodemetadata.cpp
+
+HEADERS += \
+    palencoder.h \
+    ../../library/tbc/lddecodemetadata.h
+
+# Add external includes to the include path
+INCLUDEPATH += ../../library/tbc
+
+# Default rules for deployment.
+qnx: target.path = /tmp/$${TARGET}/bin
+else: unix:!android: target.path = /usr/local/bin/
+!isEmpty(target.path): INSTALLS += target

--- a/tools/ld-chroma-decoder/encoder/main.cpp
+++ b/tools/ld-chroma-decoder/encoder/main.cpp
@@ -1,0 +1,185 @@
+/************************************************************************
+
+    main.cpp
+
+    ld-chroma-encoder - PAL encoder for testing
+    Copyright (C) 2019 Adam Sampson
+
+    This file is part of ld-decode-tools.
+
+    ld-chroma-decoder is free software: you can redistribute it and/or
+    modify it under the terms of the GNU General Public License as
+    published by the Free Software Foundation, either version 3 of the
+    License, or (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+************************************************************************/
+
+#include <QCoreApplication>
+#include <QDebug>
+#include <QFile>
+#include <QtGlobal>
+#include <QCommandLineParser>
+#include <cstdio>
+
+#include "lddecodemetadata.h"
+
+#include "palencoder.h"
+
+// Global for debug output
+static bool showDebug = false;
+
+// Global for quiet mode (suppress info and warning messages)
+static bool showOutput = true;
+
+// Qt debug message handler
+void debugOutputHandler(QtMsgType type, const QMessageLogContext &context, const QString &msg)
+{
+    // Use:
+    // context.file - to show the filename
+    // context.line - to show the line number
+    // context.function - to show the function name
+
+    QByteArray localMsg = msg.toLocal8Bit();
+    switch (type) {
+    case QtDebugMsg: // These are debug messages meant for developers
+        if (showDebug) {
+            // If the code was compiled as 'release' the context.file will be NULL
+            if (context.file != nullptr) fprintf(stderr, "Debug: [%s:%d] %s\n", context.file, context.line, localMsg.constData());
+            else fprintf(stderr, "Debug: %s\n", localMsg.constData());
+        }
+        break;
+    case QtInfoMsg: // These are information messages meant for end-users
+        if (showOutput) {
+            if (context.file != nullptr) fprintf(stderr, "Info: [%s:%d] %s\n", context.file, context.line, localMsg.constData());
+            else fprintf(stderr, "Info: %s\n", localMsg.constData());
+        }
+        break;
+    case QtWarningMsg:
+        if (showOutput) {
+            if (context.file != nullptr) fprintf(stderr, "Warning: [%s:%d] %s\n", context.file, context.line, localMsg.constData());
+            else fprintf(stderr, "Warning: %s\n", localMsg.constData());
+        }
+        break;
+    case QtCriticalMsg:
+        if (context.file != nullptr) fprintf(stderr, "Critical: [%s:%d] %s\n", context.file, context.line, localMsg.constData());
+        else fprintf(stderr, "Critical: %s\n", localMsg.constData());
+        break;
+    case QtFatalMsg:
+        if (context.file != nullptr) fprintf(stderr, "Fatal: [%s:%d] %s\n", context.file, context.line, localMsg.constData());
+        else fprintf(stderr, "Fatal: %s\n", localMsg.constData());
+        abort();
+    }
+}
+
+int main(int argc, char *argv[])
+{
+    // Install the local debug message handler
+    qInstallMessageHandler(debugOutputHandler);
+
+    QCoreApplication a(argc, argv);
+
+    // Set application name and version
+    QCoreApplication::setApplicationName("ld-chroma-encoder");
+    QCoreApplication::setApplicationVersion("1.0");
+    QCoreApplication::setOrganizationDomain("domesday86.com");
+
+    // Set up the command line parser
+    QCommandLineParser parser;
+    parser.setApplicationDescription(
+                "ld-chroma-encoder - PAL encoder for testing\n"
+                "\n"
+                "(c)2019 Adam Sampson\n"
+                "GPLv3 Open-Source - github: https://github.com/happycube/ld-decode");
+    parser.addHelpOption();
+    parser.addVersionOption();
+
+    // -- General options --
+
+    // Option to show debug (-d)
+    QCommandLineOption showDebugOption(QStringList() << "d" << "debug",
+                                       QCoreApplication::translate("main", "Show debug"));
+    parser.addOption(showDebugOption);
+
+    // Option to set quiet mode (-q)
+    QCommandLineOption setQuietOption(QStringList() << "q" << "quiet",
+                                       QCoreApplication::translate("main", "Suppress info and warning messages"));
+    parser.addOption(setQuietOption);
+
+    // -- Positional arguments --
+
+    // Positional argument to specify input video file
+    parser.addPositionalArgument("input", QCoreApplication::translate("main", "Specify input RGB file (- for piped input)"));
+
+    // Positional argument to specify output video file
+    parser.addPositionalArgument("output", QCoreApplication::translate("main", "Specify output TBC file"));
+
+    // Process the command line options and arguments given by the user
+    parser.process(a);
+
+    // Get the options from the parser
+    if (parser.isSet(showDebugOption)) showDebug = true;
+    if (parser.isSet(setQuietOption)) showOutput = false;
+
+    // Get the arguments from the parser
+    QString inputFileName;
+    QString outputFileName;
+    QStringList positionalArguments = parser.positionalArguments();
+    if (positionalArguments.count() == 2) {
+        inputFileName = positionalArguments.at(0);
+        outputFileName = positionalArguments.at(1);
+    } else {
+        // Quit with error
+        qCritical("You must specify the input RGB and output TBC files");
+        return -1;
+    }
+
+    if (inputFileName == outputFileName) {
+        // Quit with error
+        qCritical("Input and output files cannot be the same");
+        return -1;
+    }
+
+    // Open the input file
+    QFile rgbFile(inputFileName);
+    if (inputFileName == "-") {
+        if (!rgbFile.open(stdin, QFile::ReadOnly)) {
+            qCritical("Cannot open stdin");
+            return -1;
+        }
+    } else {
+        if (!rgbFile.open(QFile::ReadOnly)) {
+            qCritical() << "Cannot open input file:" << inputFileName;
+            return -1;
+        }
+    }
+
+    // Open the output file
+    QFile tbcFile(outputFileName);
+    if (!tbcFile.open(QFile::WriteOnly)) {
+        qCritical() << "Cannot open output file:" << outputFileName;
+        return -1;
+    }
+
+    // Encode the data
+    LdDecodeMetaData metaData;
+    PALEncoder encoder(rgbFile, tbcFile, metaData);
+    if (!encoder.encode()) {
+        return -1;
+    }
+
+    // Write the metadata
+    if (!metaData.write(outputFileName + ".json")) {
+        return -1;
+    }
+
+    // Quit with success
+    return 0;
+}

--- a/tools/ld-chroma-decoder/encoder/palencoder.cpp
+++ b/tools/ld-chroma-decoder/encoder/palencoder.cpp
@@ -1,0 +1,314 @@
+/************************************************************************
+
+    palencoder.cpp
+
+    ld-chroma-encoder - PAL encoder for testing
+    Copyright (C) 2019 Adam Sampson
+
+    This file is part of ld-decode-tools.
+
+    ld-chroma-decoder is free software: you can redistribute it and/or
+    modify it under the terms of the GNU General Public License as
+    published by the Free Software Foundation, either version 3 of the
+    License, or (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+************************************************************************/
+
+/*!
+    \class PALEncoder
+
+    This is a simplistic PAL encoder for decoder testing.
+
+    The output includes the colourburst and encoded active region, with the
+    reference carrier phase progressing appropriately over the 4-frame
+    sequence. It doesn't include sync pulses or colourburst suppression
+    (because ld-chroma-decoder doesn't currently need them), and the code aims
+    to be accurate rather than fast.
+
+    References below are to "Digital Video and HDTV Algorithms and Interfaces"
+    by Charles Poynton, 2003, first edition, ISBN 1-55860-792-7. Later editions
+    have less material about analogue video standards.
+ */
+
+#include "palencoder.h"
+
+#include <cmath>
+
+PALEncoder::PALEncoder(QFile &_rgbFile, QFile &_tbcFile, LdDecodeMetaData &_metaData)
+    : rgbFile(_rgbFile), tbcFile(_tbcFile), metaData(_metaData)
+{
+    // PAL subcarrier frequency [Poynton p529]
+    fSC = 4433618.75;
+
+    // Initialise video parameters based on ld-decode's usual output.
+    // numberOfSequentialFields will be computed automatically.
+    videoParameters.isSourcePal = true;
+    videoParameters.colourBurstStart = 98;
+    videoParameters.colourBurstEnd = 138;
+    videoParameters.activeVideoStart = 185;
+    videoParameters.activeVideoEnd = 1107;
+    videoParameters.white16bIre = 54016;
+    videoParameters.black16bIre = 16384;
+    videoParameters.fieldWidth = 1135;
+    videoParameters.fieldHeight = 313;
+    // If you change the sample rate, you will also need to recompute the
+    // filter coefficients below.
+    videoParameters.sampleRate = 17734375;
+    // fsc in this struct is an integer, so it's not precise for PAL; the code
+    // below uses fSC instead.
+    videoParameters.fsc = 4433618;
+    videoParameters.isMapped = false;
+
+    // Initialise active region dimensions, based on ld-chroma-decoder's usual output.
+    activeWidth = 928;
+    activeLeft = ((videoParameters.activeVideoStart + videoParameters.activeVideoEnd) / 2) - (activeWidth / 2);
+    activeTop = 44;
+    activeHeight = 620 - activeTop;
+
+    // Resize the input buffer.
+    // The RGB data is triples of 16-bit unsigned numbers in native byte order.
+    rgbFrame.resize(activeWidth * activeHeight * 3 * 2);
+
+    // Resize the output buffers.
+    Y.resize(videoParameters.fieldWidth);
+    U.resize(videoParameters.fieldWidth);
+    V.resize(videoParameters.fieldWidth);
+}
+
+bool PALEncoder::encode()
+{
+    // Process frames until EOF
+    qint32 numFrames = 0;
+    while (true) {
+        qint32 result = encodeFrame(numFrames);
+        if (result == -1) {
+            return false;
+        } else if (result == 0) {
+            break;
+        }
+        numFrames++;
+    }
+
+    // Store video parameters, now we've generated all the fields
+    metaData.setVideoParameters(videoParameters);
+
+    return true;
+}
+
+// Read one frame from the input, and write two fields to the output.
+// Returns 0 on EOF, 1 on success; on failure, prints an error and returns -1.
+qint32 PALEncoder::encodeFrame(qint32 frameNo)
+{
+    // Read the input frame
+    qint64 remainBytes = rgbFrame.size();
+    qint64 posBytes = 0;
+    while (remainBytes > 0) {
+        qint64 count = rgbFile.read(rgbFrame.data() + posBytes, remainBytes);
+        if (count == 0 && remainBytes == rgbFrame.size()) {
+            // EOF at the start of a frame
+            return 0;
+        } else if (count == 0) {
+            qCritical() << "Unexpected end of input file";
+            return -1;
+        } else if (count < 0) {
+            qCritical() << "Error reading from input file";
+            return -1;
+        }
+        remainBytes -= count;
+        posBytes += count;
+    }
+
+    // Write the two fields -- even-numbered lines, then odd-numbered lines.
+    // In a PAL TBC file, the first field is the one that starts with the
+    // half-line (i.e. frame line 44, when counting from 0).
+    if (!encodeField(frameNo * 2)) {
+        return -1;
+    }
+    if (!encodeField((frameNo * 2) + 1)) {
+        return -1;
+    }
+
+    return 1;
+}
+
+// Encode one field from rgbFrame to the output.
+// Returns true on success; on failure, prints an error and returns false.
+bool PALEncoder::encodeField(qint32 fieldNo)
+{
+    const qint32 lineOffset = fieldNo % 2;
+
+    // TBC data is unsigned 16-bit values in native byte order
+    QVector<quint16> outputLine(videoParameters.fieldWidth);
+
+    for (qint32 frameLine = 0; frameLine < 2 * videoParameters.fieldHeight; frameLine++) {
+        // Skip lines that aren't in this field
+        if ((frameLine % 2) != lineOffset) {
+            continue;
+        }
+
+        // Fill the line with black
+        outputLine.fill(videoParameters.black16bIre);
+
+        // Encode the line
+        const quint16 *rgbData = nullptr;
+        if (frameLine >= activeTop && frameLine < (activeTop + activeHeight)) {
+            rgbData = reinterpret_cast<const quint16 *>(rgbFrame.data()) + ((frameLine - activeTop) * activeWidth * 3);
+        }
+        encodeLine(fieldNo, frameLine, rgbData, outputLine);
+
+        // Write the line to the TBC file
+        const char *outputData = reinterpret_cast<const char *>(outputLine.data());
+        qint64 remainBytes = outputLine.size() * 2;
+        qint64 posBytes = 0;
+        while (remainBytes > 0) {
+            qint64 count = tbcFile.write(outputData + posBytes, remainBytes);
+            if (count < 0) {
+                qCritical() << "Error writing to output file";
+                return false;
+            }
+            remainBytes -= count;
+            posBytes += count;
+        }
+    }
+
+    // Generate field metadata
+    LdDecodeMetaData::Field fieldData;
+    fieldData.isFirstField = (fieldNo % 2) == 0;
+    fieldData.syncConf = 100;
+    // Burst peak-to-peak amplitude is 3/7 of black-white range
+    fieldData.medianBurstIRE = 100.0 * (3.0 / 7.0) / 2.0;
+    fieldData.fieldPhaseID = 0;
+    fieldData.audioSamples = 0;
+    metaData.appendField(fieldData);
+
+    return true;
+}
+
+// Generate a gate waveform with raised-cosine transitions, with 50% points at given start and end times
+static double raisedCosineGate(double t, double startTime, double endTime, double halfRiseTime)
+{
+    if (t < startTime - halfRiseTime) {
+        return 0.0;
+    } else if (t < startTime + halfRiseTime) {
+        return 0.5 + (0.5 * sin((M_PI / 2.0) * ((t - startTime) / halfRiseTime)));
+    } else if (t < endTime - halfRiseTime) {
+        return 1.0;
+    } else if (t < endTime + halfRiseTime) {
+        return 0.5 - (0.5 * sin((M_PI / 2.0) * ((t - endTime) / halfRiseTime)));
+    } else {
+        return 0.0;
+    }
+}
+
+// Apply a FIR filter
+static void applyFIRFilter(QVector<double> &data, qint32 filterSize, const double filter[])
+{
+    const qint32 dataSize = data.size();
+    QVector<double> tmp(dataSize);
+
+    for (qint32 i = 0; i < dataSize; i++) {
+        double v = 0.0;
+        for (qint32 j = 0, k = i - (filterSize / 2); j < filterSize; j++, k++) {
+            // Assume data is 0 outside the vector bounds
+            if (k >= 0 && k < dataSize) {
+                v += filter[j] * data[k];
+            }
+        }
+        tmp[i] = v;
+    }
+
+    data = tmp;
+}
+
+// 1.3 MHz low-pass FIR filter.
+// Generated by: scipy.signal.firwin(9, [1.3e6/17734375], window='hamming')
+static constexpr qint32 UV_FILTER_SIZE = 9;
+static constexpr double UV_FILTER[UV_FILTER_SIZE] = {
+    0.01611319, 0.04614531, 0.12141641, 0.19982705, 0.23299608,
+    0.19982705, 0.12141641, 0.04614531, 0.01611319
+};
+
+void PALEncoder::encodeLine(qint32 fieldNo, qint32 frameLine, const quint16 *rgbData, QVector<quint16> &outputLine)
+{
+    // Compute the subcarrier phase at the start of the line. [Poynton p529]
+    // How many complete lines have gone by since the start of the 4-frame sequence?
+    const qint32 fieldID = fieldNo % 8; 
+    const qint32 prevLines = ((fieldID / 2) * 625) + ((fieldID % 2) * 312) + (frameLine / 2);
+    // So how many cycles of the subcarrier have gone by?
+    const double prevCycles = prevLines * 283.7516;
+
+    // Compute the V-switch state and colourburst phase on this line [Poynton p530]
+    const double Vsw = ((frameLine % 4) < 2) ? 1.0 : -1.0;
+    const double burstOffset = Vsw * 135.0 * M_PI / 180.0;
+
+    // Compute colourburst gating profile [Poynton p530]
+    const double halfBurstRiseTime = 300.0e-9 / 2.0;
+    const double burstStartTime = (1.0 * videoParameters.colourBurstStart) / videoParameters.sampleRate;
+    const double burstEndTime = (1.0 * videoParameters.colourBurstEnd) / videoParameters.sampleRate;
+
+    // Compute luma/chroma gating profiles to avoid sharp transitions at the
+    // edge of the active region. The rise times are as suggested in
+    // [Poynton p323], timed so that the video reaches full amplitude at the
+    // start/end of the active region.
+    const double halfLumaRiseTime = 2.0 / (4.0 * fSC);
+    const double halfChromaRiseTime = 3.0 / (4.0 * fSC);
+    const double activeStartTime = ((1.0 * videoParameters.activeVideoStart) / videoParameters.sampleRate) - (2.0 * halfChromaRiseTime);
+    const double activeEndTime = (1.0 * videoParameters.activeVideoEnd) / videoParameters.sampleRate + (2.0 * halfChromaRiseTime);
+
+    // Clear Y'UV buffers. Values in these are scaled so that 0.0 is black and
+    // 1.0 is white.
+    Y.fill(0.0);
+    U.fill(0.0);
+    V.fill(0.0);
+
+    if (rgbData != nullptr) {
+        // Convert the R'G'B' data to Y'UV form [Poynton p337 eq 28.5]
+        for (qint32 i = 0; i < activeWidth; i++) {
+            const double R = rgbData[i * 3]       / 65535.0;
+            const double G = rgbData[(i * 3) + 1] / 65535.0;
+            const double B = rgbData[(i * 3) + 2] / 65535.0;
+
+            const qint32 x = activeLeft + i;
+            Y[x] = (R * 0.299)     + (G * 0.587)     + (B * 0.114);
+            U[x] = (R * -0.147141) + (G * -0.288869) + (B * 0.436010);
+            V[x] = (R * 0.614975)  + (G * -0.514965) + (B * -0.100010);
+        }
+
+        // Low-pass filter U and V to 1.3 MHz [Poynton p342]
+        applyFIRFilter(U, UV_FILTER_SIZE, UV_FILTER);
+        applyFIRFilter(V, UV_FILTER_SIZE, UV_FILTER);
+    }
+
+    for (qint32 x = 0; x < videoParameters.fieldWidth; x++) {
+        // For this sample, compute time relative to start of line, and subcarrier phase
+        const double t = (1.0 * x) / videoParameters.sampleRate;
+        const double a = 2.0 * M_PI * ((fSC * t) + prevCycles);
+
+        // Generate colourburst.
+        // Burst peak-to-peak amplitude is 3/7 of black-white range. [Poynton p532 eq 44.3]
+        const double burst = sin(a + burstOffset) * (3.0 / 7.0) / 2.0;
+
+        // Encode the chroma signal [Poynton p338]
+        const double chroma = (U[x] * sin(a)) + (V[x] * cos(a) * Vsw);
+
+        // Combine everything to make up the composite signal
+        const double burstGate = raisedCosineGate(t, burstStartTime, burstEndTime, halfBurstRiseTime);
+        const double lumaGate = raisedCosineGate(t, activeStartTime, activeEndTime, halfLumaRiseTime);
+        const double chromaGate = raisedCosineGate(t, activeStartTime, activeEndTime, halfChromaRiseTime);
+        const double composite = (burst * burstGate) + qBound(-lumaGate, Y[x], lumaGate) + qBound(-chromaGate, chroma, chromaGate);
+
+        // Scale to a 16-bit output sample and limit the excursion. Some RGB
+        // colours (e.g. strongly saturated yellows) can go outside ld-decode's
+        // usual range.
+        const double scaled = (composite * (videoParameters.white16bIre - videoParameters.black16bIre)) + videoParameters.black16bIre;
+        outputLine[x] = qBound(0.0, scaled, 65535.0);
+    }
+}

--- a/tools/ld-chroma-decoder/encoder/palencoder.h
+++ b/tools/ld-chroma-decoder/encoder/palencoder.h
@@ -1,0 +1,65 @@
+/************************************************************************
+
+    palencoder.h
+
+    ld-chroma-encoder - PAL encoder for testing
+    Copyright (C) 2019 Adam Sampson
+
+    This file is part of ld-decode-tools.
+
+    ld-chroma-decoder is free software: you can redistribute it and/or
+    modify it under the terms of the GNU General Public License as
+    published by the Free Software Foundation, either version 3 of the
+    License, or (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+************************************************************************/
+
+#ifndef PALENCODER_H
+#define PALENCODER_H
+
+#include <QByteArray>
+#include <QFile>
+#include <QVector>
+
+#include "lddecodemetadata.h"
+
+class PALEncoder
+{
+public:
+    PALEncoder(QFile &rgbFile, QFile &tbcFile, LdDecodeMetaData &metaData);
+
+    // Encode RGB stream to PAL.
+    // Returns true on success; on failure, prints an error and returns false.
+    bool encode();
+
+private:
+    qint32 encodeFrame(qint32 frameNo);
+    bool encodeField(qint32 fieldNo);
+    void encodeLine(qint32 fieldNo, qint32 frameLine, const quint16 *rgbData, QVector<quint16> &outputLine);
+
+    QFile &rgbFile;
+    QFile &tbcFile;
+    LdDecodeMetaData &metaData;
+
+    LdDecodeMetaData::VideoParameters videoParameters;
+    double fSC;
+    qint32 activeWidth;
+    qint32 activeHeight;
+    qint32 activeLeft;
+    qint32 activeTop;
+
+    QByteArray rgbFrame;
+    QVector<double> Y;
+    QVector<double> U;
+    QVector<double> V;
+};
+
+#endif

--- a/tools/ld-chroma-decoder/framecanvas.cpp
+++ b/tools/ld-chroma-decoder/framecanvas.cpp
@@ -24,6 +24,10 @@
 
 #include "framecanvas.h"
 
+// Definitions of static constexpr data members, for compatibility with
+// pre-C++17 compilers
+constexpr FrameCanvas::RGB FrameCanvas::green;
+
 FrameCanvas::FrameCanvas(QByteArray &_rgbFrame, const LdDecodeMetaData::VideoParameters &_videoParameters,
                          qint32 _firstActiveLine, qint32 _lastActiveLine)
     : rgbData(reinterpret_cast<quint16 *>(_rgbFrame.data())), rgbSize(_rgbFrame.size() / sizeof(quint16)),
@@ -50,8 +54,6 @@ qint32 FrameCanvas::right()
 {
     return videoParameters.activeVideoEnd;
 }
-
-const FrameCanvas::RGB FrameCanvas::green {0, 65535, 0};
 
 FrameCanvas::RGB FrameCanvas::grey(quint16 value)
 {

--- a/tools/ld-chroma-decoder/framecanvas.h
+++ b/tools/ld-chroma-decoder/framecanvas.h
@@ -48,7 +48,7 @@ public:
     struct RGB {
         quint16 r, g, b;
     };
-    static const RGB green;
+    static constexpr RGB green {0, 65535, 0};
     static RGB grey(quint16 value);
 
     // Plot a pixel

--- a/tools/ld-chroma-decoder/main.cpp
+++ b/tools/ld-chroma-decoder/main.cpp
@@ -171,6 +171,12 @@ int main(int argc, char *argv[])
 
     // -- PAL decoder options --
 
+    // Option to specify chroma gain
+    QCommandLineOption chromaGainOption(QStringList() << "chroma-gain",
+                                        QCoreApplication::translate("main", "PAL: Gain factor applied to U/V chroma components (default 0.735)"),
+                                        QCoreApplication::translate("main", "number"));
+    parser.addOption(chromaGainOption);
+
     // Option to select the Transform PAL filter mode
     QCommandLineOption transformModeOption(QStringList() << "transform-mode",
                                            QCoreApplication::translate("main", "Transform: Filter mode to use (level, threshold; default level)"),
@@ -288,6 +294,16 @@ int main(int argc, char *argv[])
             palConfig.transformMode = TransformPal::levelMode;
             // Quit with error
             qCritical() << "Unknown Transform mode " << name;
+            return -1;
+        }
+    }
+
+    if (parser.isSet(chromaGainOption)) {
+        palConfig.chromaGain = parser.value(chromaGainOption).toDouble();
+
+        if (palConfig.chromaGain <= 0.0) {
+            // Quit with error
+            qCritical("Chroma gain must be greater than 0");
             return -1;
         }
     }

--- a/tools/ld-chroma-decoder/palcolour.cpp
+++ b/tools/ld-chroma-decoder/palcolour.cpp
@@ -513,10 +513,10 @@ void PalColour::decodeLine(const SourceField &inputField, const ChromaSample *ch
         const double rV = line.Vsw * -(qv[i] * line.bp - pv[i] * line.bq) * scaledSaturation;
 
         // Convert YUV to RGB, saturating levels at 0-65535 to prevent overflow.
-        // This conversion is taken from Video Demystified (5th edition) page 18.
-        const double R = qBound(0.0, rY + (1.140 * rV),                65535.0);
-        const double G = qBound(0.0, rY - (0.395 * rU) - (0.581 * rV), 65535.0);
-        const double B = qBound(0.0, rY + (2.032 * rU),                65535.0);
+        // Coefficients from Poynton, "Digital Video and HDTV" first edition, p337 eq 28.6.
+        const double R = qBound(0.0, rY                    + (1.139883 * rV),  65535.0);
+        const double G = qBound(0.0, rY + (-0.394642 * rU) + (-0.580622 * rV), 65535.0);
+        const double B = qBound(0.0, rY + (2.032062 * rU),                     65535.0);
 
         // Pack the data back into the RGB 16/16/16 buffer
         const qint32 pp = i * 3; // 3 words per pixel

--- a/tools/ld-chroma-decoder/palcolour.cpp
+++ b/tools/ld-chroma-decoder/palcolour.cpp
@@ -119,8 +119,7 @@ void PalColour::updateConfiguration(const LdDecodeMetaData::VideoParameters &_vi
     configurationSet = true;
 }
 
-// Private method to build the look up tables
-// must be called by the constructor when the object is created
+// Rebuild the lookup tables based on the configuration
 void PalColour::buildLookUpTables()
 {
     // Generate the reference carrier: quadrature samples of a sine wave at the
@@ -285,6 +284,7 @@ void PalColour::decodeFrames(const QVector<SourceField> &inputFields, qint32 sta
     }
 }
 
+// Decode one field into outputFrame
 void PalColour::decodeField(const SourceField &inputField, const double *chromaData, double chromaGain, QByteArray &outputFrame)
 {
     // Pointer to the composite signal data
@@ -313,6 +313,8 @@ PalColour::LineInfo::LineInfo(qint32 _number)
 {
 }
 
+// Detect the colourburst on a line.
+// Stores the burst details into line.
 void PalColour::detectBurst(LineInfo &line, const quint16 *inputData)
 {
     // Dummy black line, used when the filter needs to look outside the field.
@@ -378,6 +380,10 @@ void PalColour::detectBurst(LineInfo &line, const quint16 *inputData)
     line.burstNorm = qMax(sqrt(line.bp * line.bp + line.bq * line.bq), 130000.0 / 128);
 }
 
+// Decode one line into outputFrame.
+// chromaData (templated, so it can be any numeric type) is the input to
+// the chroma demodulator; this may be the composite signal from
+// inputField, or it may be pre-filtered down to chroma.
 template <typename ChromaSample, bool PREFILTERED_CHROMA>
 void PalColour::decodeLine(const SourceField &inputField, const ChromaSample *chromaData, const LineInfo &line, double chromaGain,
                            QByteArray &outputFrame)

--- a/tools/ld-chroma-decoder/palcolour.cpp
+++ b/tools/ld-chroma-decoder/palcolour.cpp
@@ -60,6 +60,11 @@
     filters with more complex coefficients than the report describes.
  */
 
+// Definitions of static constexpr data members, for compatibility with
+// pre-C++17 compilers
+constexpr qint32 PalColour::MAX_WIDTH;
+constexpr qint32 PalColour::FILTER_SIZE;
+
 PalColour::PalColour(QObject *parent)
     : QObject(parent), configurationSet(false)
 {

--- a/tools/ld-chroma-decoder/palcolour.cpp
+++ b/tools/ld-chroma-decoder/palcolour.cpp
@@ -375,10 +375,12 @@ void PalColour::detectBurst(LineInfo &line, const quint16 *inputData)
     line.bp = (bp - bqo) / 2;
     line.bq = (bq + bpo) / 2;
 
-    // burstNorm normalises bp and bq to 1.
+    // Normalise the magnitude of the bp/bq vector to 1.
     // Kill colour if burst too weak.
     // XXX magic number 130000 !!! check!
-    line.burstNorm = qMax(sqrt(line.bp * line.bp + line.bq * line.bq), 130000.0 / 128);
+    const double burstNorm = qMax(sqrt(line.bp * line.bp + line.bq * line.bq), 130000.0 / 128);
+    line.bp /= burstNorm;
+    line.bq /= burstNorm;
 }
 
 // Decode one line into outputFrame.
@@ -486,7 +488,7 @@ void PalColour::decodeLine(const SourceField &inputField, const ChromaSample *ch
     const double scaledContrast = 65535.0 / (videoParameters.white16bIre - videoParameters.black16bIre);
 
     // Gain for the U/V components
-    const double scaledSaturation = (2.0 / line.burstNorm) * chromaGain;
+    const double scaledSaturation = 2.0 * chromaGain;
 
     for (qint32 i = videoParameters.activeVideoStart; i < videoParameters.activeVideoEnd; i++) {
         // Compute luma by...

--- a/tools/ld-chroma-decoder/palcolour.cpp
+++ b/tools/ld-chroma-decoder/palcolour.cpp
@@ -190,10 +190,10 @@ void PalColour::buildLookUpTables()
 
         // For U/V.
         // 0, 2, 1, 3 are vertical taps 0, +/- 1, +/- 2, +/- 3 (see filter loop below).
-        cfilt[f][0] = 256 * (1 + cos(M_PI * fc   / ca)) / d;
-        cfilt[f][2] = 256 * (1 + cos(M_PI * ff   / ca)) / d;
-        cfilt[f][1] = 256 * (1 + cos(M_PI * fff  / ca)) / d;
-        cfilt[f][3] = 256 * (1 + cos(M_PI * ffff / ca)) / d;
+        cfilt[f][0] = (1 + cos(M_PI * fc   / ca)) / d;
+        cfilt[f][2] = (1 + cos(M_PI * ff   / ca)) / d;
+        cfilt[f][1] = (1 + cos(M_PI * fff  / ca)) / d;
+        cfilt[f][3] = (1 + cos(M_PI * ffff / ca)) / d;
 
         // Each horizontal coefficient is applied to 2 columns (when b == 0,
         // it's the same column twice).
@@ -215,8 +215,8 @@ void PalColour::buildLookUpTables()
         // patterning.
         //
         // 0, 1 are vertical taps 0, +/- 2 (see filter loop below).
-        yfilt[f][0] =       256 * (1 + cos(M_PI * fy   / ya)) / d;
-        yfilt[f][1] = 0.2 * 256 * (1 + cos(M_PI * fffy / ya)) / d;
+        yfilt[f][0] =       (1 + cos(M_PI * fy   / ya)) / d;
+        yfilt[f][1] = 0.2 * (1 + cos(M_PI * fffy / ya)) / d;
 
         ydiv += 2 * (1 * yfilt[f][0] + 2 * 0 + 2 * yfilt[f][1] + 2 * 0);
     }

--- a/tools/ld-chroma-decoder/palcolour.cpp
+++ b/tools/ld-chroma-decoder/palcolour.cpp
@@ -346,10 +346,10 @@ void PalColour::detectBurst(LineInfo &line, const quint16 *inputData)
     // opposite V-switch phase (and a 90 degree subcarrier phase shift).
     double bp = 0, bq = 0, bpo = 0, bqo = 0;
     for (qint32 i = videoParameters.colourBurstStart; i < videoParameters.colourBurstEnd; i++) {
-        bp += ((in0[i] - ((in3[i] + in4[i]) / 2)) / 2) * sine[i];
-        bq += ((in0[i] - ((in3[i] + in4[i]) / 2)) / 2) * cosine[i];
-        bpo += ((in2[i] - in1[i]) / 2) * sine[i];
-        bqo += ((in2[i] - in1[i]) / 2) * cosine[i];
+        bp += ((in0[i] - ((in3[i] + in4[i]) / 2.0)) / 2.0) * sine[i];
+        bq += ((in0[i] - ((in3[i] + in4[i]) / 2.0)) / 2.0) * cosine[i];
+        bpo += ((in2[i] - in1[i]) / 2.0) * sine[i];
+        bqo += ((in2[i] - in1[i]) / 2.0) * cosine[i];
     }
 
     // Normalise the sums above

--- a/tools/ld-chroma-decoder/palcolour.cpp
+++ b/tools/ld-chroma-decoder/palcolour.cpp
@@ -131,7 +131,7 @@ void PalColour::buildLookUpTables()
     //   so we can rotate the chroma samples to put U/V on the right axes
     // refAmpl is the sinewave amplitude.
     refAmpl = 1.28;
-    refNorm = (refAmpl * refAmpl / 2);
+    refNorm = refAmpl * refAmpl / 2;
 
     for (qint32 i = 0; i < videoParameters.fieldWidth; i++) {
         const double rad = 2 * M_PI * i * videoParameters.fsc / videoParameters.sampleRate;
@@ -500,14 +500,14 @@ void PalColour::decodeLine(const SourceField &inputField, const ChromaSample *ch
         // reference phase) backwards by the burst phase (relative to the
         // reference phase), in order to recover U and V. The Vswitch is
         // applied to flip the V-phase on alternate lines for PAL.
-        const double rU =            -((pu[i] * line.bp + qu[i] * line.bq)) * scaledSaturation;
-        const double rV = line.Vsw * -((qv[i] * line.bp - pv[i] * line.bq)) * scaledSaturation;
+        const double rU =            -(pu[i] * line.bp + qu[i] * line.bq) * scaledSaturation;
+        const double rV = line.Vsw * -(qv[i] * line.bp - pv[i] * line.bq) * scaledSaturation;
 
         // Convert YUV to RGB, saturating levels at 0-65535 to prevent overflow.
         // This conversion is taken from Video Demystified (5th edition) page 18.
         const double R = qBound(0.0, rY + (1.140 * rV),                65535.0);
         const double G = qBound(0.0, rY - (0.395 * rU) - (0.581 * rV), 65535.0);
-        const double B = qBound(0.0, rY + (2.032 * rU),                65535.0 );
+        const double B = qBound(0.0, rY + (2.032 * rU),                65535.0);
 
         // Pack the data back into the RGB 16/16/16 buffer
         const qint32 pp = i * 3; // 3 words per pixel

--- a/tools/ld-chroma-decoder/palcolour.h
+++ b/tools/ld-chroma-decoder/palcolour.h
@@ -84,8 +84,7 @@ public:
                       QVector<QByteArray> &outputFrames);
 
     // Maximum frame size, based on PAL
-    static const qint32 MAX_WIDTH = 1135;
-    static const qint32 MAX_HEIGHT = 625;
+    static constexpr qint32 MAX_WIDTH = 1135;
 
 private:
     // Decode one field into outputFrame.
@@ -134,7 +133,7 @@ private:
     // array represents one quarter of a filter. The zeroth horizontal element
     // is included in the sum twice, so the coefficient is halved to
     // compensate. Each filter is (2 * FILTER_SIZE) + 1 elements wide.
-    static const qint32 FILTER_SIZE = 7;
+    static constexpr qint32 FILTER_SIZE = 7;
     double cfilt[FILTER_SIZE + 1][4];
     double yfilt[FILTER_SIZE + 1][2];
 

--- a/tools/ld-chroma-decoder/palcolour.h
+++ b/tools/ld-chroma-decoder/palcolour.h
@@ -113,8 +113,6 @@ private:
 
     // The subcarrier reference signal
     double sine[MAX_WIDTH], cosine[MAX_WIDTH];
-    double refAmpl;
-    double refNorm;
 
     // Coefficients for the three 2D chroma low-pass filters. There are
     // separate filters for U and V, but only the signs differ, so they can

--- a/tools/ld-chroma-decoder/palcolour.h
+++ b/tools/ld-chroma-decoder/palcolour.h
@@ -87,9 +87,6 @@ public:
     static constexpr qint32 MAX_WIDTH = 1135;
 
 private:
-    // Decode one field into outputFrame.
-    void decodeField(const SourceField &inputField, const double *chromaData, double chromaGain, QByteArray &outputFrame);
-
     // Information about a line we're decoding.
     struct LineInfo {
         explicit LineInfo(qint32 number);
@@ -100,14 +97,9 @@ private:
         double burstNorm;
     };
 
-    // Detect the colourburst on a line.
-    // Stores the burst details into line.
+    void buildLookUpTables();
+    void decodeField(const SourceField &inputField, const double *chromaData, double chromaGain, QByteArray &outputFrame);
     void detectBurst(LineInfo &line, const quint16 *inputData);
-
-    // Decode one line into outputFrame.
-    // chromaData (templated, so it can be any numeric type) is the input to
-    // the chroma demodulator; this may be the composite signal from
-    // inputField, or it may be pre-filtered down to chroma.
     template <typename ChromaSample, bool PREFILTERED_CHROMA>
     void decodeLine(const SourceField &inputField, const ChromaSample *chromaData, const LineInfo &line, double chromaGain,
                     QByteArray &outputFrame);
@@ -136,9 +128,6 @@ private:
     static constexpr qint32 FILTER_SIZE = 7;
     double cfilt[FILTER_SIZE + 1][4];
     double yfilt[FILTER_SIZE + 1][2];
-
-    // Method to build the required look-up tables
-    void buildLookUpTables();
 };
 
 #endif // PALCOLOUR_H

--- a/tools/ld-chroma-decoder/palcolour.h
+++ b/tools/ld-chroma-decoder/palcolour.h
@@ -94,7 +94,6 @@ private:
         qint32 number;
         double bp, bq;
         double Vsw;
-        double burstNorm;
     };
 
     void buildLookUpTables();

--- a/tools/ld-chroma-decoder/palcolour.h
+++ b/tools/ld-chroma-decoder/palcolour.h
@@ -108,7 +108,7 @@ private:
     // chromaData (templated, so it can be any numeric type) is the input to
     // the chroma demodulator; this may be the composite signal from
     // inputField, or it may be pre-filtered down to chroma.
-    template <typename ChromaSample, bool useTransformFilter>
+    template <typename ChromaSample, bool PREFILTERED_CHROMA>
     void decodeLine(const SourceField &inputField, const ChromaSample *chromaData, const LineInfo &line, double chromaGain,
                     QByteArray &outputFrame);
 

--- a/tools/ld-chroma-decoder/palcolour.h
+++ b/tools/ld-chroma-decoder/palcolour.h
@@ -56,6 +56,8 @@ public:
 
     struct Configuration {
         bool blackAndWhite = false;
+        // This value is chosen to compensate for typical LaserDisc characteristics
+        double chromaGain = 0.735;
         ChromaFilterMode chromaFilter = palColourFilter;
         TransformPal::TransformMode transformMode = TransformPal::thresholdMode;
         double transformThreshold = 0.4;

--- a/tools/ld-decode-tools.pro
+++ b/tools/ld-decode-tools.pro
@@ -4,6 +4,7 @@ TEMPLATE = subdirs
 SUBDIRS = \
     ld-analyse \
     ld-chroma-decoder \
+    ld-chroma-decoder/encoder \
     ld-chroma-decoder/testfilter \
     ld-combine \
     ld-dropout-correct \


### PR DESCRIPTION
Three things:

- Several simplifications and cleanups to the PALcolour code, having worked out more of the theory behind it.

- The original somewhat-arbitrary chroma gain factor is now set in one place, and there's a --chroma-gain option that lets you override it. The default value is the equivalent of what it was before, so this doesn't visibly change the output. (in practice, the gain is a bit low at the moment for good discs -- it's easy to see this if you look at the RGB values resulting from 75% bars.)

- The new ld-chroma-encoder tool does the opposite of ld-chroma-decoder: it takes an .rgb file and produces a synthetic .tbc file. I've only done PAL for now, but NTSC would be easy to add. It's unlikely to be very useful to end users, but it means you can test ld-chroma-decoder with arbitrary images, and easily compare the original to the decoded result.

We can now have both kinds of test material - Mobile *and* Calendar!

![mobcal2](https://user-images.githubusercontent.com/436317/65193105-d4ed6c80-da71-11e9-9c7e-8999ed8d219c.png)
