### PR TITLE
Don't reject high CAV frame numbers

### DIFF
--- a/lddecode_core.py
+++ b/lddecode_core.py
@@ -2359,6 +2359,9 @@ class LDdecode:
                 self.isCLV = True
                 #logging.info('CLV', mins)
             elif (l & 0xf00000) == 0xf00000: # CAV frame
+                # Ignore the top bit of the first digit, used for PSC
+                l &= 0x7ffff
+
                 fnum = 0
                 for y in range(16, -1, -4):
                     fnum *= 10


### PR DESCRIPTION
The top bit of the first picture number digit is used to signal (the lack of) a picture stop on some discs, so it needs to be masked off before the BCD is decoded in the code added to ld-decode for #332. (tools/library was doing this already so no change is needed there.)

For example, with side 4 of [CC1390L](https://www.lddb.com/laserdisc/06049/CC1390L/This-Is-Spinal-Tap:-Special-Edition), before this fix:

```
file frame 50000 unknown
file frame 50001 unknown
file frame 50002 unknown
file frame 50003 unknown
file frame 50004 unknown
```

And after:

```
file frame 50000 CAV frame 41209
file frame 50001 unknown
file frame 50002 CAV frame 41210
file frame 50003 CAV frame 41211
file frame 50004 CAV frame 41212
```