### PR TITLE
Make the top-level Makefile build/install all of ld-decode

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,17 +25,13 @@ jobs:
         # This list is from: https://github.com/happycube/ld-decode/wiki/Installation
         sudo apt-get install -y --no-install-recommends clang libopencv-dev libfann-dev python3-numpy python3-scipy python3-matplotlib git qt5-default libqwt-qt5-dev libfftw3-dev python3-tk python3-pandas python3-numba libavformat-dev libavcodec-dev libavutil-dev ffmpeg openssl pv
 
-    - name: Build toplevel
-      timeout-minutes: 5
-      run: |
-        make
-
-    - name: Build tools
+    - name: Build
       timeout-minutes: 15
-      run: |
-        cd tools
-        qmake -recursive
-        make
+      run: make prefix=/usr
+
+    - name: Install
+      timeout-minutes: 5
+      run: make install prefix=/usr DESTDIR=/tmp/staging
 
     - name: Run testfilter
       timeout-minutes: 5

--- a/Makefile
+++ b/Makefile
@@ -1,23 +1,75 @@
-# Makefile for the Software Decode of Laserdiscs project
+### Top-level Makefile for ld-decode ###
 
-# Note: Targets do not include auto-generated .h files, which means
-#       that make clean will not remove them.
-TARGETS=ld-ldf-reader
+# Prefix into which ld-decode will be installed.
+# This must be set both at build and install time. If you're using a
+# non-default directory here, make sure that Python knows to look in there for
+# modules (e.g. by setting PYTHONPATH in your environment).
+prefix ?= /usr/local
 
-CFLAGS=-g -O2 -fno-omit-frame-pointer -march=native -Itools/library/filter
+# Staging dir for building distribution packages.
+# If you're building packages, it may make more sense to build the Python and
+# Qt parts using your distribution's tools, rather than using this Makefile
+# (but don't forget the helpers!).
+DESTDIR =
 
-all: $(TARGETS)
+# Tools you might want to override
+PYTHON3 ?= python3
+QMAKE ?= qmake
 
-clean:
-	rm -f $(TARGETS)
+### Targets for users to invoke ###
 
-install:
-	cp ld-ldf-reader /usr/local/bin
+all: build-helpers build-python build-tools
+install: install-helpers install-python install-tools
+clean: clean-helpers clean-python clean-tools
 
-tools/library/filter/deemp.h: scripts/filtermaker
-	python3 scripts/filtermaker >$@
+.PHONY: all build-helpers build-python build-tools
+.PHONY: install install-helpers install-python install-tools
+.PHONY: clean clean-helpers clean-python clean-tools
+
+### Helper programs used by ld-decode ###
+
+helpers = ld-ldf-reader
+
+build-helpers: $(helpers)
 
 ld-ldf-reader: ld-ldf-reader.c
-	clang -o ld-ldf-reader ld-ldf-reader.c -Wno-deprecated-declarations -lavcodec -lavutil -lavformat -O2
+	$(CC) -O2 -Wno-deprecated-declarations -o $@ $< -lavcodec -lavutil -lavformat
 
+install-helpers:
+	install -d "$(DESTDIR)$(prefix)/bin"
+	install -m755 $(helpers) "$(DESTDIR)$(prefix)/bin"
 
+clean-helpers:
+	rm -f $(helpers)
+
+### Python modules and scripts ###
+
+build-python:
+	$(PYTHON3) setup.py build
+
+install-python:
+	if [ -z "$(DESTDIR)" ]; then \
+		$(PYTHON3) setup.py install --prefix="$(prefix)"; \
+	else \
+		$(PYTHON3) setup.py install --root="$(DESTDIR)" --prefix="$(prefix)"; \
+	fi
+
+clean-python:
+	$(PYTHON3) setup.py clean -a
+
+### Qt-based tools ###
+
+build-tools:
+	cd tools && $(QMAKE) -recursive PREFIX="$(prefix)"
+	$(MAKE) -C tools
+
+install-tools:
+	$(MAKE) -C tools install INSTALL_ROOT="$(DESTDIR)"
+
+clean-tools:
+	$(MAKE) -C tools clean
+
+### Generated files, not updated automatically ###
+
+tools/library/filter/deemp.h: scripts/filtermaker
+	$(PYTHON3) scripts/filtermaker >$@

--- a/tools/ld-analyse/ld-analyse.pro
+++ b/tools/ld-analyse/ld-analyse.pro
@@ -97,9 +97,11 @@ INCLUDEPATH += ../library/filter
 INCLUDEPATH += ../library/tbc
 INCLUDEPATH += ../ld-chroma-decoder
 
-# Default rules for deployment.
-qnx: target.path = /tmp/$${TARGET}/bin
-else: unix:!android: target.path = /usr/local/bin/
+# Rules for installation
+isEmpty(PREFIX) {
+    PREFIX = /usr/local
+}
+unix:!android: target.path = $$PREFIX/bin/
 !isEmpty(target.path): INSTALLS += target
 
 RESOURCES += \

--- a/tools/ld-chroma-decoder/encoder/encoder.pro
+++ b/tools/ld-chroma-decoder/encoder/encoder.pro
@@ -32,7 +32,9 @@ HEADERS += \
 INCLUDEPATH += ../../library/filter
 INCLUDEPATH += ../../library/tbc
 
-# Default rules for deployment.
-qnx: target.path = /tmp/$${TARGET}/bin
-else: unix:!android: target.path = /usr/local/bin/
+# Rules for installation
+isEmpty(PREFIX) {
+    PREFIX = /usr/local
+}
+unix:!android: target.path = $$PREFIX/bin/
 !isEmpty(target.path): INSTALLS += target

