### PR TITLE
Added enhanced Multidisc dropout correction feature to ld-dropout-correct

### DIFF
--- a/tools/ld-dropout-correct/correctorpool.cpp
+++ b/tools/ld-dropout-correct/correctorpool.cpp
@@ -90,7 +90,7 @@ bool CorrectorPool::process()
     // Initialise processing state
     inputFrameNumber = 1;
     outputFrameNumber = 1;
-    lastFrameNumber = 5; //ldDecodeMetaData[0].getNumberOfFrames();
+    lastFrameNumber = ldDecodeMetaData[0].getNumberOfFrames();
     totalTimer.start();
 
     // Start a vector of decoding threads to process the video
@@ -141,7 +141,7 @@ bool CorrectorPool::getInputFrame(qint32& frameNumber,
                                   QVector<qint32>& secondFieldNumber, QVector<QByteArray>& secondFieldVideoData, QVector<LdDecodeMetaData::Field>& secondFieldMetadata,
                                   QVector<LdDecodeMetaData::VideoParameters>& videoParameters,
                                   bool& _reverse, bool& _intraField, bool& _overCorrect,
-                                  QVector<qint32>& minVbiForSource, QVector<qint32>& maxVbiForSource)
+                                  QVector<qint32>& minVbiForSource, QVector<qint32>& maxVbiForSource, QVector<qint32>& availableSourcesForFrame)
 {
     QMutexLocker locker(&inputMutex);
 
@@ -157,7 +157,7 @@ bool CorrectorPool::getInputFrame(qint32& frameNumber,
     qint32 numberOfSources = sourceVideos.size();
 
     qDebug().nospace() << "CorrectorPool::getInputFrame(): Processing sequential frame number #" <<
-                          frameNumber << " from " << numberOfSources << " sources";
+                          frameNumber << " from " << numberOfSources << " possible sources";
 
     // Prepare the vectors
     firstFieldNumber.resize(numberOfSources);
@@ -211,6 +211,10 @@ bool CorrectorPool::getInputFrame(qint32& frameNumber,
         }
     }
 
+    // Figure out which of the available sources can be used to correct the current frame
+    availableSourcesForFrame = getAvailableSourcesForFrame(currentVbiFrame);
+
+    // Set the other miscellaneous parameters
     _reverse = reverse;
     _intraField = intraField;
     _overCorrect = overCorrect;

--- a/tools/ld-dropout-correct/correctorpool.cpp
+++ b/tools/ld-dropout-correct/correctorpool.cpp
@@ -3,7 +3,7 @@
     correctorpool.cpp
 
     ld-dropout-correct - Dropout correction for ld-decode
-    Copyright (C) 2018-2019 Simon Inns
+    Copyright (C) 2018-2020 Simon Inns
 
     This file is part of ld-decode-tools.
 

--- a/tools/ld-dropout-correct/correctorpool.cpp
+++ b/tools/ld-dropout-correct/correctorpool.cpp
@@ -90,7 +90,7 @@ bool CorrectorPool::process()
     // Initialise processing state
     inputFrameNumber = 1;
     outputFrameNumber = 1;
-    lastFrameNumber = ldDecodeMetaData[0].getNumberOfFrames();
+    lastFrameNumber = 5; //ldDecodeMetaData[0].getNumberOfFrames();
     totalTimer.start();
 
     // Start a vector of decoding threads to process the video
@@ -140,7 +140,8 @@ bool CorrectorPool::getInputFrame(qint32& frameNumber,
                                   QVector<qint32>& firstFieldNumber, QVector<QByteArray>& firstFieldVideoData, QVector<LdDecodeMetaData::Field>& firstFieldMetadata,
                                   QVector<qint32>& secondFieldNumber, QVector<QByteArray>& secondFieldVideoData, QVector<LdDecodeMetaData::Field>& secondFieldMetadata,
                                   QVector<LdDecodeMetaData::VideoParameters>& videoParameters,
-                                  bool& _reverse, bool& _intraField, bool& _overCorrect)
+                                  bool& _reverse, bool& _intraField, bool& _overCorrect,
+                                  QVector<qint32>& minVbiForSource, QVector<qint32>& maxVbiForSource)
 {
     QMutexLocker locker(&inputMutex);
 
@@ -213,6 +214,9 @@ bool CorrectorPool::getInputFrame(qint32& frameNumber,
     _reverse = reverse;
     _intraField = intraField;
     _overCorrect = overCorrect;
+
+    minVbiForSource = sourceMinimumVbiFrame;
+    maxVbiForSource = sourceMaximumVbiFrame;
 
     return true;
 }

--- a/tools/ld-dropout-correct/correctorpool.cpp
+++ b/tools/ld-dropout-correct/correctorpool.cpp
@@ -157,7 +157,7 @@ bool CorrectorPool::getInputFrame(qint32& frameNumber,
     qint32 numberOfSources = sourceVideos.size();
 
     qDebug().nospace() << "CorrectorPool::getInputFrame(): Processing sequential frame number #" <<
-                          frameNumber << " from " << numberOfSources << " possible sources";
+                          frameNumber << " from " << numberOfSources << " possible source(s)";
 
     // Prepare the vectors
     firstFieldNumber.resize(numberOfSources);
@@ -169,7 +169,8 @@ bool CorrectorPool::getInputFrame(qint32& frameNumber,
     videoParameters.resize(numberOfSources);
 
     // Get the current VBI frame number based on the first source
-    qint32 currentVbiFrame = convertSequentialFrameNumberToVbi(frameNumber, 0);
+    qint32 currentVbiFrame = -1;
+    if (numberOfSources > 1) currentVbiFrame = convertSequentialFrameNumberToVbi(frameNumber, 0);
     for (qint32 sourceNo = 0; sourceNo < numberOfSources; sourceNo++) {
         // Determine the fields for the input frame
         if (sourceNo == 0) {
@@ -212,7 +213,12 @@ bool CorrectorPool::getInputFrame(qint32& frameNumber,
     }
 
     // Figure out which of the available sources can be used to correct the current frame
-    availableSourcesForFrame = getAvailableSourcesForFrame(currentVbiFrame);
+    availableSourcesForFrame.clear();
+    if (numberOfSources > 1) {
+        availableSourcesForFrame = getAvailableSourcesForFrame(currentVbiFrame);
+    } else {
+        availableSourcesForFrame.append(0);
+    }
 
     // Set the other miscellaneous parameters
     _reverse = reverse;

--- a/tools/ld-dropout-correct/correctorpool.h
+++ b/tools/ld-dropout-correct/correctorpool.h
@@ -51,11 +51,13 @@ public:
                        QVector<qint32> &firstFieldNumber, QVector<QByteArray> &firstFieldVideoData, QVector<LdDecodeMetaData::Field> &firstFieldMetadata,
                        QVector<qint32> &secondFieldNumber, QVector<QByteArray> &secondFieldVideoData, QVector<LdDecodeMetaData::Field> &secondFieldMetadata,
                        QVector<LdDecodeMetaData::VideoParameters> &videoParameters,
-                       bool& _reverse, bool& _intraField, bool& _overCorrect, QVector<qint32> &minVbiForSource, QVector<qint32> &maxVbiForSource, QVector<qint32> &availableSourcesForFrame, QVector<qreal> &sourceFrameQuality);
+                       bool& _reverse, bool& _intraField, bool& _overCorrect, QVector<qint32> &minVbiForSource,
+                       QVector<qint32> &maxVbiForSource, QVector<qint32> &availableSourcesForFrame, QVector<qreal> &sourceFrameQuality);
 
     bool setOutputFrame(qint32 frameNumber,
                         QByteArray firstTargetFieldData, QByteArray secondTargetFieldData,
-                        qint32 firstFieldSeqNo, qint32 secondFieldSeqNo);
+                        qint32 firstFieldSeqNo, qint32 secondFieldSeqNo,
+                        qint32 sameSourceReplacement, qint32 multiSourceReplacement, qint32 totalReplacementDistance);
 
 private:
     QString outputFilename;
@@ -85,6 +87,11 @@ private:
         QByteArray secondTargetFieldData;
         qint32 firstFieldSeqNo;
         qint32 secondFieldSeqNo;
+
+        // Statistics
+        qint32 sameSourceReplacement;
+        qint32 multiSourceReplacement;
+        qint32 totalReplacementDistance;
     };
 
     qint32 outputFrameNumber;

--- a/tools/ld-dropout-correct/correctorpool.h
+++ b/tools/ld-dropout-correct/correctorpool.h
@@ -51,7 +51,7 @@ public:
                        QVector<qint32> &firstFieldNumber, QVector<QByteArray> &firstFieldVideoData, QVector<LdDecodeMetaData::Field> &firstFieldMetadata,
                        QVector<qint32> &secondFieldNumber, QVector<QByteArray> &secondFieldVideoData, QVector<LdDecodeMetaData::Field> &secondFieldMetadata,
                        QVector<LdDecodeMetaData::VideoParameters> &videoParameters,
-                       bool& _reverse, bool& _intraField, bool& _overCorrect);
+                       bool& _reverse, bool& _intraField, bool& _overCorrect, QVector<qint32> &minVbiForSource, QVector<qint32> &maxVbiForSource);
 
     bool setOutputFrame(qint32 frameNumber,
                         QByteArray firstTargetFieldData, QByteArray secondTargetFieldData,

--- a/tools/ld-dropout-correct/correctorpool.h
+++ b/tools/ld-dropout-correct/correctorpool.h
@@ -51,7 +51,7 @@ public:
                        QVector<qint32> &firstFieldNumber, QVector<QByteArray> &firstFieldVideoData, QVector<LdDecodeMetaData::Field> &firstFieldMetadata,
                        QVector<qint32> &secondFieldNumber, QVector<QByteArray> &secondFieldVideoData, QVector<LdDecodeMetaData::Field> &secondFieldMetadata,
                        QVector<LdDecodeMetaData::VideoParameters> &videoParameters,
-                       bool& _reverse, bool& _intraField, bool& _overCorrect, QVector<qint32> &minVbiForSource, QVector<qint32> &maxVbiForSource, QVector<qint32> &availableSourcesForFrame);
+                       bool& _reverse, bool& _intraField, bool& _overCorrect, QVector<qint32> &minVbiForSource, QVector<qint32> &maxVbiForSource, QVector<qint32> &availableSourcesForFrame, QVector<qreal> &sourceFrameQuality);
 
     bool setOutputFrame(qint32 frameNumber,
                         QByteArray firstTargetFieldData, QByteArray secondTargetFieldData,

--- a/tools/ld-dropout-correct/correctorpool.h
+++ b/tools/ld-dropout-correct/correctorpool.h
@@ -51,7 +51,7 @@ public:
                        QVector<qint32> &firstFieldNumber, QVector<QByteArray> &firstFieldVideoData, QVector<LdDecodeMetaData::Field> &firstFieldMetadata,
                        QVector<qint32> &secondFieldNumber, QVector<QByteArray> &secondFieldVideoData, QVector<LdDecodeMetaData::Field> &secondFieldMetadata,
                        QVector<LdDecodeMetaData::VideoParameters> &videoParameters,
-                       bool& _reverse, bool& _intraField, bool& _overCorrect, QVector<qint32> &minVbiForSource, QVector<qint32> &maxVbiForSource);
+                       bool& _reverse, bool& _intraField, bool& _overCorrect, QVector<qint32> &minVbiForSource, QVector<qint32> &maxVbiForSource, QVector<qint32> &availableSourcesForFrame);
 
     bool setOutputFrame(qint32 frameNumber,
                         QByteArray firstTargetFieldData, QByteArray secondTargetFieldData,

--- a/tools/ld-dropout-correct/correctorpool.h
+++ b/tools/ld-dropout-correct/correctorpool.h
@@ -41,7 +41,7 @@ class CorrectorPool : public QObject
     Q_OBJECT
 public:
     explicit CorrectorPool(QString _outputFilename, QString _outputJsonFilename,
-                           qint32 _maxThreads, QVector<LdDecodeMetaData> &_ldDecodeMetaData, QVector<SourceVideo> &_sourceVideos,
+                           qint32 _maxThreads, QVector<LdDecodeMetaData *> &_ldDecodeMetaData, QVector<SourceVideo *> &_sourceVideos,
                            bool _reverse, bool _intraField, bool _overCorrect, QObject *parent = nullptr);
 
     bool process();
@@ -76,8 +76,8 @@ private:
     QMutex inputMutex;
     qint32 inputFrameNumber;
     qint32 lastFrameNumber;
-    QVector<LdDecodeMetaData> &ldDecodeMetaData;
-    QVector<SourceVideo> &sourceVideos;
+    QVector<LdDecodeMetaData *> &ldDecodeMetaData;
+    QVector<SourceVideo *> &sourceVideos;
 
     // Output stream information (all guarded by outputMutex while threads are running)
     QMutex outputMutex;

--- a/tools/ld-dropout-correct/correctorpool.h
+++ b/tools/ld-dropout-correct/correctorpool.h
@@ -3,7 +3,7 @@
     correctorpool.h
 
     ld-dropout-correct - Dropout correction for ld-decode
-    Copyright (C) 2018-2019 Simon Inns
+    Copyright (C) 2018-2020 Simon Inns
 
     This file is part of ld-decode-tools.
 

--- a/tools/ld-dropout-correct/dropoutcorrect.cpp
+++ b/tools/ld-dropout-correct/dropoutcorrect.cpp
@@ -3,7 +3,7 @@
     dropoutcorrect.cpp
 
     ld-dropout-correct - Dropout correction for ld-decode
-    Copyright (C) 2018-2019 Simon Inns
+    Copyright (C) 2018-2020 Simon Inns
     Copyright (C) 2019 Adam Sampson
 
     This file is part of ld-decode-tools.

--- a/tools/ld-dropout-correct/dropoutcorrect.cpp
+++ b/tools/ld-dropout-correct/dropoutcorrect.cpp
@@ -43,18 +43,19 @@ void DropOutCorrect::run()
     QVector<LdDecodeMetaData::Field> firstFieldMetadata;
     QVector<LdDecodeMetaData::Field> secondFieldMetadata;
     bool reverse, intraField, overCorrect;
-
-    qDebug() << "DropOutCorrect::process(): Threaded processing loop initialising...";
+    QVector<qint32> minVbiForSource;
+    QVector<qint32> maxVbiForSource;
 
     while(!abort) {
         // Get the next field to process from the input file
         if (!correctorPool.getInputFrame(frameNumber, firstFieldSeqNo, firstSourceField, firstFieldMetadata,
                                        secondFieldSeqNo, secondSourceField, secondFieldMetadata,
-                                       videoParameters, reverse, intraField, overCorrect)) {
+                                       videoParameters, reverse, intraField, overCorrect,
+                                       minVbiForSource, maxVbiForSource)) {
             // No more input fields -- exit
             break;
         }
-        qDebug() << "DropOutCorrect::process(): Got frame number" << frameNumber;
+        qDebug() << "DropOutCorrect::process(): Got sequential frame number" << frameNumber << "with" <<firstFieldSeqNo.size() << "sources available";
 
         // Copy the input frames' data to the target frames.
         // We'll use these both as source and target during correction, which

--- a/tools/ld-dropout-correct/dropoutcorrect.h
+++ b/tools/ld-dropout-correct/dropoutcorrect.h
@@ -65,6 +65,8 @@ private:
 
         bool isSameField;
         qint32 fieldLine;
+
+        qint32 sourceNumber;
     };
 
     // Decoder pool
