### PR TITLE
EFM PLL dropout handling improvements

### DIFF
--- a/efm_pll.py
+++ b/efm_pll.py
@@ -150,6 +150,15 @@ class EFM_PLL:
                 # Update the reference clock?
                 if self.frequencyHysteresis < -1.0 or self.frequencyHysteresis > 1.0:
                     aper = self.periodAdjustBase * edgeDelta / self.currentPeriod
+
+                    # If there's been a substantial gap since the last edge (e.g.
+                    # a dropout), edgeDelta can be very large here, so we need to
+                    # limit how much of an adjustment we're willing to make
+                    if aper < -self.periodAdjustBase:
+                        aper = -self.periodAdjustBase
+                    elif aper > self.periodAdjustBase:
+                        aper = self.periodAdjustBase
+
                     self.currentPeriod += aper
 
                     if self.currentPeriod < self.minimumPeriod:

--- a/lddecode_core.py
+++ b/lddecode_core.py
@@ -477,8 +477,10 @@ class RFDecode:
         rv['video'] = video_out[self.blockcut:-self.blockcut_end] if cut else video_out
 
         if self.decode_digital_audio:
-            efm_out = npfft.ifft(indata_fft * self.Filters['Fefm']) 
-            rv['efm'] = np.uint16(efm_out[self.blockcut:-self.blockcut_end].real) if cut else efm_out
+            efm_out = npfft.ifft(indata_fft * self.Filters['Fefm'])
+            if cut:
+                efm_out = efm_out[self.blockcut:-self.blockcut_end]
+            rv['efm'] = np.int16(np.clip(efm_out.real, -32768, 32767))
 
         if self.decode_analog_audio:
             # Audio phase 1
@@ -2426,8 +2428,7 @@ class LDdecode:
             self.outfile_audio.write(audio)
 
         if self.digital_audio == True:
-            efm_s16 = np.int16(np.int32(efm) - 32768)
-            efm_out = self.efm_pll.process(efm_s16)
+            efm_out = self.efm_pll.process(efm)
             self.outfile_efm.write(efm_out.tobytes())
         else:
             efm = None

--- a/tools/ld-ldstoefm/pll.cpp
+++ b/tools/ld-ldstoefm/pll.cpp
@@ -134,6 +134,15 @@ void Pll::pushEdge(qreal sampleDelta)
             // Update the reference clock?
             if (frequencyHysteresis < -1.0 || frequencyHysteresis > 1.0) {
                 qreal aper = periodAdjustBase * edgeDelta / currentPeriod;
+
+                // If there's been a substantial gap since the last edge (e.g.
+                // a dropout), edgeDelta can be very large here, so we need to
+                // limit how much of an adjustment we're willing to make
+                if (aper < -periodAdjustBase)
+                    aper = -periodAdjustBase;
+                else if (aper > periodAdjustBase)
+                    aper = periodAdjustBase;
+
                 currentPeriod += aper;
 
                 if (currentPeriod < minimumPeriod) {

--- a/tools/ld-ldstoefm/pll.h
+++ b/tools/ld-ldstoefm/pll.h
@@ -37,9 +37,7 @@ public:
 
 private:
     // ZC detector state
-    bool zcFirstRun;
     qint16 zcPreviousInput;
-    bool prevDirection;
     qreal delta;
 
     // PLL state
@@ -54,7 +52,6 @@ private:
     qint8 tCounter;
 
     void pushEdge(qreal sampleDelta);
-    void pushTValue(qint8 bit);
 };
 
 #endif // PLL_H


### PR DESCRIPTION
1. Update the C++ PLL so it's in sync with the Python version.

2. Simplify the conversion of the waveform being fed into EFM_PLL, which used to look rather odd: 

![badefm](https://user-images.githubusercontent.com/436317/69922578-6aa37000-1495-11ea-963e-7c30bd9164c1.png)

This actually didn't mess up the zero crossings all that much, except when there was a really big peak and it clipped - avoiding clipping gives small improvements on dropout-y samples. It now looks correct, and I've checked that it's the same (apart from amplitude) as my standalone filter program:

![goodefm](https://user-images.githubusercontent.com/436317/69922586-7727c880-1495-11ea-8333-9306cd020400.png)

3. @happycube spotted that the EFM errors in Squibnocket were correlated with dropouts. Graphing the PLL clock over time showed that dropouts were knocking it badly off frequency:

![squibbefore](https://user-images.githubusercontent.com/436317/69922635-f3221080-1495-11ea-8d98-406f358065ca.png)

(The sinusoid is tracking the slightly-off-centre disc rotation, so this is a radial scratch.)

This turns out to be a bug in the correction calculation - it wasn't checking for very large gaps between edges. Limiting the correction gives better behaviour, and results in small improvements in all my samples:

![squibafter](https://user-images.githubusercontent.com/436317/69922648-0503b380-1496-11ea-8023-dc78e2e5ad0a.png)

A PLL with a proper loop filter might give better results; it's still wandering up and down a lot!