### PR TITLE
Add Transform PAL threshold matrix support

### DIFF
--- a/tools/ld-chroma-decoder/main.cpp
+++ b/tools/ld-chroma-decoder/main.cpp
@@ -185,7 +185,7 @@ int main(int argc, char *argv[])
 
     // Option to select the Transform PAL filter mode
     QCommandLineOption transformModeOption(QStringList() << "transform-mode",
-                                           QCoreApplication::translate("main", "Transform: Filter mode to use (level, threshold; default level)"),
+                                           QCoreApplication::translate("main", "Transform: Filter mode to use (level, threshold; default threshold)"),
                                            QCoreApplication::translate("main", "mode"));
     parser.addOption(transformModeOption);
 

--- a/tools/ld-chroma-decoder/main.cpp
+++ b/tools/ld-chroma-decoder/main.cpp
@@ -29,6 +29,7 @@
 #include <QCommandLineParser>
 #include <QScopedPointer>
 #include <QThread>
+#include <fstream>
 
 #include "decoderpool.h"
 #include "lddecodemetadata.h"
@@ -84,6 +85,56 @@ void debugOutputHandler(QtMsgType type, const QMessageLogContext &context, const
         else fprintf(stderr, "Fatal: %s\n", localMsg.constData());
         abort();
     }
+}
+
+// Load the thresholds file for the Transform decoders, if specified. We must
+// do this after PalColour has been configured, so we know how many values to
+// expect.
+//
+// Return true on success; on failure, print a message and return false.
+static bool loadTransformThresholds(QCommandLineParser &parser, QCommandLineOption &transformThresholdsOption, PalColour::Configuration &palConfig)
+{
+    if (!parser.isSet(transformThresholdsOption)) {
+        // Nothing to load
+        return true;
+    }
+
+    // Open the file
+    QString filename = parser.value(transformThresholdsOption);
+    std::ifstream thresholdsFile(filename.toStdString());
+    if (thresholdsFile.fail()) {
+        qCritical() << "Transform thresholds file could not be opened:" << filename;
+        return false;
+    }
+
+    // Read threshold values from the file
+    palConfig.transformThresholds.clear();
+    while (true) {
+        double value;
+        thresholdsFile >> value;
+        if (thresholdsFile.eof()) {
+            break;
+        }
+        if (value < 0.0 || value > 1.0) {
+            qCritical() << "Values in Transform thresholds file must be between 0 and 1:" << filename;
+            return false;
+        }
+        if (thresholdsFile.fail()) {
+            qCritical() << "Couldn't parse Transform thresholds file:" << filename;
+            return false;
+        }
+        palConfig.transformThresholds.push_back(value);
+    }
+
+    // Check we've read the right number
+    if (palConfig.transformThresholds.size() != palConfig.getThresholdsSize()) {
+        qCritical() << "Transform thresholds file contained" << palConfig.transformThresholds.size()
+                    << "values, expecting" << palConfig.getThresholdsSize() << "values:" << filename;
+        return false;
+    }
+
+    thresholdsFile.close();
+    return true;
 }
 
 int main(int argc, char *argv[])
@@ -191,9 +242,15 @@ int main(int argc, char *argv[])
 
     // Option to select the Transform PAL threshold
     QCommandLineOption transformThresholdOption(QStringList() << "transform-threshold",
-                                                QCoreApplication::translate("main", "Transform: Similarity threshold in 'threshold' mode (default 0.4)"),
+                                                QCoreApplication::translate("main", "Transform: Uniform similarity threshold in 'threshold' mode (default 0.4)"),
                                                 QCoreApplication::translate("main", "number"));
     parser.addOption(transformThresholdOption);