@@ -80,12 +82,12 @@ private:
                       bool thisFieldIsFirst, bool intraField, QVector<qint32> availableSourcesForFrame);
     QVector<DropOutLocation> populateDropoutsVector(LdDecodeMetaData::Field field, bool overCorrect);
     QVector<DropOutLocation> setDropOutLocations(QVector<DropOutLocation> dropOuts);
-    Replacement findReplacementLine(const QVector<DropOutLocation> &thisFieldDropouts,
-                                    const QVector<DropOutLocation> &otherFieldDropouts,
+    Replacement findReplacementLine(const QVector<QVector<DropOutLocation>> &thisFieldDropouts,
+                                    const QVector<QVector<DropOutLocation>> &otherFieldDropouts,
                                     qint32 dropOutIndex, bool thisFieldIsFirst, bool matchChromaPhase,
                                     bool isColourBurst, bool intraField);
-    void findPotentialReplacementLine(const QVector<DropOutLocation> &targetDropouts, qint32 targetIndex,
-                                      const QVector<DropOutLocation> &sourceDropouts, bool isSameField,
+    void findPotentialReplacementLine(const QVector<QVector<DropOutLocation>> &targetDropouts, qint32 targetIndex,
+                                      const QVector<QVector<DropOutLocation>> &sourceDropouts, bool isSameField,
                                       qint32 sourceOffset, qint32 stepAmount,
                                       qint32 firstActiveFieldLine, qint32 lastActiveFieldLine,
                                       QVector<Replacement> &candidates);

--- a/tools/ld-dropout-correct/dropoutcorrect.h
+++ b/tools/ld-dropout-correct/dropoutcorrect.h
@@ -3,7 +3,7 @@
     dropoutcorrect.h
 
     ld-dropout-correct - Dropout correction for ld-decode
-    Copyright (C) 2018-2019 Simon Inns
+    Copyright (C) 2018-2020 Simon Inns
 
     This file is part of ld-decode-tools.
 

--- a/tools/ld-dropout-correct/dropoutcorrect.h
+++ b/tools/ld-dropout-correct/dropoutcorrect.h
@@ -74,10 +74,10 @@ private:
     LdDecodeMetaData ldDecodeMetaData;
     QVector<LdDecodeMetaData::VideoParameters> videoParameters;
 
-    void correctField(const QVector<DropOutLocation> &thisFieldDropouts,
-                      const QVector<DropOutLocation> &otherFieldDropouts,
-                      QByteArray &thisFieldData, const QByteArray &otherFieldData,
-                      bool thisFieldIsFirst, bool intraField);
+    void correctField(const QVector<QVector<DropOutLocation> > &thisFieldDropouts,
+                      const QVector<QVector<DropOutLocation> > &otherFieldDropouts,
+                      QVector<QByteArray> &thisFieldData, const QVector<QByteArray> &otherFieldData,
+                      bool thisFieldIsFirst, bool intraField, QVector<qint32> availableSourcesForFrame);
     QVector<DropOutLocation> populateDropoutsVector(LdDecodeMetaData::Field field, bool overCorrect);
     QVector<DropOutLocation> setDropOutLocations(QVector<DropOutLocation> dropOuts);
     Replacement findReplacementLine(const QVector<DropOutLocation> &thisFieldDropouts,

--- a/tools/ld-dropout-correct/dropoutcorrect.h
+++ b/tools/ld-dropout-correct/dropoutcorrect.h
@@ -89,13 +89,15 @@ private:
     void correctField(const QVector<QVector<DropOutLocation> > &thisFieldDropouts,
                       const QVector<QVector<DropOutLocation> > &otherFieldDropouts,
                       QVector<QByteArray> &thisFieldData, const QVector<QByteArray> &otherFieldData,
-                      bool thisFieldIsFirst, bool intraField, QVector<qint32> availableSourcesForFrame, QVector<qreal> sourceFrameQuality, Statistics &statistics);
+                      bool thisFieldIsFirst, bool intraField, QVector<qint32> &availableSourcesForFrame,
+                      QVector<qreal> &sourceFrameQuality, Statistics &statistics);
     QVector<DropOutLocation> populateDropoutsVector(LdDecodeMetaData::Field field, bool overCorrect);
     QVector<DropOutLocation> setDropOutLocations(QVector<DropOutLocation> dropOuts);
     Replacement findReplacementLine(const QVector<QVector<DropOutLocation>> &thisFieldDropouts,
                                     const QVector<QVector<DropOutLocation>> &otherFieldDropouts,
                                     qint32 dropOutIndex, bool thisFieldIsFirst, bool matchChromaPhase,
-                                    bool isColourBurst, bool intraField, QVector<qint32> availableSourcesForFrame, QVector<qreal> sourceFrameQuality);
+                                    bool isColourBurst, bool intraField, QVector<qint32> &availableSourcesForFrame,
+                                    QVector<qreal> &sourceFrameQuality);
     void findPotentialReplacementLine(const QVector<QVector<DropOutLocation>> &targetDropouts, qint32 targetIndex,
                                       const QVector<QVector<DropOutLocation>> &sourceDropouts, bool isSameField,
                                       qint32 sourceOffset, qint32 stepAmount,

--- a/tools/ld-dropout-correct/dropoutcorrect.h
+++ b/tools/ld-dropout-correct/dropoutcorrect.h
@@ -68,6 +68,15 @@ private:
 
         qint32 sourceNumber;
         qreal quality;
+
+        qint32 distance;
+    };
+
+    // Statistics
+    struct Statistics {
+        qint32 sameSourceReplacement;
+        qint32 multiSourceReplacement;
+        qint32 totalReplacementDistance;
     };
 
     // Decoder pool
@@ -80,7 +89,7 @@ private:
     void correctField(const QVector<QVector<DropOutLocation> > &thisFieldDropouts,
                       const QVector<QVector<DropOutLocation> > &otherFieldDropouts,
                       QVector<QByteArray> &thisFieldData, const QVector<QByteArray> &otherFieldData,
-                      bool thisFieldIsFirst, bool intraField, QVector<qint32> availableSourcesForFrame, QVector<qreal> sourceFrameQuality);
+                      bool thisFieldIsFirst, bool intraField, QVector<qint32> availableSourcesForFrame, QVector<qreal> sourceFrameQuality, Statistics &statistics);
     QVector<DropOutLocation> populateDropoutsVector(LdDecodeMetaData::Field field, bool overCorrect);
     QVector<DropOutLocation> setDropOutLocations(QVector<DropOutLocation> dropOuts);
     Replacement findReplacementLine(const QVector<QVector<DropOutLocation>> &thisFieldDropouts,
@@ -94,7 +103,7 @@ private:
                                       QVector<Replacement> &candidates, qint32 sourceNo, QVector<qreal> sourceFrameQuality);
     void correctDropOut(const DropOutLocation &dropOut,
                         const Replacement &replacement, const Replacement &chromaReplacement,
-                        QVector<QByteArray> &thisFieldData, const QVector<QByteArray> &otherFieldData);
+                        QVector<QByteArray> &thisFieldData, const QVector<QByteArray> &otherFieldData, Statistics &statistics);
 };
 
 #endif // DROPOUTCORRECT_H

