### PR TITLE
Tweaks for Mac compilation.

### DIFF
--- a/tools/ld-analyse/dropoutanalysisdialog.h
+++ b/tools/ld-analyse/dropoutanalysisdialog.h
@@ -26,11 +26,20 @@
 #define DROPOUTANALYSISDIALOG_H
 
 #include <QDialog>
+/* Workaround to compile on Mac. Similar may need to be done for other non-ubuntu distros */
+#if defined(__APPLE__)
+#include <qwt_plot.h>
+#include <qwt_plot_canvas.h>
+#include <qwt_legend.h>
+#include <qwt_plot_grid.h>
+#include <qwt_plot_curve.h>
+#else
 #include <qwt/qwt_plot.h>
 #include <qwt/qwt_plot_canvas.h>
 #include <qwt/qwt_legend.h>
 #include <qwt/qwt_plot_grid.h>
 #include <qwt/qwt_plot_curve.h>
+#endif
 
 #include "lddecodemetadata.h"
 

--- a/tools/ld-analyse/dropoutanalysisdialog.h
+++ b/tools/ld-analyse/dropoutanalysisdialog.h
@@ -26,20 +26,12 @@
 #define DROPOUTANALYSISDIALOG_H
 
 #include <QDialog>
-/* Workaround to compile on Mac. Similar may need to be done for other non-ubuntu distros */
-#if defined(__APPLE__)
 #include <qwt_plot.h>
 #include <qwt_plot_canvas.h>
 #include <qwt_legend.h>
 #include <qwt_plot_grid.h>
 #include <qwt_plot_curve.h>
-#else
-#include <qwt/qwt_plot.h>
-#include <qwt/qwt_plot_canvas.h>
-#include <qwt/qwt_legend.h>
-#include <qwt/qwt_plot_grid.h>
-#include <qwt/qwt_plot_curve.h>
-#endif
+
 
 #include "lddecodemetadata.h"
 

--- a/tools/ld-analyse/ld-analyse.pro
+++ b/tools/ld-analyse/ld-analyse.pro
@@ -121,7 +121,8 @@ LIBS += -lopencv_core -lopencv_imgcodecs -lopencv_highgui -lopencv_imgproc -lope
 
 # Include the QWT library (used for charting)
 unix:!macx {
-INCLUDEPATH += $(QWT)/include
+#INCLUDEPATH += $(QWT)/include
+INCLUDEPATH += /usr/include/qwt
 LIBS += -lqwt-qt5 #Distrubutions other than Ubuntu may be -lqwt
 }
 macx {

--- a/tools/ld-analyse/ld-analyse.pro
+++ b/tools/ld-analyse/ld-analyse.pro
@@ -126,7 +126,6 @@ INCLUDEPATH += /usr/include/qwt
 LIBS += -lqwt-qt5 #Distrubutions other than Ubuntu may be -lqwt
 }
 macx {
-# There's probably a better way to reference these, but works for now...
-INCLUDEPATH += "/usr/local/Cellar/qwt/6.1.4/lib/qwt.framework/Versions/6/Headers"
-LIBS += -F"/usr/local/Cellar/qwt/6.1.4/lib" -framework qwt
+INCLUDEPATH += "/usr/local/lib/qwt.framework/Versions/6/Headers"
+LIBS += -F"/usr/local/lib" -framework qwt
 }

--- a/tools/ld-analyse/ld-analyse.pro
+++ b/tools/ld-analyse/ld-analyse.pro
@@ -108,8 +108,11 @@ RESOURCES += \
     ld-analyse-resources.qrc
 
 # Additional include paths to support MacOS compilation
+macx {
 INCLUDEPATH += "/usr/local/opt/opencv@2/include"
 LIBS += -L"/usr/local/opt/opencv@2/lib"
+INCLUDEPATH += "/usr/local/include"
+}
 
 # Normal open-source OS goodness
 INCLUDEPATH += "/usr/local/include/opencv"
@@ -117,9 +120,12 @@ LIBS += -L"/usr/local/lib"
 LIBS += -lopencv_core -lopencv_imgcodecs -lopencv_highgui -lopencv_imgproc -lopencv_video -lfftw3
 
 # Include the QWT library (used for charting)
+unix:!macx {
 INCLUDEPATH += $(QWT)/include
-LIBS += -lqwt-qt5
-
-
-
-
+LIBS += -lqwt-qt5 #Distrubutions other than Ubuntu may be -lqwt
+}
+macx {
+# There's probably a better way to reference these, but works for now...
+INCLUDEPATH += "/usr/local/Cellar/qwt/6.1.4/lib/qwt.framework/Versions/6/Headers"
+LIBS += -F"/usr/local/Cellar/qwt/6.1.4/lib" -framework qwt
+}

