### PR TITLE
Fix ld-chroma-encoder V-switch generation

### DIFF
--- a/tools/ld-chroma-decoder/encoder/palencoder.cpp
+++ b/tools/ld-chroma-decoder/encoder/palencoder.cpp
@@ -246,7 +246,7 @@ void PALEncoder::encodeLine(qint32 fieldNo, qint32 frameLine, const quint16 *rgb
     const double prevCycles = prevLines * 283.7516;
 
     // Compute the V-switch state and colourburst phase on this line [Poynton p530]
-    const double Vsw = ((frameLine % 4) < 2) ? 1.0 : -1.0;
+    const double Vsw = (prevLines % 2) == 0 ? 1.0 : -1.0;
     const double burstOffset = Vsw * 135.0 * M_PI / 180.0;
 
     // Compute colourburst gating profile [Poynton p530]


### PR DESCRIPTION
As PAL has 625 lines, the V-switch state on the top line should alternate between frames. Without this, the 3D relationships between fields are wrong, and Transform 3D decoding doesn't work.

Poynton doesn't say what the initial state should be at the start of the 4-frame sequence. I'm going with the phase shown in the examples in "Video Demystified" -- positive on the first line of the first field.