--- a/tools/ld-dropout-correct/dropoutcorrect.h
+++ b/tools/ld-dropout-correct/dropoutcorrect.h
@@ -85,15 +85,15 @@ private:
     Replacement findReplacementLine(const QVector<QVector<DropOutLocation>> &thisFieldDropouts,
                                     const QVector<QVector<DropOutLocation>> &otherFieldDropouts,
                                     qint32 dropOutIndex, bool thisFieldIsFirst, bool matchChromaPhase,
-                                    bool isColourBurst, bool intraField);
+                                    bool isColourBurst, bool intraField, QVector<qint32> availableSourcesForFrame);
     void findPotentialReplacementLine(const QVector<QVector<DropOutLocation>> &targetDropouts, qint32 targetIndex,
                                       const QVector<QVector<DropOutLocation>> &sourceDropouts, bool isSameField,
                                       qint32 sourceOffset, qint32 stepAmount,
                                       qint32 firstActiveFieldLine, qint32 lastActiveFieldLine,
-                                      QVector<Replacement> &candidates);
+                                      QVector<Replacement> &candidates, qint32 sourceNo);
     void correctDropOut(const DropOutLocation &dropOut,
                         const Replacement &replacement, const Replacement &chromaReplacement,
-                        QByteArray &thisFieldData, const QByteArray &otherFieldData);
+                        QVector<QByteArray> &thisFieldData, const QVector<QByteArray> &otherFieldData);
 };
 
 #endif // DROPOUTCORRECT_H

