### PR TITLE
Set out_scale earlier in FieldPAL's constructor

### DIFF
--- a/lddecode_core.py
+++ b/lddecode_core.py
@@ -1935,7 +1935,9 @@ class FieldPAL(Field):
     
     def __init__(self, *args, **kwargs):
         super(FieldPAL, self).__init__(*args, **kwargs)
-        
+
+        self.out_scale = np.double(0xd300 - 0x0100) / (100 - self.rf.SysParams['vsync_ire'])
+
         if not self.valid:
             return
 
@@ -1954,8 +1956,6 @@ class FieldPAL(Field):
         self.lineoffset = 2 if self.isFirstField else 3
 
         self.linecode = [self.decodephillipscode(l + self.lineoffset) for l in [16, 17, 18]]
-
-        self.out_scale = np.double(0xd300 - 0x0100) / (100 - self.rf.SysParams['vsync_ire'])
 
         #self.downscale(final=True)
 


### PR DESCRIPTION
This matches FieldNTSC, and fixes a crash when you try to decode an NTSC sample in PAL mode:

```
>>> /home/ats/src/ld-decode/ld-decode.py --ignoreleadout --pal ../ld-decode-testdata/issues/73/turtle_abba_1.lds testout/test
ERROR:root:Unable to find any sync pulses, jumping one second
Traceback (most recent call last):
  File "/home/ats/src/ld-decode/ld-decode.py", line 132, in <module>
    write_json(ldd, outname)
  File "/home/ats/src/ld-decode/ld-decode.py", line 96, in write_json
    jsondict = ldd.build_json(ldd.curfield)
  File "/home/ats/src/ld-decode/lddecode_core.py", line 2888, in build_json
    vp['black16bIre'] = np.float(f.hz_to_output(f.rf.iretohz(self.blackIRE)))
  File "/home/ats/src/ld-decode/lddecode_core.py", line 1921, in hz_to_output
    return np.uint16(np.clip((reduced * self.out_scale) + 256, 0, 65535) + 0.5)
AttributeError: 'FieldPAL' object has no attribute 'out_scale'
/home/ats/src/ld-decode/ld-decode.py failed with exit code 1
```