### PR TITLE
Use different source lines for luma and chroma in dropout correction

### DIFF
--- a/tools/ld-dropout-correct/dropoutcorrect.cpp
+++ b/tools/ld-dropout-correct/dropoutcorrect.cpp
@@ -100,10 +100,7 @@ void DropOutCorrect::correctField(const QVector<DropOutLocation> &thisFieldDropo
                                   bool thisFieldIsFirst, bool intraField)
 {
     for (qint32 dropoutIndex = 0; dropoutIndex < thisFieldDropouts.size(); dropoutIndex++) {
-        // Don't correct by default
         Replacement replacement;
-        replacement.isSameField = true;
-        replacement.fieldLine = -1;
 
         // Is the current dropout in the colour burst?
         if (thisFieldDropouts[dropoutIndex].location == Location::colourBurst) {
@@ -325,12 +322,10 @@ DropOutCorrect::Replacement DropOutCorrect::findReplacementLine(const QVector<Dr
     qDebug() << (isColourBurst ? "Colourburst" : "Visible video") << "dropout on line"
              << thisFieldDropouts[dropOutIndex].fieldLine << "of" << (thisFieldIsFirst ? "first" : "second") << "field";
 
+    // If no candidate is found, return no replacement
     Replacement replacement;
-    if (candidates.empty()) {
-        // No replacements found -- don't correct it
-        replacement.isSameField = true;
-        replacement.fieldLine = -1;
-    } else {
+
+    if (!candidates.empty()) {
         // Find the candidate with the lowest spatial distance from the dropout
         qint32 lowestDistance = 1000000;
         for (const Replacement &candidate: candidates) {

--- a/tools/ld-dropout-correct/dropoutcorrect.cpp
+++ b/tools/ld-dropout-correct/dropoutcorrect.cpp
@@ -99,34 +99,26 @@ void DropOutCorrect::correctField(const QVector<DropOutLocation> &thisFieldDropo
                                   QByteArray &thisFieldData, const QByteArray &otherFieldData,
                                   bool thisFieldIsFirst, bool intraField)
 {
-    if (thisFieldDropouts.empty()) {
-        // No dropouts in this field -- nothing to do
-        return;
-    }
-
-    // Find replacement lines for this field's dropouts
-    QVector<Replacement> replacementLines;
-    replacementLines.resize(thisFieldDropouts.size());
     for (qint32 dropoutIndex = 0; dropoutIndex < thisFieldDropouts.size(); dropoutIndex++) {
         // Don't correct by default
-        replacementLines[dropoutIndex].fieldLine = -1;
+        Replacement replacement;
+        replacement.isSameField = true;
+        replacement.fieldLine = -1;
 
         // Is the current dropout in the colour burst?
         if (thisFieldDropouts[dropoutIndex].location == Location::colourBurst) {
-            replacementLines[dropoutIndex] = findReplacementLine(thisFieldDropouts, otherFieldDropouts,
-                                                                 dropoutIndex, thisFieldIsFirst, true, intraField);
+            replacement = findReplacementLine(thisFieldDropouts, otherFieldDropouts,
+                                              dropoutIndex, thisFieldIsFirst, true, intraField);
         }
 
         // Is the current dropout in the visible video line?
         if (thisFieldDropouts[dropoutIndex].location == Location::visibleLine) {
-            replacementLines[dropoutIndex] = findReplacementLine(thisFieldDropouts, otherFieldDropouts,
-                                                                 dropoutIndex, thisFieldIsFirst, false, intraField);
+            replacement = findReplacementLine(thisFieldDropouts, otherFieldDropouts,
+                                              dropoutIndex, thisFieldIsFirst, false, intraField);
         }
-    }
 
-    // Correct the data
-    for (qint32 dropoutIndex = 0; dropoutIndex < thisFieldDropouts.size(); dropoutIndex++) {
-        correctDropOut(thisFieldDropouts[dropoutIndex], replacementLines[dropoutIndex], thisFieldData, otherFieldData);
+        // Correct the data
+        correctDropOut(thisFieldDropouts[dropoutIndex], replacement, thisFieldData, otherFieldData);
     }
 }
 

--- a/tools/ld-dropout-correct/dropoutcorrect.h
+++ b/tools/ld-dropout-correct/dropoutcorrect.h
@@ -71,6 +71,10 @@ private:
     LdDecodeMetaData ldDecodeMetaData;
     LdDecodeMetaData::VideoParameters videoParameters;
 
+    void correctField(const QVector<DropOutLocation> &thisFieldDropouts,
+                      const QVector<DropOutLocation> &otherFieldDropouts,
+                      QByteArray &thisFieldData, const QByteArray &otherFieldData,
+                      bool thisFieldIsFirst, bool intraField);
     QVector<DropOutLocation> populateDropoutsVector(LdDecodeMetaData::Field field, bool overCorrect);
     QVector<DropOutLocation> setDropOutLocations(QVector<DropOutLocation> dropOuts);
     Replacement findReplacementLine(const QVector<DropOutLocation> &thisFieldDropouts,

--- a/tools/ld-dropout-correct/dropoutcorrect.h
+++ b/tools/ld-dropout-correct/dropoutcorrect.h
@@ -85,7 +85,8 @@ private:
                                       qint32 sourceOffset, qint32 stepAmount,
                                       qint32 firstActiveFieldLine, qint32 lastActiveFieldLine,
                                       QVector<Replacement> &candidates);
-    void correctDropOut(const DropOutLocation &dropOut, const Replacement &replacement, QByteArray &targetField, const QByteArray &sourceField);
+    void correctDropOut(const DropOutLocation &dropOut, const Replacement &replacement,
+                        QByteArray &thisFieldData, const QByteArray &otherFieldData);
 };
 
 #endif // DROPOUTCORRECT_H

--- a/tools/ld-dropout-correct/dropoutcorrect.h
+++ b/tools/ld-dropout-correct/dropoutcorrect.h
@@ -82,13 +82,15 @@ private:
     QVector<DropOutLocation> setDropOutLocations(QVector<DropOutLocation> dropOuts);
     Replacement findReplacementLine(const QVector<DropOutLocation> &thisFieldDropouts,
                                     const QVector<DropOutLocation> &otherFieldDropouts,
-                                    qint32 dropOutIndex, bool thisFieldIsFirst, bool isColourBurst, bool intraField);
+                                    qint32 dropOutIndex, bool thisFieldIsFirst, bool matchChromaPhase,
+                                    bool isColourBurst, bool intraField);
     void findPotentialReplacementLine(const QVector<DropOutLocation> &targetDropouts, qint32 targetIndex,
                                       const QVector<DropOutLocation> &sourceDropouts, bool isSameField,
                                       qint32 sourceOffset, qint32 stepAmount,
                                       qint32 firstActiveFieldLine, qint32 lastActiveFieldLine,
                                       QVector<Replacement> &candidates);
-    void correctDropOut(const DropOutLocation &dropOut, const Replacement &replacement,
+    void correctDropOut(const DropOutLocation &dropOut,
+                        const Replacement &replacement, const Replacement &chromaReplacement,
                         QByteArray &thisFieldData, const QByteArray &otherFieldData);
 };
 

--- a/tools/ld-dropout-correct/dropoutcorrect.h
+++ b/tools/ld-dropout-correct/dropoutcorrect.h
@@ -60,6 +60,9 @@ private:
     };
 
     struct Replacement {
+        // The default value is no replacement
+        Replacement() : isSameField(true), fieldLine(-1) {}
+
         bool isSameField;
         qint32 fieldLine;
     };

--- a/tools/ld-dropout-correct/ld-dropout-correct.pro
+++ b/tools/ld-dropout-correct/ld-dropout-correct.pro
@@ -18,16 +18,20 @@ SOURCES += \
     correctorpool.cpp \
     main.cpp \
     dropoutcorrect.cpp \
+    ../library/tbc/filters.cpp \
     ../library/tbc/lddecodemetadata.cpp \
     ../library/tbc/sourcevideo.cpp
 
 HEADERS += \
     correctorpool.h \
     dropoutcorrect.h \
+    ../library/filter/firfilter.h \
+    ../library/tbc/filters.h \
     ../library/tbc/lddecodemetadata.h \
     ../library/tbc/sourcevideo.h
 
 # Add external includes to the include path
+INCLUDEPATH += ../library/filter
 INCLUDEPATH += ../library/tbc
 
 # Default rules for deployment.

--- a/tools/library/tbc/filters.cpp
+++ b/tools/library/tbc/filters.cpp
@@ -29,10 +29,9 @@
 #include <array>
 
 // PAL - Filter at Fsc/2 (Fsc = 4433618 (/2 = 2,216,809), sample rate = 17,734,472)
-// 2.2 MHz LPF - 9 Taps
-// from scipy import signal
-// scipy.signal.firwin(5, [2.2e6/17734472], window='hamming')
-//static constexpr std::array<double, 9> palLumaFilterCoeffs {
+// 2.2 MHz LPF - 6 Taps
+// import scipy.signal
+// scipy.signal.firwin(6, [2.2e6/17734472], window='hamming')
 static constexpr std::array<double, 6> palLumaFilterCoeffs {
     0.02516142,  0.13911332,  0.33572527,  0.33572527,  0.13911332,
     0.02516142
@@ -41,9 +40,9 @@ static constexpr std::array<double, 6> palLumaFilterCoeffs {
 static constexpr auto palLumaFilter = makeFIRFilter(palLumaFilterCoeffs);
 
 // NTSC - Filter at Fsc/2 (Fsc = 3579545 (/2 = 1,789,772.5), sample rate = 14,318,180)
-// 1.8 MHz LPF - 9 Taps
-// from scipy import signal
-// scipy.signal.firwin(5, [1.8e6/14318180], window='hamming')
+// 1.8 MHz LPF - 6 Taps
+// import scipy.signal
+// scipy.signal.firwin(6, [1.8e6/14318180], window='hamming')
 static constexpr std::array<double, 6> ntscLumaFilterCoeffs {
     0.0250663,  0.1390033,  0.3359304,  0.3359304,  0.1390033,
     0.0250663


### PR DESCRIPTION
When fixing a dropout, we used to find a line that had the same chroma phase, which could be some distance away. This makes it find two source lines, an arbitrary one for luma and a correctly-phased one for chroma -- which means we can usually take an adjacent line for luma.

Chroma separation is done using Simon's 1D LPF, so it's only approximate but it's plenty good enough for dropout correction. At the moment it filters two lines for every dropout it corrects, so it could potentially be sped up a bit in the future by caching the filter results.

Uncorrected, before and after for Aspen (NTSC):

![doc-aspen-off-output](https://user-images.githubusercontent.com/436317/69907820-66fbe480-13d4-11ea-8e76-fe63f1a2260f.png)
![doc-aspen-on-output](https://user-images.githubusercontent.com/436317/69907821-69f6d500-13d4-11ea-89bb-a4d853fbe093.png)
![doc-aspen-on-output](https://user-images.githubusercontent.com/436317/69907829-8135c280-13d4-11ea-88fb-9a8a8fc8185b.png)

Uncorrected, before and after for Kagemusha (PAL):

![doc-kagemusha-off-output](https://user-images.githubusercontent.com/436317/69907823-6d8a5c00-13d4-11ea-9bd0-b73cdce966f7.png)
![doc-kagemusha-on-output](https://user-images.githubusercontent.com/436317/69907824-70854c80-13d4-11ea-8b37-477c16588647.png)
![doc-kagemusha-on-output](https://user-images.githubusercontent.com/436317/69907833-872ba380-13d4-11ea-9728-6514f7e71998.png)

(I would show The UN and You but it just looks the same...)

This looks particularly good in motion compared to the previous version -- you don't see replacements flickering in and out any more.