--- a/tools/ld-dropout-correct/dropoutcorrect.h
+++ b/tools/ld-dropout-correct/dropoutcorrect.h
@@ -67,6 +67,7 @@ private:
         qint32 fieldLine;
 
         qint32 sourceNumber;
+        qreal quality;
     };
 
     // Decoder pool
@@ -79,18 +80,18 @@ private:
     void correctField(const QVector<QVector<DropOutLocation> > &thisFieldDropouts,
                       const QVector<QVector<DropOutLocation> > &otherFieldDropouts,
                       QVector<QByteArray> &thisFieldData, const QVector<QByteArray> &otherFieldData,
-                      bool thisFieldIsFirst, bool intraField, QVector<qint32> availableSourcesForFrame);
+                      bool thisFieldIsFirst, bool intraField, QVector<qint32> availableSourcesForFrame, QVector<qreal> sourceFrameQuality);
     QVector<DropOutLocation> populateDropoutsVector(LdDecodeMetaData::Field field, bool overCorrect);
     QVector<DropOutLocation> setDropOutLocations(QVector<DropOutLocation> dropOuts);
     Replacement findReplacementLine(const QVector<QVector<DropOutLocation>> &thisFieldDropouts,
                                     const QVector<QVector<DropOutLocation>> &otherFieldDropouts,
                                     qint32 dropOutIndex, bool thisFieldIsFirst, bool matchChromaPhase,
-                                    bool isColourBurst, bool intraField, QVector<qint32> availableSourcesForFrame);
+                                    bool isColourBurst, bool intraField, QVector<qint32> availableSourcesForFrame, QVector<qreal> sourceFrameQuality);
     void findPotentialReplacementLine(const QVector<QVector<DropOutLocation>> &targetDropouts, qint32 targetIndex,
                                       const QVector<QVector<DropOutLocation>> &sourceDropouts, bool isSameField,
                                       qint32 sourceOffset, qint32 stepAmount,
                                       qint32 firstActiveFieldLine, qint32 lastActiveFieldLine,
-                                      QVector<Replacement> &candidates, qint32 sourceNo);
+                                      QVector<Replacement> &candidates, qint32 sourceNo, QVector<qreal> sourceFrameQuality);
     void correctDropOut(const DropOutLocation &dropOut,
                         const Replacement &replacement, const Replacement &chromaReplacement,
                         QVector<QByteArray> &thisFieldData, const QVector<QByteArray> &otherFieldData);

