### PR TITLE
stdin/stdout support for ld-dropout-correct and ld-chroma-decoder

### DIFF
--- a/tools/ld-chroma-decoder/decoderpool.cpp
+++ b/tools/ld-chroma-decoder/decoderpool.cpp
@@ -77,7 +77,7 @@ bool DecoderPool::process()
     }
 
     // Open the output RGB file
-    if (outputFileName.isNull()) {
+    if (outputFileName == "-") {
         // No output filename, use stdout instead
         if (!targetVideo.open(stdout, QIODevice::WriteOnly)) {
             // Failed to open stdout

--- a/tools/ld-dropout-correct/correctorpool.h
+++ b/tools/ld-dropout-correct/correctorpool.h
@@ -40,7 +40,8 @@ class CorrectorPool : public QObject
 {
     Q_OBJECT
 public:
-    explicit CorrectorPool(QString _inputFileName, QString _outputFilename, qint32 _maxThreads, LdDecodeMetaData &_ldDecodeMetaData,
+    explicit CorrectorPool(QString _inputFilename, QString _outputFilename, QString _outputJsonFilename,
+                           qint32 _maxThreads, LdDecodeMetaData &_ldDecodeMetaData,
                            bool _reverse, bool _intraField, bool _overCorrect, QObject *parent = nullptr);
 
     bool process();
@@ -59,6 +60,7 @@ public:
 private:
     QString inputFilename;
     QString outputFilename;
+    QString outputJsonFilename;
     qint32 maxThreads;
     bool reverse;
     bool intraField;

--- a/tools/ld-dropout-correct/main.cpp
+++ b/tools/ld-dropout-correct/main.cpp
@@ -97,6 +97,18 @@ int main(int argc, char *argv[])
                                        QCoreApplication::translate("main", "Show debug"));
     parser.addOption(showDebugOption);
 
+    // Option to specify a different JSON input file
+    QCommandLineOption inputJsonOption(QStringList() << "input-json",
+                                       QCoreApplication::translate("main", "Specify the input JSON file (default input.json)"),
+                                       QCoreApplication::translate("main", "filename"));
+    parser.addOption(inputJsonOption);
+
+    // Option to specify a different JSON output file
+    QCommandLineOption outputJsonOption(QStringList() << "output-json",
+                                        QCoreApplication::translate("main", "Specify the output JSON file (default output.json)"),
+                                        QCoreApplication::translate("main", "filename"));
+    parser.addOption(outputJsonOption);
+
     // Option to reverse the field order (-r)
     QCommandLineOption setReverseOption(QStringList() << "r" << "reverse",
                                        QCoreApplication::translate("main", "Reverse the field order to second/first (default first/second)"));
@@ -119,10 +131,10 @@ int main(int argc, char *argv[])
     parser.addOption(threadsOption);
 
     // Positional argument to specify input video file
-    parser.addPositionalArgument("input", QCoreApplication::translate("main", "Specify input TBC file"));
+    parser.addPositionalArgument("input", QCoreApplication::translate("main", "Specify input TBC file (- for piped input)"));
 
     // Positional argument to specify output video file
-    parser.addPositionalArgument("output", QCoreApplication::translate("main", "Specify output TBC file"));
+    parser.addPositionalArgument("output", QCoreApplication::translate("main", "Specify output TBC file (omit or - for piped output)"));
 
     // Process the command line options and arguments given by the user
     parser.process(a);
@@ -146,17 +158,30 @@ int main(int argc, char *argv[])
     }
 
     QString inputFilename;
-    QString outputFilename;
+    QString outputFilename = "-";
     QStringList positionalArguments = parser.positionalArguments();
     if (positionalArguments.count() == 2) {
         inputFilename = positionalArguments.at(0);
         outputFilename = positionalArguments.at(1);
+    } else if (positionalArguments.count() == 1) {
+        inputFilename = positionalArguments.at(0);
     } else {
         // Quit with error
         qCritical("You must specify input and output TBC files");
         return -1;
     }
 
+    // Check filename arguments are reasonable
+    if (inputFilename == "-" && !parser.isSet(inputJsonOption)) {
+        // Quit with error
+        qCritical("With piped input, you must also specify the input JSON file");
+        return -1;
+    }
+    if (outputFilename == "-" && !parser.isSet(outputJsonOption)) {
+        // Quit with error
+        qCritical("With piped output, you must also specify the output JSON file");
+        return -1;
+    }
     if (inputFilename == outputFilename) {
         // Quit with error
         qCritical("Input and output files cannot be the same");
@@ -166,19 +191,27 @@ int main(int argc, char *argv[])
     // Process the command line options
     if (isDebugOn) showDebug = true;
 
-    // Open the JSON metadata
-    LdDecodeMetaData metaData;
+    // Work out the metadata filenames
+    QString inputJsonFilename = inputFilename + ".json";
+    if (parser.isSet(inputJsonOption)) {
+        inputJsonFilename = parser.value(inputJsonOption);
+    }
+    QString outputJsonFilename = outputFilename + ".json";
+    if (parser.isSet(outputJsonOption)) {
+        outputJsonFilename = parser.value(outputJsonOption);
+    }
 
     // Open the source video metadata
-    qInfo().nospace().noquote() << "Reading JSON metadata from " << inputFilename << ".json";
-    if (!metaData.read(inputFilename + ".json")) {
+    LdDecodeMetaData metaData;
+    qInfo().nospace().noquote() << "Reading JSON metadata from " << inputJsonFilename;
+    if (!metaData.read(inputJsonFilename)) {
         qCritical() << "Unable to open TBC JSON metadata file";
         return 1;
     }
 
     // Perform the processing
     qInfo() << "Beginning dropout correction...";
-    CorrectorPool correctorPool(inputFilename, outputFilename, maxThreads, metaData, reverse, intraField, overCorrect);
+    CorrectorPool correctorPool(inputFilename, outputFilename, outputJsonFilename, maxThreads, metaData, reverse, intraField, overCorrect);
     if (!correctorPool.process()) return 1;
 
     // Quit with success

--- a/tools/ld-dropout-correct/main.cpp
+++ b/tools/ld-dropout-correct/main.cpp
@@ -177,7 +177,7 @@ int main(int argc, char *argv[])
     }
 
     // Perform the processing
-    qInfo() << "Beginning VBI processing...";
+    qInfo() << "Beginning dropout correction...";
     CorrectorPool correctorPool(inputFilename, outputFilename, maxThreads, metaData, reverse, intraField, overCorrect);
     if (!correctorPool.process()) return 1;
 

--- a/tools/ld-process-vbi/decoderpool.cpp
+++ b/tools/ld-process-vbi/decoderpool.cpp
@@ -24,8 +24,10 @@
 
 #include "decoderpool.h"
 
-DecoderPool::DecoderPool(QString _inputFileName, qint32 _maxThreads, LdDecodeMetaData &_ldDecodeMetaData, QObject *parent)
-    : QObject(parent), inputFilename(_inputFileName), maxThreads(_maxThreads), ldDecodeMetaData(_ldDecodeMetaData)
+DecoderPool::DecoderPool(QString _inputFilename, QString _outputJsonFilename,
+                         qint32 _maxThreads, LdDecodeMetaData &_ldDecodeMetaData, QObject *parent)
+    : QObject(parent), inputFilename(_inputFilename), outputJsonFilename(_outputJsonFilename),
+      maxThreads(_maxThreads), ldDecodeMetaData(_ldDecodeMetaData)
 {
 }
 
@@ -85,8 +87,7 @@ bool DecoderPool::process()
 
     // Write the JSON metadata file
     qInfo() << "Writing JSON metadata file...";
-    QString outputFileName = inputFilename + ".json";
-    ldDecodeMetaData.write(outputFileName);
+    ldDecodeMetaData.write(outputJsonFilename);
     qInfo() << "VBI processing complete";
 
     // Close the source video

--- a/tools/ld-process-vbi/decoderpool.h
+++ b/tools/ld-process-vbi/decoderpool.h
@@ -41,7 +41,7 @@ class DecoderPool : public QObject
     Q_OBJECT
 public:
     // Public methods
-    explicit DecoderPool(QString _inputFileName,
+    explicit DecoderPool(QString _inputFilename, QString _outputJsonFilename,
                         qint32 _maxThreads, LdDecodeMetaData &_ldDecodeMetaData,
                         QObject *parent = nullptr);
     bool process();
@@ -52,6 +52,7 @@ public:
 
 private:
     QString inputFilename;
+    QString outputJsonFilename;
     bool performCorrection;
     bool noBackup;
     qint32 maxThreads;

--- a/tools/library/tbc/sourcevideo.cpp
+++ b/tools/library/tbc/sourcevideo.cpp
@@ -144,12 +144,12 @@ QByteArray SourceVideo::getVideoField(qint32 fieldNumber)
     fieldData->resize(fieldByteLength);
 
     do {
-        receivedBytes = inputFile.read(fieldData->data(), fieldByteLength - receivedBytes);
+        receivedBytes = inputFile.read(fieldData->data() + totalReceivedBytes, fieldByteLength - totalReceivedBytes);
         totalReceivedBytes += receivedBytes;
     } while (receivedBytes > 0 && totalReceivedBytes < fieldByteLength);
 
     // Verify read was ok
-    if (receivedBytes != fieldByteLength) qFatal("Could not read input fields from file even though they were available");
+    if (totalReceivedBytes != fieldByteLength) qFatal("Could not read input fields from file even though they were available");
 
     // Insert the field data into the cache
     fieldCache.insert(fieldNumber, fieldData, 1);
@@ -196,12 +196,12 @@ QByteArray SourceVideo::getVideoField(qint32 fieldNumber, qint32 startFieldLine,
     qint64 totalReceivedBytes = 0;
     qint64 receivedBytes = 0;
     do {
-        receivedBytes = inputFile.read(outputFieldLineData.data(), requiredReadLength - receivedBytes);
+        receivedBytes = inputFile.read(outputFieldLineData.data() + totalReceivedBytes, requiredReadLength - totalReceivedBytes);
         totalReceivedBytes += receivedBytes;
     } while (receivedBytes > 0 && totalReceivedBytes < requiredReadLength);
 
     // Verify read was ok
-    if (receivedBytes != requiredReadLength) qFatal("Could not read input fields from file even though they were available");
+    if (totalReceivedBytes != requiredReadLength) qFatal("Could not read input fields from file even though they were available");
 
     // Return the data
     return outputFieldLineData;

--- a/tools/library/tbc/sourcevideo.h
+++ b/tools/library/tbc/sourcevideo.h
@@ -53,6 +53,7 @@ public:
 private:
     // File handling globals
     QFile inputFile;
+    qint64 inputFilePos;
     bool isSourceVideoOpen;
     qint32 availableFields;
     qint32 fieldByteLength;

--- a/tools/library/tbc/sourcevideo.h
+++ b/tools/library/tbc/sourcevideo.h
@@ -43,8 +43,7 @@ public:
     void close(void);
 
     // Field handling methods
-    QByteArray getVideoField(qint32 fieldNumber);
-    QByteArray getVideoField(qint32 fieldNumber, qint32 startFieldLine, qint32 endFieldLine);
+    QByteArray getVideoField(qint32 fieldNumber, qint32 startFieldLine = -1, qint32 endFieldLine = -1);
 
     // Get and set methods
     bool isSourceValid();
@@ -59,7 +58,7 @@ private:
     qint32 fieldByteLength;
     qint32 fieldLineLength;
 
-    QByteArray outputFieldLineData;
+    QByteArray outputFieldData;
 
     // Field caching
     QCache<qint32, QByteArray> fieldCache;


### PR DESCRIPTION
ld-chroma-decoder was already capable of writing .rgb output to stdout, so you could pipe its output directly into a video encoder.

This patch series allows ld-dropout-correct to write .tbc output to stdout, and ld-chroma-decoder to read .tbc input from stdin. This means you can go straight from ld-decode's .tbc to video with no temporary files:

```
ld-dropout-correct --output-json disc.doc.json disc.tbc - | \
    ld-chroma-decoder --input-json disc.tbc.json - - | \
    ffplay -f rawvideo [...] -i -
```

(And this is fast enough now to watch in real time, although I'll leave muxing the audio in as an exercise for the reader!)

There are a couple of caveats: if you're using stdin/stdout, you need to specify the corresponding JSON file as an extra option, and it only works if the input file is being read straight through without seeking.

I've added the --input/output-json options to ld-process-vbi as well, but I haven't added explicit stdin .tbc support there because it would need to seek forward. This could be fixed in the future by having SourceVideo read and discard data, but I figure it's probably less useful since you'd usually want to decode the VBI before decoding the video.