### PR TITLE
Three VBI fixes for ld-decode

### DIFF
--- a/ld-cut
+++ b/ld-cut
@@ -69,13 +69,19 @@ if args.MTF_offset is not None:
 
 if args.seek != -1:
     startloc = ldd.seek(args.start, args.seek) 
-    if startloc > 1:
+    if startloc is None:
+        print("ERROR: Seeking failed")
+        exit(1)
+    elif startloc > 1:
         startloc -= 1
 else:
     startloc = args.start * 2
 
 if args.end != -1:
     endloc = ldd.seek(startloc, args.end)
+    if endloc is None:
+        print("ERROR: Seeking failed")
+        exit(1)
 elif args.length != -1:
     endloc = startloc + (args.length * 2)
 else:

--- a/ld-decode
+++ b/ld-decode
@@ -89,7 +89,9 @@ if system == 'NTSC' and not args.ntscj:
 #print(ldd.blackIRE)
 
 if args.seek != -1:
-    ldd.seek(firstframe, args.seek)
+    if ldd.seek(firstframe, args.seek) is None:
+        print("ERROR: Seeking failed")
+        exit(1)
 
 if args.MTF is not None:
     ldd.rf.mtf_mult = args.MTF

--- a/lddecode/core.py
+++ b/lddecode/core.py
@@ -2968,21 +2968,19 @@ class LDdecode:
 
         for retries in range(3):
             fnr = self.seek_getframenr(cur)
-            cur = int((self.fieldloc / self.bytes_per_field))
             if fnr is None:
                 return None
-            else:
-                if fnr == target:
-                    logging.info("Finished seek")
-                    print("Finished seeking, starting at frame", fnr, file=sys.stderr)
-                    self.roughseek(cur)
-                    return cur
-                else:
-                    cur += ((target - fnr) * 2) - 1
 
-        print("Finished seeking, starting at frame", fnr, file=sys.stderr)
+            cur = int((self.fieldloc / self.bytes_per_field))
+            if fnr == target:
+                logging.info("Finished seek")
+                print("Finished seeking, starting at frame", fnr, file=sys.stderr)
+                self.roughseek(cur)
+                return cur
 
-        return cur - 0
+            cur += ((target - fnr) * 2) - 1
+
+        return None
 
     def build_json(self, f):
         ''' build up the JSON structure for file output. '''

--- a/lddecode/core.py
+++ b/lddecode/core.py
@@ -2489,6 +2489,7 @@ class LDdecode:
 
         self.fieldinfo = []
 
+        self.leadIn = False
         self.leadOut = False
         self.isCLV = False
         self.frameNumber = None
@@ -2667,6 +2668,8 @@ class LDdecode:
             
             if l == 0x80eeee: # lead-out reached
                 leadoutCount += 1
+            elif l == 0x88ffff: # lead-in
+                self.leadIn = True
             elif (l & 0xf0dd00) == 0xf0dd00: # CLV minutes/hours
                 self.clvMinutes = (l & 0xf) + (((l >> 4) & 0xf) * 10) + (((l >> 16) & 0xf) * 60)
                 self.isCLV = True
@@ -2913,6 +2916,8 @@ class LDdecode:
                         print("file frame %d CLV timecode %d:%.2d.%.2d frame %d" % (rawloc, self.clvMinutes, self.clvSeconds, self.clvFrameNum, self.frameNumber), file=sys.stderr)
                     elif self.frameNumber:
                         print("file frame %d CAV frame %d" % (rawloc, self.frameNumber), file=sys.stderr)
+                    elif self.leadIn:
+                        print("file frame %d lead in" % (rawloc), file=sys.stderr)
                     elif self.leadOut:
                         print("file frame %d lead out" % (rawloc), file=sys.stderr)
                     else:


### PR DESCRIPTION
If seeking with `-S` fails, exit 1 rather than continuing from the wrong position.

Recognise the lead-in VBI code, rather than showing it as unknown.

Ignore VBI codes containing invalid BCD digits. Fixes #332.