### PR TITLE
Add unit tests for VbiDecoder

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -37,6 +37,10 @@ jobs:
       timeout-minutes: 5
       run: tools/library/filter/testfilter/testfilter
 
+    - name: Run testvbidecoder
+      timeout-minutes: 5
+      run: tools/library/tbc/testvbidecoder/testvbidecoder
+
     - name: Decode NTSC CAV
       timeout-minutes: 10
       run: |

--- a/tools/ld-decode-tools.pro
+++ b/tools/ld-decode-tools.pro
@@ -11,4 +11,5 @@ SUBDIRS = \
     ld-lds-converter \
     ld-process-efm \
     ld-process-vbi \
-    library/filter/testfilter
+    library/filter/testfilter \
+    library/tbc/testvbidecoder

--- a/tools/library/tbc/testvbidecoder/testvbidecoder.cpp
+++ b/tools/library/tbc/testvbidecoder/testvbidecoder.cpp
@@ -77,8 +77,6 @@ void testDecode()
     // the standard says shouldn't work (e.g. invalid BCD digits), and for
     // things that discs do anyway regardless of what the standard says :-)
 
-    // FIXME - #if 0 blocks are tests that should pass but don't
-
     cerr << "Testing VbiDecoder::decode\n";
     cerr << "IEC 60857-1986 - 10.1.1 Lead-in\n";
 
@@ -283,10 +281,8 @@ void testDecode()
     {
         Vbi expected;
 
-#if 0
         // Ignore X1 not in range 0-7
         assertSame(decoder.decode(0x88DAFE, 0, 0), expected);
-#endif
     }
 
     cerr << "IEC 60857-1986 - 10.1.10 CLV picture number\n";

--- a/tools/library/tbc/testvbidecoder/testvbidecoder.cpp
+++ b/tools/library/tbc/testvbidecoder/testvbidecoder.cpp
@@ -230,9 +230,7 @@ void testDecode()
 
         // Any bit flips in X4 should be detected as invalid parity
         assert(!decoder.decode(0x8BA417, 0, 0).parity);
-#if 0
         assert(!decoder.decode(0x8BA407, 0, 0).parity);
-#endif
         assert(!decoder.decode(0x8BA447, 0, 0).parity);
         assert(!decoder.decode(0x8BA487, 0, 0).parity);
     }
@@ -270,10 +268,7 @@ void testDecode()
         expected.side = true;
         expected.standardAm2 = true;
         expected.parity = true;
-
-#if 0
         assertSame(decoder.decode(0x8BA839, 0, 0), expected);
-#endif
 
         // Any bit flips in X4 should be detected as invalid parity
         assert(!decoder.decode(0x8BA829, 0, 0).parity);

--- a/tools/library/tbc/testvbidecoder/testvbidecoder.cpp
+++ b/tools/library/tbc/testvbidecoder/testvbidecoder.cpp
@@ -99,10 +99,8 @@ void testDecode()
         assertSame(decoder.decode(0, 0x80EEEE, 0), expected);
         assertSame(decoder.decode(0, 0, 0x80EEEE), expected);
 
-#if 0
         // EE1015 - lead-out code in line 16
         assertSame(decoder.decode(0x80EEEE, 0x80EEEE, 0), expected);
-#endif
     }
 
     cerr << "IEC 60857-1986 - 10.1.3 Picture numbers\n";
@@ -169,10 +167,8 @@ void testDecode()
     {
         Vbi expected;
 
-#if 0
         // Ignore invalid second digit
         assertSame(decoder.decode(0, 0x84ADDD, 0), expected);
-#endif
     }
 
     cerr << "IEC 60857-1986 - 10.1.6 Programme time code\n";
@@ -190,12 +186,10 @@ void testDecode()
     {
         Vbi expected;
 
-#if 0
         // Ignore invalid digits
         assertSame(decoder.decode(0, 0xFADD23, 0), expected);
         assertSame(decoder.decode(0, 0xF1DDA3, 0), expected);
         assertSame(decoder.decode(0, 0xF1DD2A, 0), expected);
-#endif
     }
 
     cerr << "IEC 60857-1986 - 10.1.7 Constant linear velocity code\n";
