### PR TITLE
Miscellaneous tidying in ld-decode-vbi

### DIFF
--- a/tools/ld-process-vbi/closedcaption.cpp
+++ b/tools/ld-process-vbi/closedcaption.cpp
@@ -24,11 +24,6 @@
 
 #include "closedcaption.h"
 
-ClosedCaption::ClosedCaption(QObject *parent) : QObject(parent)
-{
-
-}
-
 // Public method to read CEA-608 Closed Captioning data (NTSC only)
 ClosedCaption::CcData ClosedCaption::getData(QByteArray lineData, LdDecodeMetaData::VideoParameters videoParameters)
 {

--- a/tools/ld-process-vbi/closedcaption.h
+++ b/tools/ld-process-vbi/closedcaption.h
@@ -25,18 +25,12 @@
 #ifndef CLOSEDCAPTION_H
 #define CLOSEDCAPTION_H
 
-#include <QObject>
-
 #include "sourcevideo.h"
 #include "lddecodemetadata.h"
 
-class ClosedCaption : public QObject
+class ClosedCaption
 {
-    Q_OBJECT
-
 public:
-    explicit ClosedCaption(QObject *parent = nullptr);
-
     struct CcData {
         uchar byte0;
         uchar byte1;

--- a/tools/ld-process-vbi/decoderpool.cpp
+++ b/tools/ld-process-vbi/decoderpool.cpp
@@ -25,8 +25,8 @@
 #include "decoderpool.h"
 
 DecoderPool::DecoderPool(QString _inputFilename, QString _outputJsonFilename,
-                         qint32 _maxThreads, LdDecodeMetaData &_ldDecodeMetaData, QObject *parent)
-    : QObject(parent), inputFilename(_inputFilename), outputJsonFilename(_outputJsonFilename),
+                         qint32 _maxThreads, LdDecodeMetaData &_ldDecodeMetaData)
+    : inputFilename(_inputFilename), outputJsonFilename(_outputJsonFilename),
       maxThreads(_maxThreads), ldDecodeMetaData(_ldDecodeMetaData)
 {
 }

--- a/tools/ld-process-vbi/decoderpool.cpp
+++ b/tools/ld-process-vbi/decoderpool.cpp
@@ -116,8 +116,8 @@ bool DecoderPool::getInputField(qint32 &fieldNumber, QByteArray& fieldVideoData,
     // Show what we are about to process
     qDebug() << "DecoderPool::process(): Processing field number" << fieldNumber;
 
-    // Fetch the input data (we require only lines 10 to 21 from the field)
-    fieldVideoData = sourceVideo.getVideoField(fieldNumber, 10, 21);
+    // Fetch the input data
+    fieldVideoData = sourceVideo.getVideoField(fieldNumber, VbiLineDecoder::startFieldLine, VbiLineDecoder::endFieldLine);
     fieldMetadata = ldDecodeMetaData.getField(fieldNumber);
     videoParameters = ldDecodeMetaData.getVideoParameters();
 

--- a/tools/ld-process-vbi/decoderpool.h
+++ b/tools/ld-process-vbi/decoderpool.h
@@ -25,7 +25,6 @@
 #ifndef DECODERPOOL_H
 #define DECODERPOOL_H
 
-#include <QObject>
 #include <QAtomicInt>
 #include <QByteArray>
 #include <QElapsedTimer>
@@ -36,14 +35,12 @@
 #include "lddecodemetadata.h"
 #include "vbilinedecoder.h"
 
-class DecoderPool : public QObject
+class DecoderPool
 {
-    Q_OBJECT
 public:
     // Public methods
     explicit DecoderPool(QString _inputFilename, QString _outputJsonFilename,
-                        qint32 _maxThreads, LdDecodeMetaData &_ldDecodeMetaData,
-                        QObject *parent = nullptr);
+                        qint32 _maxThreads, LdDecodeMetaData &_ldDecodeMetaData);
     bool process();
 
     // Member functions used by worker threads

--- a/tools/ld-process-vbi/fmcode.cpp
+++ b/tools/ld-process-vbi/fmcode.cpp
@@ -24,11 +24,6 @@
 
 #include "fmcode.h"
 
-FmCode::FmCode(QObject *parent) : QObject(parent)
-{
-
-}
-
 // Public method to read a 40-bit FM coded signal from a field line
 FmCode::FmDecode FmCode::fmDecoder(QByteArray lineData, LdDecodeMetaData::VideoParameters videoParameters)
 {

--- a/tools/ld-process-vbi/fmcode.h
+++ b/tools/ld-process-vbi/fmcode.h
@@ -25,14 +25,11 @@
 #ifndef FMCODE_H
 #define FMCODE_H
 
-#include <QObject>
-
 #include "sourcevideo.h"
 #include "lddecodemetadata.h"
 
-class FmCode : public QObject
+class FmCode
 {
-    Q_OBJECT
 public:
     struct FmDecode {
         quint64 receiverClockSyncBits;
@@ -43,13 +40,7 @@ public:
         quint64 trailingDataRecognitionBits;
     };
 
-    explicit FmCode(QObject *parent = nullptr);
-
     FmCode::FmDecode fmDecoder(QByteArray lineData, LdDecodeMetaData::VideoParameters videoParameters);
-
-signals:
-
-public slots:
 
 private:
     bool isEvenParity(quint64 data);

--- a/tools/ld-process-vbi/vbilinedecoder.cpp
+++ b/tools/ld-process-vbi/vbilinedecoder.cpp
@@ -25,6 +25,11 @@
 #include "vbilinedecoder.h"
 #include "decoderpool.h"
 
+// Definitions of static constexpr data members, for compatibility with
+// pre-C++17 compilers
+constexpr qint32 VbiLineDecoder::startFieldLine;
+constexpr qint32 VbiLineDecoder::endFieldLine;
+
 VbiLineDecoder::VbiLineDecoder(QAtomicInt& _abort, DecoderPool& _decoderPool, QObject *parent)
     : QThread(parent), abort(_abort), decoderPool(_decoderPool)
 {
@@ -40,6 +45,7 @@ void VbiLineDecoder::run()
     QByteArray sourceFieldData;
     LdDecodeMetaData::Field fieldMetadata;
     LdDecodeMetaData::VideoParameters videoParameters;
+
 
     while(!abort) {
         // Get the next field to process from the input file
@@ -63,15 +69,13 @@ void VbiLineDecoder::run()
         // Determine the 16-bit zero-crossing point
         qint32 zcPoint = videoParameters.white16bIre - videoParameters.black16bIre;
 
-        // Get the VBI data from the field lines (we only read field lines 10-21, so the real field line number is -9)
+        // Get the VBI data from field lines 16-18
         qDebug() << "VbiDecoder::process(): Getting field-lines for field" << fieldNumber;
-        fieldMetadata.vbi.vbiData[0] = manchesterDecoder(getActiveVideoLine(&sourceFieldData, 16 - 9, videoParameters), zcPoint, videoParameters);
-        fieldMetadata.vbi.vbiData[1] = manchesterDecoder(getActiveVideoLine(&sourceFieldData, 17 - 9, videoParameters), zcPoint, videoParameters);
-        fieldMetadata.vbi.vbiData[2] = manchesterDecoder(getActiveVideoLine(&sourceFieldData, 18 - 9, videoParameters), zcPoint, videoParameters);
-
-        if (fieldMetadata.vbi.vbiData[0] == 0) qDebug() << "VbiDecoder::process(): No VBI present on line 16";
-        if (fieldMetadata.vbi.vbiData[1] == 0) qDebug() << "VbiDecoder::process(): No VBI present on line 17";
-        if (fieldMetadata.vbi.vbiData[2] == 0) qDebug() << "VbiDecoder::process(): No VBI present on line 18";
+        for (qint32 i = 0; i < 3; i++) {
+            fieldMetadata.vbi.vbiData[i] = manchesterDecoder(getActiveVideoLine(&sourceFieldData, i + 16 - startFieldLine, videoParameters),
+                                                             zcPoint, videoParameters);
+            if (fieldMetadata.vbi.vbiData[i] == 0) qDebug() << "VbiDecoder::process(): No VBI present on line" << i + 16;
+        }
 
         // Show the VBI data as hexadecimal (for every 1000th field)
         if (fieldNumber % 1000 == 0) {
@@ -80,14 +84,14 @@ void VbiLineDecoder::run()
 
         // Process NTSC specific data if source type is NTSC
         if (!videoParameters.isSourcePal) {
-            // Get the 40-bit FM coded data from the field lines
-            fmDecode = fmCode.fmDecoder(getActiveVideoLine(&sourceFieldData, 10 - 9, videoParameters), videoParameters);
+            // Get the 40-bit FM coded data from field line 10
+            fmDecode = fmCode.fmDecoder(getActiveVideoLine(&sourceFieldData, 10 - startFieldLine, videoParameters), videoParameters);
 
-            // Get the white flag from the field lines
-            isWhiteFlag = whiteFlag.getWhiteFlag(getActiveVideoLine(&sourceFieldData, 11 - 9, videoParameters), videoParameters);
+            // Get the white flag from field line 11
+            isWhiteFlag = whiteFlag.getWhiteFlag(getActiveVideoLine(&sourceFieldData, 11 - startFieldLine, videoParameters), videoParameters);
 
             // Get the closed captioning from field line 21
-            ccData = closedCaption.getData(getActiveVideoLine(&sourceFieldData, 21 - 9, videoParameters), videoParameters);
+            ccData = closedCaption.getData(getActiveVideoLine(&sourceFieldData, 21 - startFieldLine, videoParameters), videoParameters);
 
             // Update the metadata
             if (fmDecode.receiverClockSyncBits != 0) {
@@ -129,12 +133,12 @@ QByteArray VbiLineDecoder::getActiveVideoLine(QByteArray *sourceField, qint32 fi
                                         LdDecodeMetaData::VideoParameters videoParameters)
 {
     // Range-check the scan line
-    if (fieldLine > videoParameters.fieldHeight || fieldLine < 1) {
+    if (fieldLine < 0 || fieldLine >= videoParameters.fieldHeight) {
         qWarning() << "Cannot generate field-line data, line number is out of bounds! Scan line =" << fieldLine;
         return QByteArray();
     }
 
-    qint32 startPointer = ((fieldLine - 1) * videoParameters.fieldWidth * 2) + (videoParameters.activeVideoStart * 2);
+    qint32 startPointer = (fieldLine * videoParameters.fieldWidth * 2) + (videoParameters.activeVideoStart * 2);
     qint32 length = (videoParameters.activeVideoEnd - videoParameters.activeVideoStart) * 2;
 
     return sourceField->mid(startPointer, length);

--- a/tools/ld-process-vbi/vbilinedecoder.h
+++ b/tools/ld-process-vbi/vbilinedecoder.h
@@ -43,6 +43,10 @@ class VbiLineDecoder : public QThread {
 public:
     explicit VbiLineDecoder(QAtomicInt& _abort, DecoderPool& _decoderPool, QObject *parent = nullptr);
 
+    // The range of field lines needed from the input file (inclusive)
+    static constexpr qint32 startFieldLine = 10;
+    static constexpr qint32 endFieldLine = 21;
+
 protected:
     void run() override;
 

--- a/tools/ld-process-vbi/whiteflag.cpp
+++ b/tools/ld-process-vbi/whiteflag.cpp
@@ -24,11 +24,6 @@
 
 #include "whiteflag.h"
 
-WhiteFlag::WhiteFlag(QObject *parent) : QObject(parent)
-{
-
-}
-
 // Public method to read the white flag status from a field-line
 bool WhiteFlag::getWhiteFlag(QByteArray lineData, LdDecodeMetaData::VideoParameters videoParameters)
 {

--- a/tools/ld-process-vbi/whiteflag.h
+++ b/tools/ld-process-vbi/whiteflag.h
@@ -28,19 +28,10 @@
 #include "sourcevideo.h"
 #include "lddecodemetadata.h"
 
-#include <QObject>
-
-class WhiteFlag : public QObject
+class WhiteFlag
 {
-    Q_OBJECT
 public:
-    explicit WhiteFlag(QObject *parent = nullptr);
-
     bool getWhiteFlag(QByteArray lineData, LdDecodeMetaData::VideoParameters videoParameters);
-
-signals:
-
-public slots:
 };
 
 #endif // WHITEFLAG_H

--- a/tools/library/tbc/lddecodemetadata.h
+++ b/tools/library/tbc/lddecodemetadata.h
@@ -25,7 +25,6 @@
 #ifndef LDDECODEMETADATA_H
 #define LDDECODEMETADATA_H
 
-#include <QObject>
 #include <QVector>
 #include <QTemporaryFile>
 #include <QDebug>
@@ -181,10 +180,6 @@ public:
 
     qint32 convertClvTimecodeToFrameNumber(LdDecodeMetaData::ClvTimecode clvTimeCode);
     LdDecodeMetaData::ClvTimecode convertFrameNumberToClvTimecode(qint32 clvFrameNumber);
-
-signals:
-
-public slots:
 
 private:
     JsonWax json;

--- a/tools/library/tbc/sourcevideo.h
+++ b/tools/library/tbc/sourcevideo.h
@@ -25,14 +25,12 @@
 #ifndef SOURCEVIDEO_H
 #define SOURCEVIDEO_H
 
-#include <QObject>
 #include <QFile>
 #include <QCache>
 #include <QDebug>
 
 class SourceVideo
 {
-
 public:
     SourceVideo();
     ~SourceVideo();

--- a/tools/library/tbc/vbidecoder.h
+++ b/tools/library/tbc/vbidecoder.h
@@ -25,7 +25,6 @@
 #ifndef VBIDECODER_H
 #define VBIDECODER_H
 
-#include <QObject>
 #include <QDebug>
 
 class VbiDecoder


### PR DESCRIPTION
Some tidying, extracted from my zvbi experiments:

- Remove more unused QObject bits from ld-decode-vbi and library/tbc.

- Add constants for the range of line numbers ld-decode-vbi extracts, so these can now be changed in one place.

No functional changes.