--- a/tools/ld-dropout-correct/main.cpp
+++ b/tools/ld-dropout-correct/main.cpp
@@ -166,7 +166,6 @@ int main(int argc, char *argv[])
     QString outputFilename = "-";
     QStringList positionalArguments = parser.positionalArguments();
     qint32 totalNumberOfInputFiles = positionalArguments.count() - 1;
-    inputFilenames.resize(totalNumberOfInputFiles);
 
     // Ensure we don't have more than 32 sources
     if (totalNumberOfInputFiles > 32) {
@@ -176,6 +175,9 @@ int main(int argc, char *argv[])
 
     // Get the input TBC sources
     if (positionalArguments.count() >= 2) {
+        // Resize the input filenames vector according to the number of input files supplied
+        inputFilenames.resize(totalNumberOfInputFiles);
+
         for (qint32 i = 0; i < positionalArguments.count() - 1; i++) {
             inputFilenames[i] = positionalArguments.at(i);
         }

--- a/tools/ld-dropout-correct/main.cpp
+++ b/tools/ld-dropout-correct/main.cpp
@@ -332,11 +332,21 @@ int main(int argc, char *argv[])
 
     // Perform the DOC process ----------------------------------------------------------------------------------------
     qInfo() << "Initial source checks are ok and sources are loaded";
+    qint32 result = 0;
     CorrectorPool correctorPool(outputFilename, outputJsonFilename, maxThreads,
                                 ldDecodeMetaData, sourceVideos,
                                 reverse, intraField, overCorrect);
-    if (!correctorPool.process()) return 1;
+    if (!correctorPool.process()) result = 1;
 
-    // Quit with success
-    return 0;
+    // Close open source video files
+    for (qint32 i = 0; i < totalNumberOfInputFiles; i++) sourceVideos[i]->close();
+
+    // Remove metadata objects
+    for (qint32 i = 0; i < totalNumberOfInputFiles; i++) delete ldDecodeMetaData[i];
+
+    // Remove source video objects
+    for (qint32 i = 0; i < totalNumberOfInputFiles; i++) delete sourceVideos[i];
+
+    // Quit
+    return result;
 }

--- a/tools/ld-dropout-correct/main.cpp
+++ b/tools/ld-dropout-correct/main.cpp
@@ -3,7 +3,7 @@
     main.cpp
 
     ld-dropout-correct - Dropout correction for ld-decode
-    Copyright (C) 2018-2019 Simon Inns
+    Copyright (C) 2018-2020 Simon Inns
 
     This file is part of ld-decode-tools.
 
@@ -29,7 +29,6 @@
 #include <QThread>
 
 #include "correctorpool.h"
-#include "dropoutcorrect.h"
 
 // Global for debug output
 static bool showDebug = false;

--- a/tools/library/tbc/lddecodemetadata.h
+++ b/tools/library/tbc/lddecodemetadata.h
@@ -142,6 +142,9 @@ public:
 
     LdDecodeMetaData();
 
+    // Prevent implicit copying
+    LdDecodeMetaData(const LdDecodeMetaData &src) = delete;
+
     bool read(QString fileName);
     bool write(QString fileName);
     bool writeVitsCsv(QString fileName);

--- a/tools/library/tbc/sourcevideo.h
+++ b/tools/library/tbc/sourcevideo.h
@@ -37,6 +37,9 @@ public:
     SourceVideo();
     ~SourceVideo();
 
+    // Prevent implicit copying
+    SourceVideo(const SourceVideo &src) = delete;
+
     // File handling methods
     bool open(QString filename, qint32 _fieldLength, qint32 _fieldLineLength = -1);
     void close(void);


### PR DESCRIPTION
Multidisc dropout correction along with some light updates to the ld-decode-tools library.  This version of ld-dropout-correct can correct a TBC using up to 31 additional sources for the correction data.