### PR TITLE
Fix ld-decode deadlock on exit.

### DIFF
--- a/lddecode/core.py
+++ b/lddecode/core.py
@@ -752,12 +752,10 @@ class DemodCache:
     def end(self):            
         # stop workers
         for i in self.threads:
-            if i.is_alive():
-                self.q_in.put(None)
+            self.q_in.put(None)
 
         for t in self.threads:
-            if t.is_alive():
-                t.join()
+            t.join()
 
         self.q_out.put(None)
 


### PR DESCRIPTION
On machines with small numbers of CPUs (e.g. the GitHub CI machines!), ld-decode would sometimes deadlock on exit, with two threads in different processes blocked reading from pipes.

This turned out to be a race in the DemodCache destructor. It was doing:

```
for i in self.threads:
    if i.is_alive():
        self.q_in.put(None)
```

with the workers exiting when they received a None message. However, suppose you've got two workers, and the following happens:

- DemodCache checks if A is alive - it is
- DemodCache sends None
- B receives None and exits
- DemodCache checks if B is alive - it isn't

A is now stuck waiting for a message that'll never arrive. I've fixed this by removing the is_alive checks -- so it may now send more None messages than necessary, but that's harmless.