@@ -309,13 +303,11 @@ void testDecode()
     {
         Vbi expected;
 
-#if 0
         // Ignore invalid digits
         assertSame(decoder.decode(0x84E223, 0, 0), expected);
         assertSame(decoder.decode(0x8EEA23, 0, 0), expected);
         assertSame(decoder.decode(0x8EE2A3, 0, 0), expected);
         assertSame(decoder.decode(0x8EE22A, 0, 0), expected);
-#endif
     }
 }
 

--- a/tools/library/tbc/testvbidecoder/testvbidecoder.cpp
+++ b/tools/library/tbc/testvbidecoder/testvbidecoder.cpp
@@ -1,0 +1,332 @@
+/************************************************************************
+
+    testvbidecoder.cpp
+
+    Unit tests for VbiDecoder
+    Copyright (C) 2020 Adam Sampson
+
+    This file is part of ld-decode-tools.
+
+    ld-chroma-decoder is free software: you can redistribute it and/or
+    modify it under the terms of the GNU General Public License as
+    published by the Free Software Foundation, either version 3 of the
+    License, or (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+************************************************************************/
+
+#include <cassert>
+#include <iostream>
+
+using std::cerr;
+
+#include "vbidecoder.h"
+
+// Check that two Vbi structs are field-by-field identical
+void assertSame(const VbiDecoder::Vbi &actual, const VbiDecoder::Vbi &expected)
+{
+    assert(actual.type == expected.type);
+    assert(actual.userCode == expected.userCode);
+    assert(actual.picNo == expected.picNo);
+    assert(actual.chNo == expected.chNo);
+    assert(actual.clvHr == expected.clvHr);
+    assert(actual.clvMin == expected.clvMin);
+    assert(actual.clvSec == expected.clvSec);
+    assert(actual.clvPicNo == expected.clvPicNo);
+    assert(actual.soundMode == expected.soundMode);
+    assert(actual.soundModeAm2 == expected.soundModeAm2);
+
+    assert(actual.leadIn == expected.leadIn);
+    assert(actual.leadOut == expected.leadOut);
+    assert(actual.picStop == expected.picStop);
+    assert(actual.cx == expected.cx);
+    assert(actual.size == expected.size);
+    assert(actual.side == expected.side);
+    assert(actual.teletext == expected.teletext);
+    assert(actual.dump == expected.dump);
+    assert(actual.fm == expected.fm);
+    assert(actual.digital == expected.digital);
+    assert(actual.parity == expected.parity);
+    assert(actual.copyAm2 == expected.copyAm2);
+    assert(actual.standardAm2 == expected.standardAm2);
+}
+
+// Test VbiDecoder::decode
+void testDecode()
+{
+    using Vbi = VbiDecoder::Vbi;
+    using VbiDiscTypes = VbiDecoder::VbiDiscTypes;
+    using VbiSoundModes = VbiDecoder::VbiSoundModes;
+
+    VbiDecoder decoder;
+
+    // We want to check that decoding a VBI value sets the correct values in
+    // the Vbi structure, and doesn't change any of the other values. So for
+    // each test, we construct an "expected" structure with only the relevant
+    // fields changed, and check that the result of decoding is exactly the
+    // same.
+    //
+    // We test for things that the standard says should work, for things that
+    // the standard says shouldn't work (e.g. invalid BCD digits), and for
+    // things that discs do anyway regardless of what the standard says :-)
+
+    // FIXME - #if 0 blocks are tests that should pass but don't
+
+    cerr << "Testing VbiDecoder::decode\n";
+    cerr << "IEC 60857-1986 - 10.1.1 Lead-in\n";
+
+    {
+        Vbi expected;
+        expected.leadIn = true;
+
+        assertSame(decoder.decode(0, 0x88FFFF, 0), expected);
+        assertSame(decoder.decode(0, 0, 0x88FFFF), expected);
+    }
+
+    cerr << "IEC 60857-1986 - 10.1.2 Lead-out\n";
+
+    {
+        Vbi expected;
+        expected.leadOut = true;
+
+        assertSame(decoder.decode(0, 0x80EEEE, 0), expected);
+        assertSame(decoder.decode(0, 0, 0x80EEEE), expected);
+
+#if 0
+        // EE1015 - lead-out code in line 16
+        assertSame(decoder.decode(0x80EEEE, 0x80EEEE, 0), expected);
+#endif
+    }
+
+    cerr << "IEC 60857-1986 - 10.1.3 Picture numbers\n";
+
+    {
+        Vbi expected;
+        expected.type = VbiDiscTypes::cav;
+        expected.picNo = 12345;
+
+        // Regular
+        assertSame(decoder.decode(0, 0xF12345, 0), expected);
+        assertSame(decoder.decode(0, 0, 0xF12345), expected);
+
+        // Early stopcode signalling
+        assertSame(decoder.decode(0, 0xF92345, 0), expected);
+        assertSame(decoder.decode(0, 0, 0xF92345), expected);
+    }
+
+    {
+        Vbi expected;
+
+        // Ignore invalid digits
+        assertSame(decoder.decode(0, 0xF1A345, 0), expected);
+        assertSame(decoder.decode(0, 0xF12A45, 0), expected);
+        assertSame(decoder.decode(0, 0xF123A5, 0), expected);
+        assertSame(decoder.decode(0, 0xF1234A, 0), expected);
+    }
+
+    {
+        // G138F0117 - corrupt picture number with valid picture number
+        Vbi expected;
+        expected.type = VbiDiscTypes::cav;
+        expected.picNo = 14212;
+
+        assertSame(decoder.decode(0, 0xF95FDF, 0xF94212), expected);
+    }
+
+    cerr << "IEC 60857-1986 - 10.1.4 Picture stop code\n";
+
+    {
+        Vbi expected;
+        expected.type = VbiDiscTypes::cav;
+        expected.picStop = true;
+
+        assertSame(decoder.decode(0x82CFFF, 0, 0), expected);
+        assertSame(decoder.decode(0, 0x82CFFF, 0), expected);
+    }
+
+    cerr << "IEC 60857-1986 - 10.1.5 Chapter numbers\n";
+
+    {
+        Vbi expected;
+        expected.chNo = 42;
+
+        // Stop bit 0
+        assertSame(decoder.decode(0, 0x842DDD, 0), expected);
+        assertSame(decoder.decode(0, 0, 0x842DDD), expected);
+
+        // Stop bit 1
+        assertSame(decoder.decode(0, 0x8C2DDD, 0), expected);
+        assertSame(decoder.decode(0, 0, 0x8C2DDD), expected);
+    }
+
+    {
+        Vbi expected;
+
+#if 0
+        // Ignore invalid second digit
+        assertSame(decoder.decode(0, 0x84ADDD, 0), expected);
+#endif
+    }
+
+    cerr << "IEC 60857-1986 - 10.1.6 Programme time code\n";
+
+    {
+        Vbi expected;
+        expected.type = VbiDiscTypes::clv;
+        expected.clvHr = 1;
+        expected.clvMin = 23;
+
+        assertSame(decoder.decode(0, 0xF1DD23, 0), expected);
+        assertSame(decoder.decode(0, 0, 0xF1DD23), expected);
+    }
+
+    {
+        Vbi expected;
+
+#if 0
+        // Ignore invalid digits
+        assertSame(decoder.decode(0, 0xFADD23, 0), expected);
+        assertSame(decoder.decode(0, 0xF1DDA3, 0), expected);
+        assertSame(decoder.decode(0, 0xF1DD2A, 0), expected);
+#endif
+    }
+
+    cerr << "IEC 60857-1986 - 10.1.7 Constant linear velocity code\n";
+
+    {
+        Vbi expected;
+        expected.type = VbiDiscTypes::clv;
+
+        assertSame(decoder.decode(0, 0x87FFFF, 0), expected);
+    }
+
+    cerr << "IEC 60857-1986 - 10.1.8 Programme status code (including Amendment 2)\n";
+
+    // The examples here are from real discs.
+
+    {
+        // EE 1015 side 1 - PAL with digital audio
+        Vbi expected;
+        expected.cx = false;
+        expected.soundMode = VbiSoundModes::futureUse;
+        expected.soundModeAm2 = VbiSoundModes::futureUse;
+        expected.size = true;
+        expected.side = true;
+        expected.teletext = false;
+        expected.fm = false;
+        expected.parity = true;
+        assertSame(decoder.decode(0x8BA027, 0, 0), expected);
+
+        // EE 1015 side 2
+        expected.side = false;
+        assertSame(decoder.decode(0x8BA427, 0, 0), expected);
+
+        // Any bit flips in X4 should be detected as invalid parity
+        assert(!decoder.decode(0x8BA417, 0, 0).parity);
+#if 0
+        assert(!decoder.decode(0x8BA407, 0, 0).parity);
+#endif
+        assert(!decoder.decode(0x8BA447, 0, 0).parity);
+        assert(!decoder.decode(0x8BA487, 0, 0).parity);
+    }
+
+    {
+        // NJL-11762 side 1 - NTSC
+        Vbi expected;
+        expected.soundMode = VbiSoundModes::stereo;
+        expected.soundModeAm2 = VbiSoundModes::stereo;
+        expected.cx = true;
+        expected.size = true;
+        expected.side = true;
+        expected.standardAm2 = true;
+        expected.parity = true;
+        assertSame(decoder.decode(0x8DC000, 0, 0), expected);
+
+        // NJL-11762 side 2
+        expected.side = false;
+        assertSame(decoder.decode(0x8DC400, 0, 0), expected);
+
+        // Any bit flips in X4 should be detected as invalid parity
+        assert(!decoder.decode(0x8DC410, 0, 0).parity);
+        assert(!decoder.decode(0x8DC420, 0, 0).parity);
+        assert(!decoder.decode(0x8DC440, 0, 0).parity);
+        assert(!decoder.decode(0x8DC480, 0, 0).parity);
+    }
+
+    {
+        // GGV1069, last chapter - NTSC, 8 inch, bilingual
+        Vbi expected;
+        expected.soundMode = VbiSoundModes::bilingual;
+        expected.soundModeAm2 = VbiSoundModes::bilingual;
+        expected.cx = false;
+        expected.size = false;
+        expected.side = true;
+        expected.standardAm2 = true;
+        expected.parity = true;
+
+#if 0
+        assertSame(decoder.decode(0x8BA839, 0, 0), expected);
+#endif
+
+        // Any bit flips in X4 should be detected as invalid parity
+        assert(!decoder.decode(0x8BA829, 0, 0).parity);
+        assert(!decoder.decode(0x8BA819, 0, 0).parity);
+        assert(!decoder.decode(0x8BA879, 0, 0).parity);
+        assert(!decoder.decode(0x8BA8B9, 0, 0).parity);
+    }
+
+    cerr << "IEC 60857-1986 - 10.1.9 Users code\n";
+
+    {
+        Vbi expected;
+        expected.userCode = "5AFE";
+
+        assertSame(decoder.decode(0x85DAFE, 0, 0), expected);
+    }
+
+    {
+        Vbi expected;
+
+#if 0
+        // Ignore X1 not in range 0-7
+        assertSame(decoder.decode(0x88DAFE, 0, 0), expected);
+#endif
+    }
+
+    cerr << "IEC 60857-1986 - 10.1.10 CLV picture number\n";
+
+    {
+        Vbi expected;
+        expected.type = VbiDiscTypes::clv;
+        expected.clvSec = 42;
+        expected.clvPicNo = 23;
+
+        assertSame(decoder.decode(0x8EE223, 0, 0), expected);
+    }
+
+    {
+        Vbi expected;
+
+#if 0
+        // Ignore invalid digits
+        assertSame(decoder.decode(0x84E223, 0, 0), expected);
+        assertSame(decoder.decode(0x8EEA23, 0, 0), expected);
+        assertSame(decoder.decode(0x8EE2A3, 0, 0), expected);
+        assertSame(decoder.decode(0x8EE22A, 0, 0), expected);
+#endif
+    }
+}
+
+int main()
+{
+    testDecode();
+
+    return 0;
+}

