### PR TITLE
Update the C++ EFM PLL to match the Python version

### DIFF
--- a/tools/ld-ldstoefm/pll.h
+++ b/tools/ld-ldstoefm/pll.h
@@ -37,9 +37,7 @@ public:
 
 private:
     // ZC detector state
-    bool zcFirstRun;
     qint16 zcPreviousInput;
-    bool prevDirection;
     qreal delta;
 
     // PLL state
@@ -54,7 +52,6 @@ private:
     qint8 tCounter;
 
     void pushEdge(qreal sampleDelta);
-    void pushTValue(qint8 bit);
 };
 
 #endif // PLL_H


### PR DESCRIPTION
Most of this is just refactoring. The only functional change is to remove the hysteresis (prevDirection) in the zero-crossing detector, which results in a slight improvement in accuracy.

I've checked that this produces identical output to the Python version. I haven't updated the copy in cd-decode since I don't have any CD samples to test against yet, but I expect you could just drop this straight in (i.e. change the .pro to use ../ld-ldstoefm/pll.cpp).