### PR TITLE
Check for the block being None in DemodCache.flushvideo

### DIFF
--- a/lddecode_core.py
+++ b/lddecode_core.py
@@ -754,7 +754,9 @@ class DemodCache:
 
     def flushvideo(self):
         for k in self.blocks.keys():
-            if 'demod' in self.blocks[k]:
+            if self.blocks[k] is None:
+                pass
+            elif 'demod' in self.blocks[k]:
                 self.lock.acquire()
                 del self.blocks[k]['demod']
                 self.lock.release()


### PR DESCRIPTION
This fixes a crash when decoding `tuneupav-colorbars.lds` from ld-decode-testdata:

```
>>> /home/ats/src/ld-decode/ld-decode.py --ignoreleadout ../ld-decode-testdata/tuneupav-colorbars.lds testout/test
file frame 1 CAV frame 6073
file frame 2 CAV frame 6074
ERROR - please paste the following into a bug report:
current sample: 4496615.889447236
arguments: Namespace(MTF=None, MTF_offset=None, daa=False, ignoreleadout=True, infile='../ld-decode-testdata/tuneupav-colorbars.lds', inputfreq=None, length=110000, nodod=False, noefm=False, ntsc=False, ntscj=False, outfile='testout/test', pal=False, seek=-1, start=0, threads=5, vbpf_high=None, verboseVITS=False, vlpf=None)
Exception: argument of type 'NoneType' is not iterable  Traceback:
  File "/home/ats/src/ld-decode/ld-decode.py", line 109, in <module>
    f = ldd.readfield()
  File "/home/ats/src/ld-decode/lddecode_core.py", line 2512, in readfield
    self.demodcache.flushvideo()
  File "/home/ats/src/ld-decode/lddecode_core.py", line 757, in flushvideo
    if 'demod' in self.blocks[k]:
/home/ats/src/ld-decode/ld-decode.py failed with exit code 1
```