+
+    // Option to select the Transform PAL thresholds file
+    QCommandLineOption transformThresholdsOption(QStringList() << "transform-thresholds",
+                                                 QCoreApplication::translate("main", "Transform: File containing per-bin similarity thresholds in 'threshold' mode"),
+                                                 QCoreApplication::translate("main", "file"));
+    parser.addOption(transformThresholdsOption);
 
     // Option to overlay the FFTs
     QCommandLineOption showFFTsOption(QStringList() << "show-ffts",
@@ -379,9 +436,15 @@ int main(int argc, char *argv[])
         decoder.reset(new PalDecoder(palConfig));
     } else if (decoderName == "transform2d") {
         palConfig.chromaFilter = PalColour::transform2DFilter;
+        if (!loadTransformThresholds(parser, transformThresholdsOption, palConfig)) {
+            return -1;
+        }
         decoder.reset(new PalDecoder(palConfig));
     } else if (decoderName == "transform3d") {
         palConfig.chromaFilter = PalColour::transform3DFilter;
+        if (!loadTransformThresholds(parser, transformThresholdsOption, palConfig)) {
+            return -1;
+        }
         decoder.reset(new PalDecoder(palConfig));
     } else if (decoderName == "ntsc2d") {
         decoder.reset(new NtscDecoder(combConfig));

--- a/tools/ld-chroma-decoder/main.cpp
+++ b/tools/ld-chroma-decoder/main.cpp
@@ -299,7 +299,6 @@ int main(int argc, char *argv[])
         } else if (name == "threshold") {
             palConfig.transformMode = TransformPal::thresholdMode;
         } else {
-            palConfig.transformMode = TransformPal::levelMode;
             // Quit with error
             qCritical() << "Unknown Transform mode " << name;
             return -1;

--- a/tools/ld-chroma-decoder/palcolour.cpp
+++ b/tools/ld-chroma-decoder/palcolour.cpp
@@ -70,6 +70,17 @@ PalColour::PalColour(QObject *parent)
 {
 }
 
+qint32 PalColour::Configuration::getThresholdsSize() const
+{
+    if (chromaFilter == transform2DFilter) {
+        return TransformPal2D::getThresholdsSize();
+    } else if (chromaFilter == transform3DFilter) {
+        return TransformPal3D::getThresholdsSize();
+    } else {
+        return 0;
+    }
+}
+
 qint32 PalColour::Configuration::getLookBehind() const
 {
     if (chromaFilter == transform3DFilter) {
@@ -113,7 +124,8 @@ void PalColour::updateConfiguration(const LdDecodeMetaData::VideoParameters &_vi
 
         // Configure the filter
         transformPal->updateConfiguration(videoParameters, configuration.firstActiveLine, configuration.lastActiveLine,
-                                          configuration.transformMode, configuration.transformThreshold);
+                                          configuration.transformMode, configuration.transformThreshold,
+                                          configuration.transformThresholds);
     }
 
     configurationSet = true;

--- a/tools/ld-chroma-decoder/palcolour.h
+++ b/tools/ld-chroma-decoder/palcolour.h
@@ -61,6 +61,7 @@ public:
         ChromaFilterMode chromaFilter = palColourFilter;
         TransformPal::TransformMode transformMode = TransformPal::thresholdMode;
         double transformThreshold = 0.4;
+        QVector<double> transformThresholds;
         bool showFFTs = false;
         qint32 showPositionX = 200;
         qint32 showPositionY = 200;
@@ -70,6 +71,7 @@ public:
         // Interlaced line 619 is PAL line 623 (the last active half-line)
         qint32 lastActiveLine = 620;
 
+        qint32 getThresholdsSize() const;
         qint32 getLookBehind() const;
         qint32 getLookAhead() const;
     };

--- a/tools/ld-chroma-decoder/transformpal.cpp
+++ b/tools/ld-chroma-decoder/transformpal.cpp
@@ -48,12 +48,12 @@ void TransformPal::updateConfiguration(const LdDecodeMetaData::VideoParameters &
     lastActiveLine = _lastActiveLine;
     mode = _mode;
 
-    // Resize thresholds to match the number of FFT points we will consider in
-    // applyFilter. The x loop there doesn't need to look at every point.
+    // Resize thresholds to match the number of FFT bins we will consider in
+    // applyFilter. The x loop there doesn't need to look at every bin.
     const qint32 thresholdsSize = ((xComplex / 4) + 1) * yComplex * zComplex;
 
     if (_thresholds.size() == 0) {
-        // Use the same (squared) threshold value for all elements
+        // Use the same (squared) threshold value for all bins
         thresholds.fill(threshold * threshold, thresholdsSize);
     } else {
         // Square the provided thresholds
@@ -81,11 +81,11 @@ void TransformPal::overlayFFT(qint32 positionX, qint32 positionY,
 void TransformPal::overlayFFTArrays(const fftw_complex *fftIn, const fftw_complex *fftOut,
                                     FrameCanvas &canvas)
 {
-    // How many pixels to draw for each element
+    // How many pixels to draw for each bin
     const qint32 xScale = 2;
     const qint32 yScale = 2;
 
-    // Each block shows the absolute value of the real component of an FFT element using a log scale.
+    // Each block shows the absolute value of the real component of an FFT bin using a log scale.
     // Work out a scaling factor to make all values visible.
     double maxValue = 0;
     for (qint32 i = 0; i < xComplex * yComplex * zComplex; i++) {
@@ -106,7 +106,7 @@ void TransformPal::overlayFFTArrays(const fftw_complex *fftIn, const fftw_comple
             // Outline the array
             canvas.drawRectangle(xStart, yStart, (xScale * xComplex) + 2, (yScale * yComplex) + 2, canvas.green);
 
-            // Draw the elements in the array
+            // Draw the bins in the array
             for (qint32 y = 0; y < yComplex; y++) {
                 for (qint32 x = 0; x < xComplex; x++) {
                     const double value = fabs(fftData[(((z * yComplex) + y) * xComplex) + x][0]);

--- a/tools/ld-chroma-decoder/transformpal.cpp
+++ b/tools/ld-chroma-decoder/transformpal.cpp
@@ -29,8 +29,8 @@
 
 #include <cmath>
 
-TransformPal::TransformPal()
-    : configurationSet(false)
+TransformPal::TransformPal(qint32 _xComplex, qint32 _yComplex, qint32 _zComplex)
+    : xComplex(_xComplex), yComplex(_yComplex), zComplex(_zComplex), configurationSet(false)
 {
 }
 
@@ -63,7 +63,6 @@ void TransformPal::overlayFFT(qint32 positionX, qint32 positionY,
 
 // Overlay the input and output FFT arrays, in either 2D or 3D
 void TransformPal::overlayFFTArrays(const fftw_complex *fftIn, const fftw_complex *fftOut,
-                                    qint32 xSize, qint32 ySize, qint32 zSize,
                                     FrameCanvas &canvas)
 {
     // How many pixels to draw for each element
@@ -73,28 +72,28 @@ void TransformPal::overlayFFTArrays(const fftw_complex *fftIn, const fftw_comple
     // Each block shows the absolute value of the real component of an FFT element using a log scale.
     // Work out a scaling factor to make all values visible.
     double maxValue = 0;
-    for (qint32 i = 0; i < xSize * ySize * zSize; i++) {
+    for (qint32 i = 0; i < xComplex * yComplex * zComplex; i++) {
         maxValue = qMax(maxValue, fabs(fftIn[i][0]));
         maxValue = qMax(maxValue, fabs(fftOut[i][0]));
     }
     const double valueScale = 65535.0 / log2(maxValue);
 
     // Draw each 2D plane of the array
-    for (qint32 z = 0; z < zSize; z++) {
+    for (qint32 z = 0; z < zComplex; z++) {
         for (qint32 column = 0; column < 2; column++) {
             const fftw_complex *fftData = column == 0 ? fftIn : fftOut;
 
             // Work out where this 2D array starts
-            const qint32 yStart = canvas.top() + (z * ((yScale * ySize) + 1));
-            const qint32 xStart = canvas.right() - ((2 - column) * ((xScale * xSize) + 1)) - 1;
+            const qint32 yStart = canvas.top() + (z * ((yScale * yComplex) + 1));
+            const qint32 xStart = canvas.right() - ((2 - column) * ((xScale * xComplex) + 1)) - 1;
 
             // Outline the array
-            canvas.drawRectangle(xStart, yStart, (xScale * xSize) + 2, (yScale * ySize) + 2, canvas.green);
+            canvas.drawRectangle(xStart, yStart, (xScale * xComplex) + 2, (yScale * yComplex) + 2, canvas.green);
 
             // Draw the elements in the array
-            for (qint32 y = 0; y < ySize; y++) {
-                for (qint32 x = 0; x < xSize; x++) {
-                    const double value = fabs(fftData[(((z * ySize) + y) * xSize) + x][0]);
+            for (qint32 y = 0; y < yComplex; y++) {
+                for (qint32 x = 0; x < xComplex; x++) {
+                    const double value = fabs(fftData[(((z * yComplex) + y) * xComplex) + x][0]);
                     const double shade = value <= 0 ? 0 : log2(value) * valueScale;
                     const quint16 shade16 = static_cast<quint16>(qBound(0.0, shade, 65535.0));
                     canvas.fillRectangle(xStart + (x * xScale) + 1, yStart + (y * yScale) + 1, xScale, yScale, canvas.grey(shade16));

--- a/tools/ld-chroma-decoder/transformpal.cpp
+++ b/tools/ld-chroma-decoder/transformpal.cpp
@@ -40,13 +40,29 @@ TransformPal::~TransformPal()
 
 void TransformPal::updateConfiguration(const LdDecodeMetaData::VideoParameters &_videoParameters,
                                        qint32 _firstActiveLine, qint32 _lastActiveLine,
-                                       TransformPal::TransformMode _mode, double _threshold)
+                                       TransformPal::TransformMode _mode, double threshold,
+                                       const QVector<double> &_thresholds)
 {
     videoParameters = _videoParameters;
     firstActiveLine = _firstActiveLine;
     lastActiveLine = _lastActiveLine;
     mode = _mode;
-    threshold = _threshold;
+
+    // Resize thresholds to match the number of FFT points we will consider in
+    // applyFilter. The x loop there doesn't need to look at every point.
+    const qint32 thresholdsSize = ((xComplex / 4) + 1) * yComplex * zComplex;
+
+    if (_thresholds.size() == 0) {
+        // Use the same (squared) threshold value for all elements
+        thresholds.fill(threshold * threshold, thresholdsSize);
+    } else {
+        // Square the provided thresholds
+        assert(_thresholds.size() == thresholdsSize);
+        thresholds.resize(thresholdsSize);
+        for (int i = 0; i < thresholdsSize; i++) {
+            thresholds[i] = _thresholds[i] * _thresholds[i];
+        }
+    }
 
     configurationSet = true;
 }

--- a/tools/ld-chroma-decoder/transformpal.h
+++ b/tools/ld-chroma-decoder/transformpal.h
@@ -40,7 +40,7 @@
 // Abstract base class for Transform PAL filters.
 class TransformPal {
 public:
-    TransformPal();
+    TransformPal(qint32 xComplex, qint32 yComplex, qint32 zComplex);
     virtual ~TransformPal();
 
     // Specify what the frequency-domain filter should do to each pair of
@@ -88,7 +88,12 @@ protected:
                                  QByteArray &rgbFrame) = 0;
 
     void overlayFFTArrays(const fftw_complex *fftIn, const fftw_complex *fftOut,
-                          qint32 xSize, qint32 ySize, qint32 zSize, FrameCanvas &canvas);
+                          FrameCanvas &canvas);
+
+    // FFT size
+    qint32 xComplex;
+    qint32 yComplex;
+    qint32 zComplex;
 
     // Configuration parameters
     bool configurationSet;

--- a/tools/ld-chroma-decoder/transformpal.h
+++ b/tools/ld-chroma-decoder/transformpal.h
@@ -44,11 +44,11 @@ public:
     virtual ~TransformPal();
 
     // Specify what the frequency-domain filter should do to each pair of
-    // frequencies that should be symmetrical around the carriers.
+    // bins that should be symmetrical around the carriers.
     enum TransformMode {
-        // Adjust the amplitudes of the two points to be equal
+        // Adjust the amplitudes of the two bins to be equal
         levelMode = 0,
-        // If the amplitudes aren't within a threshold of each other, zero both points
+        // If the amplitudes aren't within a threshold of each other, zero both bins
         thresholdMode
     };
 

--- a/tools/ld-chroma-decoder/transformpal.h
+++ b/tools/ld-chroma-decoder/transformpal.h
@@ -61,7 +61,8 @@ public:
     // be more similar to be considered chroma. 0.6 is pyctools-pal's default.
     void updateConfiguration(const LdDecodeMetaData::VideoParameters &videoParameters,
                              qint32 firstActiveLine, qint32 lastActiveLine,
-                             TransformMode mode, double threshold);
+                             TransformMode mode, double threshold,
+                             const QVector<double> &thresholds);
 
     // Filter input fields.
     //
@@ -100,7 +101,7 @@ protected:
     LdDecodeMetaData::VideoParameters videoParameters;
     qint32 firstActiveLine;
     qint32 lastActiveLine;
-    double threshold;
+    QVector<double> thresholds;
     TransformMode mode;
 };
 

--- a/tools/ld-chroma-decoder/transformpal2d.cpp
+++ b/tools/ld-chroma-decoder/transformpal2d.cpp
@@ -249,7 +249,7 @@ void TransformPal2D::applyFilter()
 
         // We only need to look at horizontal frequencies that might be chroma (0.5fSC to 1.5fSC).
         for (qint32 x = XTILE / 8; x <= XTILE / 4; x++) {
-            // Reflect around 4fSC Hz horizontally.
+            // Reflect around fSC horizontally
             const qint32 x_ref = (XTILE / 2) - x;
 
             const fftw_complex &in_val = bi[x];
@@ -285,8 +285,9 @@ void TransformPal2D::applyFilter()
                     bo_ref[x_ref][1] = ref_val[1] * factor;
                 }
             } else {
-                // Compare the magnitudes of the two values, and discard
-                // both if they are more different than the threshold.
+                // Compare the magnitudes of the two values, and discard both
+                // if they are more different than the threshold for this
+                // point.
                 if (m_in_sq < m_ref_sq * threshold_sq || m_ref_sq < m_in_sq * threshold_sq) {
                     // Probably not a chroma signal; throw it away.
                 } else {

--- a/tools/ld-chroma-decoder/transformpal2d.cpp
+++ b/tools/ld-chroma-decoder/transformpal2d.cpp
@@ -95,7 +95,7 @@ TransformPal2D::~TransformPal2D()
 
 qint32 TransformPal2D::getThresholdsSize()
 {
-    // On the X axis, include only the elements we actually use in applyFilter
+    // On the X axis, include only the bins we actually use in applyFilter
     return YCOMPLEX * ((XCOMPLEX / 4) + 1);
 }
 
@@ -237,7 +237,7 @@ void TransformPal2D::applyFilter()
     // symmetrical around the U carrier, which is at fSC Hz and 72 c/aph -- and
     // because we're sampling at 4fSC, this is handily equivalent to being
     // symmetrical around the V carrier owing to wraparound. We look at every
-    // point that might be a chroma signal, and only keep it if it's
+    // bin that might be a chroma signal, and only keep it if it's
     // sufficiently symmetrical with its reflection.
     //
     // The Y axis covers 0 to 288 c/aph;  72 c/aph is 1/4 * YTILE.
@@ -260,14 +260,14 @@ void TransformPal2D::applyFilter()
             // Reflect around fSC horizontally
             const qint32 x_ref = (XTILE / 2) - x;
 
-            // Get the threshold for this point
+            // Get the threshold for this bin
             const double threshold_sq = *thresholdsPtr++;
 
             const fftw_complex &in_val = bi[x];
             const fftw_complex &ref_val = bi_ref[x_ref];
 
             if (x == x_ref && y == y_ref) {
-                // This point is its own reflection (i.e. it's a carrier). Keep it!
+                // This bin is its own reflection (i.e. it's a carrier). Keep it!
                 bo[x][0] = in_val[0];
                 bo[x][1] = in_val[1];
                 continue;
@@ -298,7 +298,7 @@ void TransformPal2D::applyFilter()
             } else {
                 // Compare the magnitudes of the two values, and discard both
                 // if they are more different than the threshold for this
-                // point.
+                // bin.
                 if (m_in_sq < m_ref_sq * threshold_sq || m_ref_sq < m_in_sq * threshold_sq) {
                     // Probably not a chroma signal; throw it away.
                 } else {

--- a/tools/ld-chroma-decoder/transformpal2d.cpp
+++ b/tools/ld-chroma-decoder/transformpal2d.cpp
@@ -61,6 +61,7 @@ static double computeWindow(qint32 element, qint32 limit)
 }
 
 TransformPal2D::TransformPal2D()
+    : TransformPal(XCOMPLEX, YCOMPLEX, 1)
 {
     // Compute the window function.
     for (qint32 y = 0; y < YTILE; y++) {
@@ -337,5 +338,5 @@ void TransformPal2D::overlayFFTFrame(qint32 positionX, qint32 positionY,
     canvas.drawRectangle(positionX - 1, positionY + inputField.getOffset() - 1, XTILE + 1, (YTILE * 2) + 1, FrameCanvas::green);
 
     // Draw the arrays
-    overlayFFTArrays(fftComplexIn, fftComplexOut, XCOMPLEX, YCOMPLEX, 1, canvas);
+    overlayFFTArrays(fftComplexIn, fftComplexOut, canvas);
 }

--- a/tools/ld-chroma-decoder/transformpal2d.h
+++ b/tools/ld-chroma-decoder/transformpal2d.h
@@ -39,6 +39,9 @@ public:
     TransformPal2D();
     virtual ~TransformPal2D();
 
+    // Return the expected size of the thresholds array.
+    static qint32 getThresholdsSize();
+
     void filterFields(const QVector<SourceField> &inputFields, qint32 startIndex, qint32 endIndex,
                       QVector<const double *> &outputFields) override;
 

--- a/tools/ld-chroma-decoder/transformpal3d.cpp
+++ b/tools/ld-chroma-decoder/transformpal3d.cpp
@@ -294,7 +294,7 @@ void TransformPal3D::applyFilter()
 
             // We only need to look at horizontal frequencies that might be chroma (0.5fSC to 1.5fSC).
             for (qint32 x = XTILE / 8; x <= XTILE / 4; x++) {
-                // Reflect around fSC horizontally.
+                // Reflect around fSC horizontally
                 const qint32 x_ref = (XTILE / 2) - x;
 
                 const fftw_complex &in_val = bi[x];
@@ -331,7 +331,8 @@ void TransformPal3D::applyFilter()
                     }
                 } else {
                     // Compare the magnitudes of the two values, and discard
-                    // both if they are more different than the threshold.
+                    // both if they are more different than the threshold for
+                    // this point.
                     if (m_in_sq < m_ref_sq * threshold_sq || m_ref_sq < m_in_sq * threshold_sq) {
                         // Probably not a chroma signal; throw it away.
                     } else {

--- a/tools/ld-chroma-decoder/transformpal3d.cpp
+++ b/tools/ld-chroma-decoder/transformpal3d.cpp
@@ -104,7 +104,7 @@ TransformPal3D::~TransformPal3D()
 
 qint32 TransformPal3D::getThresholdsSize()
 {
-    // On the X axis, include only the elements we actually use in applyFilter
+    // On the X axis, include only the bins we actually use in applyFilter
     return ZCOMPLEX * YCOMPLEX * ((XCOMPLEX / 4) + 1);
 }
 
@@ -116,7 +116,7 @@ qint32 TransformPal3D::getLookBehind()
 
 qint32 TransformPal3D::getLookAhead()
 {
-    // ... and at most a tile minus one element into the future.
+    // ... and at most a tile minus one bin into the future.
     return (ZTILE - 1 + 1) / 2;
 }
 
@@ -276,7 +276,7 @@ void TransformPal3D::applyFilter()
     // symmetrical around the U carrier, which is at fSC Hz, 72 c/aph, 18.75 Hz
     // -- and because we're sampling at 4fSC, this is handily equivalent to
     // being symmetrical around the V carrier owing to wraparound. We look at
-    // every point that might be a chroma signal, and only keep it if it's
+    // every bin that might be a chroma signal, and only keep it if it's
     // sufficiently symmetrical with its reflection.
     //
     // The Z axis covers 0 to 50 Hz;      18.75 Hz is 3/8 * ZTILE.
@@ -305,14 +305,14 @@ void TransformPal3D::applyFilter()
                 // Reflect around fSC horizontally
                 const qint32 x_ref = (XTILE / 2) - x;
 
-                // Get the threshold for this point
+                // Get the threshold for this bin
                 const double threshold_sq = *thresholdsPtr++;
 
                 const fftw_complex &in_val = bi[x];
                 const fftw_complex &ref_val = bi_ref[x_ref];
 
                 if (x == x_ref && y == y_ref && z == z_ref) {
-                    // This point is its own reflection (i.e. it's a carrier). Keep it!
+                    // This bin is its own reflection (i.e. it's a carrier). Keep it!
                     bo[x][0] = in_val[0];
                     bo[x][1] = in_val[1];
                     continue;
@@ -343,7 +343,7 @@ void TransformPal3D::applyFilter()
                 } else {
                     // Compare the magnitudes of the two values, and discard
                     // both if they are more different than the threshold for
-                    // this point.
+                    // this bin.
                     if (m_in_sq < m_ref_sq * threshold_sq || m_ref_sq < m_in_sq * threshold_sq) {
                         // Probably not a chroma signal; throw it away.
                     } else {

--- a/tools/ld-chroma-decoder/transformpal3d.cpp
+++ b/tools/ld-chroma-decoder/transformpal3d.cpp
@@ -67,6 +67,7 @@ static double computeWindow(qint32 element, qint32 limit)
 }
 
 TransformPal3D::TransformPal3D()
+    : TransformPal(XCOMPLEX, YCOMPLEX, ZCOMPLEX)
 {
     // Compute the window function.
     for (qint32 z = 0; z < ZTILE; z++) {
@@ -375,5 +376,5 @@ void TransformPal3D::overlayFFTFrame(qint32 positionX, qint32 positionY,
     canvas.drawRectangle(positionX - 1, positionY - 1, XTILE + 1, YTILE + 1, FrameCanvas::green);
 
     // Draw the arrays
-    overlayFFTArrays(fftComplexIn, fftComplexOut, XCOMPLEX, YCOMPLEX, ZCOMPLEX, canvas);
+    overlayFFTArrays(fftComplexIn, fftComplexOut, canvas);
 }

--- a/tools/ld-chroma-decoder/transformpal3d.h
+++ b/tools/ld-chroma-decoder/transformpal3d.h
@@ -39,6 +39,9 @@ public:
     TransformPal3D();
     ~TransformPal3D();
 
+    // Return the expected size of the thresholds array.
+    static qint32 getThresholdsSize();
+
     // Return the number of frames that the decoder needs to be able to see
     // into the past and future (each frame being two SourceFields).
     static qint32 getLookBehind();


### PR DESCRIPTION
From discussion with Jim Easterbrook and Richard Russell, this is the approach that the production version of the BBC Transform PAL decoder used.

Experimentation with testcards and the video content from GGV1011 shows that it produces substantially fewer artefacts in 3D than using a uniform threshold across all the bins, particularly on transitions between differently-coloured regions. This is about 2% slower, because it does one extra memory read per bin.

At present it defaults to the existing behaviour of using the same threshold for all bins, so you need to provide a file of thresholds to get better performance. [Here's one I evolved for transform3d](https://github.com/atsampson/ld-decode-testsuite/blob/master/transform3d.thresholds). This was trained using ld-chroma-encoder and the VQEG/LDV test videos, which are much less noisy than typical LaserDisc video, so it's probably possible to do better.

Here's a frame from GGV1011 where per-bin thresholds make a big difference on colour transitions -- it's particularly visible in motion. transform3d with uniform thresholds:

![pr-motion2-t3d-output](https://user-images.githubusercontent.com/436317/70854614-eb129980-1eb5-11ea-9ec5-0a779d469546.png)

And transform3d with the thresholds file above:

![pr-motion2-t3df-output](https://user-images.githubusercontent.com/436317/70854616-f2d23e00-1eb5-11ea-8562-253cdb984e8d.png)

Fixes #368.