--- a/tools/ld-chroma-decoder/ld-chroma-decoder.pro
+++ b/tools/ld-chroma-decoder/ld-chroma-decoder.pro
@@ -62,9 +62,11 @@ HEADERS += \
 INCLUDEPATH += ../library/filter
 INCLUDEPATH += ../library/tbc
 
-# Default rules for deployment.
-qnx: target.path = /tmp/$${TARGET}/bin
-else: unix:!android: target.path = /usr/local/bin/
+# Rules for installation
+isEmpty(PREFIX) {
+    PREFIX = /usr/local
+}
+unix:!android: target.path = $$PREFIX/bin/
 !isEmpty(target.path): INSTALLS += target
 
 # Additional include paths to support MacOS compilation

--- a/tools/ld-diffdod/ld-diffdod.pro
+++ b/tools/ld-diffdod/ld-diffdod.pro
@@ -38,9 +38,9 @@ HEADERS += \
 INCLUDEPATH += ../library/filter
 INCLUDEPATH += ../library/tbc
 
-# Default rules for deployment.
-qnx: target.path = /tmp/$${TARGET}/bin
-else: unix:!android: target.path = /usr/local/bin/
+# Rules for installation
+isEmpty(PREFIX) {
+    PREFIX = /usr/local
+}
+unix:!android: target.path = $$PREFIX/bin/
 !isEmpty(target.path): INSTALLS += target
-
-

--- a/tools/ld-discmap/ld-discmap.pro
+++ b/tools/ld-discmap/ld-discmap.pro
@@ -34,9 +34,9 @@ HEADERS += \
 # Add external includes to the include path
 INCLUDEPATH += ../library/tbc
 
-# Default rules for deployment.
-qnx: target.path = /tmp/$${TARGET}/bin
-else: unix:!android: target.path = /usr/local/bin/
+# Rules for installation
+isEmpty(PREFIX) {
+    PREFIX = /usr/local
+}
+unix:!android: target.path = $$PREFIX/bin/
 !isEmpty(target.path): INSTALLS += target
-
-

--- a/tools/ld-dropout-correct/ld-dropout-correct.pro
+++ b/tools/ld-dropout-correct/ld-dropout-correct.pro
@@ -36,9 +36,9 @@ HEADERS += \
 INCLUDEPATH += ../library/filter
 INCLUDEPATH += ../library/tbc
 
-# Default rules for deployment.
-qnx: target.path = /tmp/$${TARGET}/bin
-else: unix:!android: target.path = /usr/local/bin/
+# Rules for installation
+isEmpty(PREFIX) {
+    PREFIX = /usr/local
+}
+unix:!android: target.path = $$PREFIX/bin/
 !isEmpty(target.path): INSTALLS += target
-
-

--- a/tools/ld-lds-converter/ld-lds-converter.pro
+++ b/tools/ld-lds-converter/ld-lds-converter.pro
@@ -21,8 +21,9 @@ SOURCES += \
 HEADERS += \
     dataconverter.h
 
-# Default rules for deployment.
-qnx: target.path = /tmp/$${TARGET}/bin
-else: unix:!android: target.path = /usr/local/bin/
+# Rules for installation
+isEmpty(PREFIX) {
+    PREFIX = /usr/local
+}
+unix:!android: target.path = $$PREFIX/bin/
 !isEmpty(target.path): INSTALLS += target
-

--- a/tools/ld-process-efm/ld-process-efm.pro
+++ b/tools/ld-process-efm/ld-process-efm.pro
@@ -86,9 +86,11 @@ FORMS += \
         aboutdialog.ui \
         mainwindow.ui
 
-# Default rules for deployment.
-qnx: target.path = /tmp/$${TARGET}/bin
-else: unix:!android: target.path = /usr/local/bin/
+# Rules for installation
+isEmpty(PREFIX) {
+    PREFIX = /usr/local
+}
+unix:!android: target.path = $$PREFIX/bin/
 !isEmpty(target.path): INSTALLS += target
 
 RESOURCES += \

--- a/tools/ld-process-vbi/ld-process-vbi.pro
+++ b/tools/ld-process-vbi/ld-process-vbi.pro
@@ -38,10 +38,9 @@ HEADERS += \
 # Add external includes to the include path
 INCLUDEPATH += ../library/tbc
 
-# Default rules for deployment.
-qnx: target.path = /tmp/$${TARGET}/bin
-else: unix:!android: target.path = /usr/local/bin/
+# Rules for installation
+isEmpty(PREFIX) {
+    PREFIX = /usr/local
+}
+unix:!android: target.path = $$PREFIX/bin/
 !isEmpty(target.path): INSTALLS += target
-
-
-

--- a/tools/library/filter/testfilter/testfilter.pro
+++ b/tools/library/filter/testfilter/testfilter.pro
@@ -11,3 +11,5 @@ HEADERS += \
 
 INCLUDEPATH += \
     ..
+
+target.CONFIG += no_default_install


### PR DESCRIPTION
The effect of this is that the installation instructions for ld-decode can be simplified to something like:

- Install the dependencies
- `make -j8` (or however many CPUs you have)
- `sudo make install`

You can also specify `prefix=/wherever` to install into a different prefix, and you can specify `prefix=/usr DESTDIR=/somewhere/else` as usual to install into a staging area when building distribution packages. The CI does a `DESTDIR` installation to check it all basically works.

Make's default `CC` is used to build ld-ldf-reader, so clang can be removed from the list of dependencies (you can still set `CC=clang` if you prefer). Variables are provided for qmake and python3 since some distributions name these differently.