--- a/tools/library/tbc/testvbidecoder/testvbidecoder.pro
+++ b/tools/library/tbc/testvbidecoder/testvbidecoder.pro
@@ -1,0 +1,14 @@
+CONFIG += c++11 testcase
+CONFIG -= app_bundle
+
+SOURCES += \
+    testvbidecoder.cpp \
+    ../vbidecoder.cpp
+
+HEADERS += \
+    ../vbidecoder.h
+
+INCLUDEPATH += \
+    ..
+
+target.CONFIG += no_default_install

--- a/tools/library/tbc/vbidecoder.cpp
+++ b/tools/library/tbc/vbidecoder.cpp
@@ -116,33 +116,6 @@ VbiDecoder::Vbi VbiDecoder::decode(qint32 vbi16, qint32 vbi17, qint32 vbi18)
 {
     Vbi vbi;
 
-    // Default VBI
-    vbi.type = VbiDecoder::VbiDiscTypes::unknownDiscType;
-    vbi.userCode = "";
-    vbi.picNo = -1;
-    vbi.chNo = -1;
-    vbi.clvHr = -1;
-    vbi.clvMin = -1;
-    vbi.clvSec = -1;
-    vbi.clvPicNo = -1;
-    vbi.soundMode = VbiDecoder::VbiSoundModes::futureUse;
-    vbi.soundModeAm2 = VbiDecoder::VbiSoundModes::futureUse;
-
-    // Default VBI Flags
-    vbi.leadIn = false;
-    vbi.leadOut = false;
-    vbi.picStop = false;
-    vbi.cx = false;
-    vbi.size = false;
-    vbi.side = false;
-    vbi.teletext = false;
-    vbi.dump = false;
-    vbi.fm = false;
-    vbi.digital = false;
-    vbi.parity = false;
-    vbi.copyAm2 = false;
-    vbi.standardAm2 = false;
-
     if (vbi16 == -1 && vbi17 == -1 && vbi18 == -1) return vbi;
 
     // IEC 60857-1986 - 10.1.1 Lead-in --------------------------------------------------------------------------------

--- a/tools/library/tbc/vbidecoder.cpp
+++ b/tools/library/tbc/vbidecoder.cpp
@@ -166,6 +166,9 @@ VbiDecoder::Vbi VbiDecoder::decode(qint32 vbi16, qint32 vbi17, qint32 vbi18)
     }
 
     if (bcdPictureNumber != 0) {
+        // This code indicates a CAV disc
+        vbi.type = VbiDecoder::VbiDiscTypes::cav;
+
         // Peform BCD to integer conversion:
         vbi.picNo =
             (10000 * ((bcdPictureNumber & 0xF0000) / (16*16*16*16))) +
@@ -186,6 +189,9 @@ VbiDecoder::Vbi VbiDecoder::decode(qint32 vbi16, qint32 vbi17, qint32 vbi18)
     // Check for picture stop code on lines 16 and 17
     if ((vbi16 == 0x82CFFF) ||
             (vbi17 == 0x82CFFF)) {
+        // This code indicates a CAV disc
+        vbi.type = VbiDecoder::VbiDiscTypes::cav;
+
         vbi.picStop = true;
         if (verboseDebug) qDebug() << "VbiDecoder::decode(): VBI Picture stop code flagged";
     }
@@ -246,9 +252,7 @@ VbiDecoder::Vbi VbiDecoder::decode(qint32 vbi16, qint32 vbi17, qint32 vbi18)
 
     // IEC 60857-1986 - 10.1.7 Constant linear velocity code ----------------------------------------------------------
 
-    // Check for CLV code on line 17 (note: this will be overwritten later if a CLV time code is found)
-    vbi.type = VbiDecoder::VbiDiscTypes::cav;
-
+    // Check for CLV code on line 17
     if ( vbi17 == 0x87FFFF ) {
         vbi.type = VbiDecoder::VbiDiscTypes::clv;
     }

--- a/tools/library/tbc/vbidecoder.cpp
+++ b/tools/library/tbc/vbidecoder.cpp
@@ -659,8 +659,8 @@ bool VbiDecoder::parity(quint32 x4, quint32 x5)
     bool x53p = false;
 
     if ((((x51count % 2) == 0) && (x51 == 0)) || (((x51count % 2) != 0) && (x51 != 0))) x51p = true;
-    if ((((x52count % 2) == 0) && (x51 == 0)) || (((x52count % 2) != 0) && (x52 != 0))) x52p = true;
-    if ((((x53count % 2) == 0) && (x51 == 0)) || (((x53count % 2) != 0) && (x53 != 0))) x53p = true;
+    if ((((x52count % 2) == 0) && (x52 == 0)) || (((x52count % 2) != 0) && (x52 != 0))) x52p = true;
+    if ((((x53count % 2) == 0) && (x53 == 0)) || (((x53count % 2) != 0) && (x53 != 0))) x53p = true;
 
     if (x51p && x52p && x53p) return true;
     return false;

--- a/tools/library/tbc/vbidecoder.cpp
+++ b/tools/library/tbc/vbidecoder.cpp
@@ -549,11 +549,13 @@ VbiDecoder::Vbi VbiDecoder::decode(qint32 vbi16, qint32 vbi17, qint32 vbi18)
         quint32 x3x4x5 = (usersCode & 0x000FFF);
 
         // x1 should be 0x00-0x07, x3-x5 are 0x00-0x0F
-        if (x1 > 7) if (verboseDebug) qDebug() << "VbiDecoder::decode(): VBI invalid user code, X1 is > 7";
-
-        // Add the two results together to get the user code
-        vbi.userCode = QString::number(x1, 16).toUpper() + QString::number(x3x4x5, 16).toUpper();
-        if (verboseDebug) qDebug() << "VbiDecoder::decode(): VBI user code is" << vbi.userCode;
+        if (x1 > 7) {
+            if (verboseDebug) qDebug() << "VbiDecoder::decode(): VBI invalid user code, X1 is > 7";
+        } else {
+            // Add the two results together to get the user code
+            vbi.userCode = QString::number(x1, 16).toUpper() + QString::number(x3x4x5, 16).toUpper();
+            if (verboseDebug) qDebug() << "VbiDecoder::decode(): VBI user code is" << vbi.userCode;
+        }
     }
 
     // IEC 60857-1986 - 10.1.10 CLV picture number --------------------------------------------------------------------

