### PR TITLE
Further dropout correction improvements

### DIFF
--- a/tools/ld-dropout-correct/dropoutcorrect.h
+++ b/tools/ld-dropout-correct/dropoutcorrect.h
@@ -75,7 +75,7 @@ private:
     QVector<DropOutLocation> setDropOutLocations(QVector<DropOutLocation> dropOuts);
     Replacement findReplacementLine(const QVector<DropOutLocation> &thisFieldDropouts,
                                     const QVector<DropOutLocation> &otherFieldDropouts,
-                                    qint32 dropOutIndex, bool isColourBurst, bool intraField);
+                                    qint32 dropOutIndex, bool thisFieldIsFirst, bool isColourBurst, bool intraField);
     qint32 findPotentialReplacementLine(const QVector<DropOutLocation> &targetDropouts, qint32 targetIndex,
                                         const QVector<DropOutLocation> &sourceDropouts, qint32 sourceOffset, qint32 stepAmount,
                                         qint32 firstActiveFieldLine, qint32 lastActiveFieldLine);

--- a/tools/ld-dropout-correct/dropoutcorrect.h
+++ b/tools/ld-dropout-correct/dropoutcorrect.h
@@ -76,9 +76,11 @@ private:
     Replacement findReplacementLine(const QVector<DropOutLocation> &thisFieldDropouts,
                                     const QVector<DropOutLocation> &otherFieldDropouts,
                                     qint32 dropOutIndex, bool thisFieldIsFirst, bool isColourBurst, bool intraField);
-    qint32 findPotentialReplacementLine(const QVector<DropOutLocation> &targetDropouts, qint32 targetIndex,
-                                        const QVector<DropOutLocation> &sourceDropouts, qint32 sourceOffset, qint32 stepAmount,
-                                        qint32 firstActiveFieldLine, qint32 lastActiveFieldLine);
+    void findPotentialReplacementLine(const QVector<DropOutLocation> &targetDropouts, qint32 targetIndex,
+                                      const QVector<DropOutLocation> &sourceDropouts, bool isSameField,
+                                      qint32 sourceOffset, qint32 stepAmount,
+                                      qint32 firstActiveFieldLine, qint32 lastActiveFieldLine,
+                                      QVector<Replacement> &candidates);
     void correctDropOut(const DropOutLocation &dropOut, const Replacement &replacement, QByteArray &targetField, const QByteArray &sourceField);
 };
 

--- a/tools/ld-dropout-correct/dropoutcorrect.h
+++ b/tools/ld-dropout-correct/dropoutcorrect.h
@@ -60,7 +60,7 @@ private:
     };
 
     struct Replacement {
-        bool isFirstField;
+        bool isSameField;
         qint32 fieldLine;
     };
 
@@ -73,7 +73,9 @@ private:
 
     QVector<DropOutLocation> populateDropoutsVector(LdDecodeMetaData::Field field, bool overCorrect);
     QVector<DropOutLocation> setDropOutLocations(QVector<DropOutLocation> dropOuts);
-    Replacement findReplacementLine(QVector<DropOutLocation>firstFieldDropouts, QVector<DropOutLocation> secondFieldDropouts, qint32 dropOutIndex, bool isColourBurst, bool intraField);
+    Replacement findReplacementLine(const QVector<DropOutLocation> &thisFieldDropouts,
+                                    const QVector<DropOutLocation> &otherFieldDropouts,
+                                    qint32 dropOutIndex, bool isColourBurst, bool intraField);
     qint32 findPotentialReplacementLine(const QVector<DropOutLocation> &targetDropouts, qint32 targetIndex,
                                         const QVector<DropOutLocation> &sourceDropouts, qint32 sourceOffset, qint32 stepAmount,
                                         qint32 firstActiveFieldLine, qint32 lastActiveFieldLine);


### PR DESCRIPTION
Simon spotted that PAL inter-field replacements also had the wrong phase. This isn't very visible in detailed scenes, but it's pretty obvious in areas of smooth colour. Before and after:

![doc-un-on-output](https://user-images.githubusercontent.com/436317/65999963-614a5700-e496-11e9-893a-76be76f4a880.png)
![doc-un-on-output](https://user-images.githubusercontent.com/436317/65999980-68716500-e496-11e9-8aa3-937896d2e61a.png)

Fixing this meant making findReplacementLine aware of which fields it was dealing with. If it's got that information, it can also use it to make slightly better measurements of distances to potential replacements, which results in a noticable improvement for NTSC (where there are twice as many nearby candidates as PAL). Before and after:

![doc-aspen-on-output](https://user-images.githubusercontent.com/436317/66000091-9f477b00-e496-11e9-94f6-7e4401c6b8b7.png)
![doc-aspen-on-output](https://user-images.githubusercontent.com/436317/66000107-a7071f80-e496-11e9-92d1-6ee4f458b170.png)

However, I think overall this produces worse results for detailed PAL scenes, because replacements can now be taken from quite a long way away. We'd probably do better to either interpolate replacements or do some filtering to correct the phase of nearby lines.