--- a/tools/ld-analyse/mainwindow.cpp
+++ b/tools/ld-analyse/mainwindow.cpp
@@ -297,6 +297,10 @@ void MainWindow::showFrame()
     if (!tbcSource.getIsSourcePal()) {
         closedCaptionDialog->addData(currentFrameNumber, tbcSource.getCcData0(currentFrameNumber), tbcSource.getCcData1(currentFrameNumber));
     }
+    // QT Bug workaround for some macOS versions
+    #if defined(Q_OS_MACOS)
+    	repaint();
+    #endif
 }
 
 // Redraw the frame viewer (for example, when scaleFactor has been changed)

--- a/tools/ld-analyse/snranalysisdialog.cpp
+++ b/tools/ld-analyse/snranalysisdialog.cpp
@@ -70,8 +70,8 @@ void SnrAnalysisDialog::removeChartContents()
 // Add a data point to the chart
 void SnrAnalysisDialog::addDataPoint(qint32 fieldNumber, qreal blackSnr, qreal whiteSnr)
 {
-    if (!isnanf(static_cast<float>(blackSnr))) blackPoints->append(QPointF(fieldNumber, blackSnr));
-    if (!isnanf(static_cast<float>(whiteSnr))) whitePoints->append(QPointF(fieldNumber, whiteSnr));
+    if (!std::isnan(static_cast<float>(blackSnr))) blackPoints->append(QPointF(fieldNumber, blackSnr));
+    if (!std::isnan(static_cast<float>(whiteSnr))) whitePoints->append(QPointF(fieldNumber, whiteSnr));
 
     // Keep track of the minimum and maximum SNR values
     if (blackSnr < minSnr) minSnr = blackSnr;

--- a/tools/ld-analyse/snranalysisdialog.h
+++ b/tools/ld-analyse/snranalysisdialog.h
@@ -31,20 +31,11 @@
 #endif
 
 #include <QDialog>
-/* Workaround to compile on Mac. Similar may need to be done for other non-ubuntu distros */
-#if defined(__APPLE__)
 #include <qwt_plot.h>
 #include <qwt_plot_canvas.h>
 #include <qwt_legend.h>
 #include <qwt_plot_grid.h>
 #include <qwt_plot_curve.h>
-#else
-#include <qwt/qwt_plot.h>
-#include <qwt/qwt_plot_canvas.h>
-#include <qwt/qwt_legend.h>
-#include <qwt/qwt_plot_grid.h>
-#include <qwt/qwt_plot_curve.h>
-#endif
 
 #include "lddecodemetadata.h"
 

--- a/tools/ld-analyse/snranalysisdialog.h
+++ b/tools/ld-analyse/snranalysisdialog.h
@@ -25,12 +25,26 @@
 #ifndef SNRANALYSISDIALOG_H
 #define SNRANALYSISDIALOG_H
 
+/* workaround for Macs */
+#if defined(__APPLE__)
+#define isnanf(X) isnan((double)(X))
+#endif
+
 #include <QDialog>
+/* Workaround to compile on Mac. Similar may need to be done for other non-ubuntu distros */
+#if defined(__APPLE__)
+#include <qwt_plot.h>
+#include <qwt_plot_canvas.h>
+#include <qwt_legend.h>
+#include <qwt_plot_grid.h>
+#include <qwt_plot_curve.h>
+#else
 #include <qwt/qwt_plot.h>
 #include <qwt/qwt_plot_canvas.h>
 #include <qwt/qwt_legend.h>
 #include <qwt/qwt_plot_grid.h>
 #include <qwt/qwt_plot_curve.h>
+#endif
 
 #include "lddecodemetadata.h"
 

--- a/tools/ld-analyse/snranalysisdialog.h
+++ b/tools/ld-analyse/snranalysisdialog.h
@@ -25,10 +25,7 @@
 #ifndef SNRANALYSISDIALOG_H
 #define SNRANALYSISDIALOG_H
 
-/* workaround for Macs */
-#if defined(__APPLE__)
-#define isnanf(X) isnan((double)(X))
-#endif
+#include <cmath>
 
 #include <QDialog>
 #include <qwt_plot.h>

--- a/tools/ld-chroma-decoder/ld-chroma-decoder.pro
+++ b/tools/ld-chroma-decoder/ld-chroma-decoder.pro
@@ -70,8 +70,11 @@ unix:!android: target.path = $$PREFIX/bin/
 !isEmpty(target.path): INSTALLS += target
 
 # Additional include paths to support MacOS compilation
+macx {
 INCLUDEPATH += "/usr/local/opt/opencv@2/include"
 LIBS += -L"/usr/local/opt/opencv@2/lib"
+INCLUDEPATH += "/usr/local/include"
+}
 
 # Normal open-source OS goodness
 INCLUDEPATH += "/usr/local/include/opencv"


### PR DESCRIPTION
Allows building with homebrew-installed qwt, and works around QT bug on macOS 10.12 (and possibly others) where ld-analyse wouldn't refresh after pressing frame buttons.