--- a/tools/library/tbc/vbidecoder.h
+++ b/tools/library/tbc/vbidecoder.h
@@ -90,6 +90,7 @@ public:
 private:
     bool verboseDebug;
     bool parity(quint32 x4, quint32 x5);
+    bool decodeBCD(quint32 bcd, qint32 &output);
 };
 
 #endif // VBIDECODER_H

--- a/tools/library/tbc/vbidecoder.h
+++ b/tools/library/tbc/vbidecoder.h
@@ -54,33 +54,32 @@ public:
         futureUse               // 11
     };
 
-    // Overall container struct for VBI information
+    // Overall container struct for VBI information, with default values
     struct Vbi {
-        VbiDiscTypes type;
-        QString userCode;
-        qint32 picNo;
-        qint32 chNo;
-        qint32 clvHr;
-        qint32 clvMin;
-        qint32 clvSec;
-        qint32 clvPicNo;
-        VbiSoundModes soundMode;
-        VbiSoundModes soundModeAm2;
+        VbiDiscTypes type = VbiDiscTypes::unknownDiscType;
+        QString userCode = "";
+        qint32 picNo = -1;
+        qint32 chNo = -1;
+        qint32 clvHr = -1;
+        qint32 clvMin = -1;
+        qint32 clvSec = -1;
+        qint32 clvPicNo = -1;
+        VbiSoundModes soundMode = VbiSoundModes::futureUse;
+        VbiSoundModes soundModeAm2 = VbiSoundModes::futureUse;
 
-        // Note: These booleans are virtual (and stored in a single int)
-        bool leadIn;
-        bool leadOut;
-        bool picStop;
-        bool cx;
-        bool size;
-        bool side;
-        bool teletext;
-        bool dump;
-        bool fm;
-        bool digital;
-        bool parity;
-        bool copyAm2;
-        bool standardAm2;
+        bool leadIn = false;
+        bool leadOut = false;
+        bool picStop = false;
+        bool cx = false;
+        bool size = false;
+        bool side = false;
+        bool teletext = false;
+        bool dump = false;
+        bool fm = false;
+        bool digital = false;
+        bool parity = false;
+        bool copyAm2 = false;
+        bool standardAm2 = false;
     };
 
     VbiDecoder();


### PR DESCRIPTION
Add unit tests for VbiDecoder (which are now run by the CI), and fix some minor problems they revealed:

- Don't assume a disc is CAV until we've seen a code indicating that.
- Fix the programme status code parity check - I believe this works for Amendment 2 codes too.
- Check BCD digits are valid in all the codes that use BCD - I've added a helper function for this.
- Don't store invalid user codes.

I've added tests for several of the oddities we've seen on real discs, but if anyone's got any more it'd be easy enough to add them.