### PR TITLE
Use QVector<quint16> rather than QByteArray for TBC fields and RGB output

### DIFF
--- a/tools/ld-analyse/ld-analyse.pro
+++ b/tools/ld-analyse/ld-analyse.pro
@@ -69,6 +69,7 @@ HEADERS += \
     ../ld-chroma-decoder/palcolour.h \
     ../ld-chroma-decoder/comb.h \
     ../ld-chroma-decoder/rgb.h \
+    ../ld-chroma-decoder/rgbframe.h \
     ../ld-chroma-decoder/yiq.h \
     ../ld-chroma-decoder/transformpal.h \
     ../ld-chroma-decoder/transformpal2d.h \

--- a/tools/ld-analyse/tbcsource.cpp
+++ b/tools/ld-analyse/tbcsource.cpp
@@ -356,7 +356,7 @@ TbcSource::ScanLineData TbcSource::getScanLineData(qint32 frameNumber, qint32 sc
     scanLineData.isSourcePal = videoParameters.isSourcePal;
 
     // Get the field video and dropout data
-    QByteArray fieldData;
+    SourceVideo::Data fieldData;
     LdDecodeMetaData::DropOuts dropouts;
     if (isFieldTop) {
         fieldData = sourceVideo.getVideoField(firstFieldNumber);
@@ -370,8 +370,7 @@ TbcSource::ScanLineData TbcSource::getScanLineData(qint32 frameNumber, qint32 sc
     scanLineData.isDropout.resize(videoParameters.fieldWidth);
     for (qint32 xPosition = 0; xPosition < videoParameters.fieldWidth; xPosition++) {
         // Get the 16-bit YC value for the current pixel (frame data is numbered 0-624 or 0-524)
-        uchar *pixelPointer = reinterpret_cast<uchar*>(fieldData.data()) + ((fieldLine - 1) * videoParameters.fieldWidth * 2) + (xPosition * 2);
-        scanLineData.data[xPosition] = (pixelPointer[1] * 256) + pixelPointer[0];
+        scanLineData.data[xPosition] = fieldData[((fieldLine - 1) * videoParameters.fieldWidth) + xPosition];
 
         scanLineData.isDropout[xPosition] = false;
         for (qint32 doCount = 0; doCount < dropouts.startx.size(); doCount++) {
@@ -598,12 +597,15 @@ QImage TbcSource::generateQImage(qint32 firstFieldNumber, qint32 secondFieldNumb
         // Display the current frame as LPF only
 
         // Get the field data
-        QByteArray firstField = sourceVideo.getVideoField(firstFieldNumber);
-        QByteArray secondField = sourceVideo.getVideoField(secondFieldNumber);
+        SourceVideo::Data firstField = sourceVideo.getVideoField(firstFieldNumber);
+        SourceVideo::Data secondField = sourceVideo.getVideoField(secondFieldNumber);
 
-        // Generate pointers to the 16-bit greyscale data
-        quint16* firstFieldPointer = reinterpret_cast<quint16*>(firstField.data());
-        quint16* secondFieldPointer = reinterpret_cast<quint16*>(secondField.data());
+        // Generate pointers to the 16-bit greyscale data.
+        // Since we're taking a non-const pointer here, this will detach from
+        // the original copy of the data (which is what we want, because we're
+        // going to filter it in place).
+        quint16 *firstFieldPointer = firstField.data();
+        quint16 *secondFieldPointer = secondField.data();
 
         // Generate a filter object
         Filters filters;
@@ -622,37 +624,25 @@ QImage TbcSource::generateQImage(qint32 firstFieldNumber, qint32 secondFieldNumb
         // Copy the raw 16-bit grayscale data into the RGB888 QImage
         for (qint32 y = 0; y < frameHeight; y++) {
             for (qint32 x = 0; x < videoParameters.fieldWidth; x++) {
-                // Take just the MSB of the input data
-                uchar pixelValue;
+                qint32 pixelOffset = (videoParameters.fieldWidth * (y / 2)) + x;
+                qreal pixelValue32;
                 if (y % 2) {
-                    qreal pixelValue32 = static_cast<qreal>(secondFieldPointer[x + (videoParameters.fieldWidth * (y / 2))]);
-
-                    // Clamp the IRE value for the pixel
-                    if (pixelValue32 < videoParameters.black16bIre) pixelValue32 = videoParameters.black16bIre;
-                    if (pixelValue32 > videoParameters.white16bIre) pixelValue32 = videoParameters.white16bIre;
-
-                    // Scale the IRE value to a 16 bit greyscale value
-                    qreal scaledValue = ((pixelValue32 - static_cast<qreal>(videoParameters.black16bIre)) /
-                                         (static_cast<qreal>(videoParameters.white16bIre) -
-                                          static_cast<qreal>(videoParameters.black16bIre))) * 65535.0;
-                    pixelValue32 = static_cast<qint32>(scaledValue);
-
-                    // Convert to 8-bit for RGB888
-                    pixelValue = static_cast<uchar>(pixelValue32 / 256);
+                    pixelValue32 = static_cast<qreal>(secondFieldPointer[pixelOffset]);
                 } else {
-                    qreal pixelValue32 = static_cast<qreal>(firstFieldPointer[x + (videoParameters.fieldWidth * (y / 2))]);
-                    if (pixelValue32 < videoParameters.black16bIre) pixelValue32 = videoParameters.black16bIre;
-                    if (pixelValue32 > videoParameters.white16bIre) pixelValue32 = videoParameters.white16bIre;
-
-                    // Scale the IRE value to a 16 bit greyscale value
-                    qreal scaledValue = ((pixelValue32 - static_cast<qreal>(videoParameters.black16bIre)) /
-                                         (static_cast<qreal>(videoParameters.white16bIre)
-                                          - static_cast<qreal>(videoParameters.black16bIre))) * 65535.0;
-                    pixelValue32 = static_cast<qint32>(scaledValue);
-
-                    // Convert to 8-bit for RGB888
-                    pixelValue = static_cast<uchar>(pixelValue32 / 256);
+                    pixelValue32 = static_cast<qreal>(firstFieldPointer[pixelOffset]);
                 }
+
+                if (pixelValue32 < videoParameters.black16bIre) pixelValue32 = videoParameters.black16bIre;
+                if (pixelValue32 > videoParameters.white16bIre) pixelValue32 = videoParameters.white16bIre;
+
+                // Scale the IRE value to a 16 bit greyscale value
+                qreal scaledValue = ((pixelValue32 - static_cast<qreal>(videoParameters.black16bIre)) /
+                                     (static_cast<qreal>(videoParameters.white16bIre)
+                                      - static_cast<qreal>(videoParameters.black16bIre))) * 65535.0;
+                pixelValue32 = static_cast<qint32>(scaledValue);
+
+                // Convert to 8-bit for RGB888
+                uchar pixelValue = static_cast<uchar>(pixelValue32 / 256);
 
                 qint32 xpp = x * 3;
                 *(frameImage.scanLine(y) + xpp + 0) = static_cast<uchar>(pixelValue); // R
@@ -664,26 +654,23 @@ QImage TbcSource::generateQImage(qint32 firstFieldNumber, qint32 secondFieldNumb
         // Display the current frame as source data
 
         // Get the field data
-        QByteArray firstField = sourceVideo.getVideoField(firstFieldNumber);
-        QByteArray secondField = sourceVideo.getVideoField(secondFieldNumber);
+        SourceVideo::Data firstField = sourceVideo.getVideoField(firstFieldNumber);
+        SourceVideo::Data secondField = sourceVideo.getVideoField(secondFieldNumber);
+
+        // Get pointers to the 16-bit greyscale data
+        const quint16 *firstFieldPointer = firstField.data();
+        const quint16 *secondFieldPointer = secondField.data();
 
         // Copy the raw 16-bit grayscale data into the RGB888 QImage
         for (qint32 y = 0; y < frameHeight; y++) {
-            // Extract the current scan line data from the frame
-            qint32 startPointer = (y / 2) * videoParameters.fieldWidth * 2;
-            qint32 length = videoParameters.fieldWidth * 2;
-
-            firstLineData = firstField.mid(startPointer, length);
-            secondLineData = secondField.mid(startPointer, length);
-
             for (qint32 x = 0; x < videoParameters.fieldWidth; x++) {
                 // Take just the MSB of the input data
-                qint32 dp = x * 2;
+                qint32 pixelOffset = (videoParameters.fieldWidth * (y / 2)) + x;
                 uchar pixelValue;
                 if (y % 2) {
-                    pixelValue = static_cast<uchar>(secondLineData[dp + 1]);
+                    pixelValue = static_cast<uchar>(secondFieldPointer[pixelOffset] / 256);
                 } else {
-                    pixelValue = static_cast<uchar>(firstLineData[dp + 1]);
+                    pixelValue = static_cast<uchar>(firstFieldPointer[pixelOffset] / 256);
                 }
 
                 qint32 xpp = x * 3;

--- a/tools/ld-chroma-decoder/comb.cpp
+++ b/tools/ld-chroma-decoder/comb.cpp
@@ -86,8 +86,8 @@ QByteArray Comb::decodeFrame(const SourceField &firstField, const SourceField &s
     qint32 fieldLine = 0;
     currentFrameBuffer.rawbuffer.clear();
     for (qint32 frameLine = 0; frameLine < frameHeight; frameLine += 2) {
-        currentFrameBuffer.rawbuffer.append(firstField.data.mid(fieldLine * videoParameters.fieldWidth * 2, videoParameters.fieldWidth * 2));
-        currentFrameBuffer.rawbuffer.append(secondField.data.mid(fieldLine * videoParameters.fieldWidth * 2, videoParameters.fieldWidth * 2));
+        currentFrameBuffer.rawbuffer.append(firstField.data.mid(fieldLine * videoParameters.fieldWidth, videoParameters.fieldWidth));
+        currentFrameBuffer.rawbuffer.append(secondField.data.mid(fieldLine * videoParameters.fieldWidth, videoParameters.fieldWidth));
         fieldLine++;
     }
 
@@ -213,7 +213,7 @@ void Comb::split1D(FrameBuffer *frameBuffer)
 {
     for (qint32 lineNumber = configuration.firstActiveLine; lineNumber < configuration.lastActiveLine; lineNumber++) {
         // Get a pointer to the line's data
-        quint16 *line = reinterpret_cast<quint16 *>(frameBuffer->rawbuffer.data() + (lineNumber * videoParameters.fieldWidth) * 2);
+        const quint16 *line = frameBuffer->rawbuffer.data() + (lineNumber * videoParameters.fieldWidth);
 
         for (qint32 h = videoParameters.activeVideoStart; h < videoParameters.activeVideoEnd; h++) {
             qreal tc1 = (((line[h + 2] + line[h - 2]) / 2) - line[h]);
@@ -297,9 +297,8 @@ void Comb::split3D(FrameBuffer *currentFrame, FrameBuffer *previousFrame)
     }
 
     for (qint32 lineNumber = configuration.firstActiveLine; lineNumber < configuration.lastActiveLine; lineNumber++) {
-
-        quint16 *currentLine = reinterpret_cast<quint16 *>(currentFrame->rawbuffer.data() + (lineNumber * videoParameters.fieldWidth) * 2);
-        quint16 *previousLine = reinterpret_cast<quint16 *>(previousFrame->rawbuffer.data() + (lineNumber * videoParameters.fieldWidth) * 2);
+        const quint16 *currentLine = currentFrame->rawbuffer.data() + (lineNumber * videoParameters.fieldWidth);
+        const quint16 *previousLine = previousFrame->rawbuffer.data() + (lineNumber * videoParameters.fieldWidth);
 
         for (qint32 h = videoParameters.activeVideoStart; h < videoParameters.activeVideoEnd; h++) {
             currentFrame->clpbuffer[2].pixel[lineNumber][h] = (previousLine[h] - currentLine[h]) / 2;
@@ -315,7 +314,7 @@ void Comb::splitIQ(FrameBuffer *frameBuffer)
 
     for (qint32 lineNumber = configuration.firstActiveLine; lineNumber < configuration.lastActiveLine; lineNumber++) {
         // Get a pointer to the line's data
-        quint16 *line = reinterpret_cast<quint16 *>(frameBuffer->rawbuffer.data() + (lineNumber * videoParameters.fieldWidth) * 2);
+        const quint16 *line = frameBuffer->rawbuffer.data() + (lineNumber * videoParameters.fieldWidth);
         bool linePhase = GetLinePhase(frameBuffer, lineNumber);
 
         qreal si = 0, sq = 0;

--- a/tools/ld-chroma-decoder/comb.h
+++ b/tools/ld-chroma-decoder/comb.h
@@ -95,7 +95,7 @@ private:
     };
 
     struct FrameBuffer {
-        QByteArray rawbuffer;
+        SourceVideo::Data rawbuffer;
 
         QVector<PixelLine> clpbuffer; // Unfiltered chroma for the current phase (can be I or Q)
         QVector<qreal> kValues;

--- a/tools/ld-chroma-decoder/comb.h
+++ b/tools/ld-chroma-decoder/comb.h
@@ -35,6 +35,7 @@
 
 #include "opticalflow.h"
 #include "rgb.h"
+#include "rgbframe.h"
 #include "sourcefield.h"
 #include "yiq.h"
 #include "yiqbuffer.h"
@@ -73,7 +74,7 @@ public:
                              const Configuration &configuration);
 
     // Decode two fields to produce an interlaced frame.
-    QByteArray decodeFrame(const SourceField &firstField, const SourceField &secondField);
+    RGBFrame decodeFrame(const SourceField &firstField, const SourceField &secondField);
 
 protected:
 
@@ -125,8 +126,8 @@ private:
     void doCNR(YiqBuffer &yiqBuffer);
     void doYNR(YiqBuffer &yiqBuffer);
 
-    QByteArray yiqToRgbFrame(const YiqBuffer &yiqBuffer, qreal burstLevel);
-    void overlayOpticalFlowMap(const FrameBuffer &frameBuffer, QByteArray &rgbOutputFrame);
+    RGBFrame yiqToRgbFrame(const YiqBuffer &yiqBuffer, qreal burstLevel);
+    void overlayOpticalFlowMap(const FrameBuffer &frameBuffer, RGBFrame &rgbOutputFrame);
     void adjustY(FrameBuffer *frameBuffer, YiqBuffer &yiqBuffer);
 };
 

--- a/tools/ld-chroma-decoder/decoder.cpp
+++ b/tools/ld-chroma-decoder/decoder.cpp
@@ -84,27 +84,27 @@ void Decoder::setVideoParameters(Decoder::Configuration &config, const LdDecodeM
                "will be colourised and trimmed to" << outputWidth << "x" << outputHeight << "RGB 16-16-16 frames";
 }
 
-QByteArray Decoder::cropOutputFrame(const Decoder::Configuration &config, QByteArray outputData) {
+RGBFrame Decoder::cropOutputFrame(const Decoder::Configuration &config, const RGBFrame &outputData) {
     const qint32 activeVideoStart = config.videoParameters.activeVideoStart;
     const qint32 activeVideoEnd = config.videoParameters.activeVideoEnd;
-    const qint32 outputLineBytes = (activeVideoEnd - activeVideoStart) * 6;
+    const qint32 outputLineLength = (activeVideoEnd - activeVideoStart) * 3;
 
-    QByteArray croppedData;
+    RGBFrame croppedData;
 
     // Insert padding at the top
     if (config.topPadLines > 0) {
-        croppedData.append(config.topPadLines * outputLineBytes, 0);
+        croppedData.insert(croppedData.begin(), config.topPadLines * outputLineLength, 0);
     }
 
     // Copy the active region from the decoded image
     for (qint32 y = config.firstActiveLine; y < config.lastActiveLine; y++) {
-        croppedData.append(outputData.mid((y * config.videoParameters.fieldWidth * 6) + (activeVideoStart * 6),
-                                          outputLineBytes));
+        croppedData.append(outputData.mid((y * config.videoParameters.fieldWidth * 3) + (activeVideoStart * 3),
+                                          outputLineLength));
     }
 
     // Insert padding at the bottom
     if (config.bottomPadLines > 0) {
-        croppedData.append(config.bottomPadLines * outputLineBytes, 0);
+        croppedData.insert(croppedData.end(), config.bottomPadLines * outputLineLength, 0);
     }
 
     return croppedData;
@@ -119,7 +119,7 @@ void DecoderThread::run()
 {
     // Input and output data
     QVector<SourceField> inputFields;
-    QVector<QByteArray> outputFrames;
+    QVector<RGBFrame> outputFrames;
 
     while (!abort) {
         // Get the next batch of fields to process

--- a/tools/ld-chroma-decoder/decoder.h
+++ b/tools/ld-chroma-decoder/decoder.h
@@ -26,13 +26,13 @@
 #define DECODER_H
 
 #include <QAtomicInt>
-#include <QByteArray>
 #include <QDebug>
 #include <QThread>
 #include <cassert>
 
 #include "lddecodemetadata.h"
 
+#include "rgbframe.h"
 #include "sourcefield.h"
 
 class DecoderPool;
@@ -93,7 +93,7 @@ public:
                                    qint32 firstActiveLine, qint32 lastActiveLine);
 
     // Crop a full decoded frame to the output frame size
-    static QByteArray cropOutputFrame(const Configuration &config, QByteArray outputData);
+    static RGBFrame cropOutputFrame(const Configuration &config, const RGBFrame &outputData);
 };
 
 // Abstract base class for chroma decoder worker threads.
@@ -107,7 +107,7 @@ protected:
 
     // Decode a sequence of fields into a sequence of frames
     virtual void decodeFrames(const QVector<SourceField> &inputFields, qint32 startIndex, qint32 endIndex,
-                              QVector<QByteArray> &outputFrames) = 0;
+                              QVector<RGBFrame> &outputFrames) = 0;
 
     // Decoder pool
     QAtomicInt& abort;

--- a/tools/ld-chroma-decoder/decoderpool.cpp
+++ b/tools/ld-chroma-decoder/decoderpool.cpp
@@ -178,7 +178,7 @@ bool DecoderPool::getInputFrames(qint32 &startFrameNumber, QVector<SourceField> 
     return true;
 }
 
-bool DecoderPool::putOutputFrames(qint32 startFrameNumber, const QVector<QByteArray> &outputFrames)
+bool DecoderPool::putOutputFrames(qint32 startFrameNumber, const QVector<RGBFrame> &outputFrames)
 {
     QMutexLocker locker(&outputMutex);
 
@@ -199,17 +199,17 @@ bool DecoderPool::putOutputFrames(qint32 startFrameNumber, const QVector<QByteAr
 // whether we can now write some of them out.
 //
 // Returns true on success, false on failure.
-bool DecoderPool::putOutputFrame(qint32 frameNumber, const QByteArray &outputFrame)
+bool DecoderPool::putOutputFrame(qint32 frameNumber, const RGBFrame &outputFrame)
 {
     // Put this frame into the map
     pendingOutputFrames[frameNumber] = outputFrame;
 
     // Write out as many frames as possible
     while (pendingOutputFrames.contains(outputFrameNumber)) {
-        const QByteArray& outputData = pendingOutputFrames.value(outputFrameNumber);
+        const RGBFrame& outputData = pendingOutputFrames.value(outputFrameNumber);
 
         // Save the frame data to the output file
-        if (!targetVideo.write(outputData.data(), outputData.size())) {
+        if (!targetVideo.write(reinterpret_cast<const char *>(outputData.data()), outputData.size() * 2)) {
             // Could not write to target video file
             qCritical() << "Writing to the output video file failed";
             return false;

--- a/tools/ld-chroma-decoder/decoderpool.h
+++ b/tools/ld-chroma-decoder/decoderpool.h
@@ -27,7 +27,6 @@
 
 #include <QObject>
 #include <QAtomicInt>
-#include <QByteArray>
 #include <QElapsedTimer>
 #include <QMap>
 #include <QMutex>
@@ -73,10 +72,10 @@ public:
     // frame being startFrameNumber.
     //
     // Returns true on success, false on failure.
-    bool putOutputFrames(qint32 startFrameNumber, const QVector<QByteArray> &outputFrames);
+    bool putOutputFrames(qint32 startFrameNumber, const QVector<RGBFrame> &outputFrames);
 
 private:
-    bool putOutputFrame(qint32 frameNumber, const QByteArray &outputFrame);
+    bool putOutputFrame(qint32 frameNumber, const RGBFrame &outputFrame);
 
     // Default batch size, in frames
     static constexpr qint32 DEFAULT_BATCH_SIZE = 16;
@@ -105,7 +104,7 @@ private:
     // Output stream information (all guarded by outputMutex while threads are running)
     QMutex outputMutex;
     qint32 outputFrameNumber;
-    QMap<qint32, QByteArray> pendingOutputFrames;
+    QMap<qint32, RGBFrame> pendingOutputFrames;
     QFile targetVideo;
     QElapsedTimer totalTimer;
 };

--- a/tools/ld-chroma-decoder/framecanvas.cpp
+++ b/tools/ld-chroma-decoder/framecanvas.cpp
@@ -28,9 +28,9 @@
 // pre-C++17 compilers
 constexpr FrameCanvas::RGB FrameCanvas::green;
 
-FrameCanvas::FrameCanvas(QByteArray &_rgbFrame, const LdDecodeMetaData::VideoParameters &_videoParameters,
+FrameCanvas::FrameCanvas(RGBFrame &_rgbFrame, const LdDecodeMetaData::VideoParameters &_videoParameters,
                          qint32 _firstActiveLine, qint32 _lastActiveLine)
-    : rgbData(reinterpret_cast<quint16 *>(_rgbFrame.data())), rgbSize(_rgbFrame.size() / sizeof(quint16)),
+    : rgbData(_rgbFrame.data()), rgbSize(_rgbFrame.size()),
       videoParameters(_videoParameters), firstActiveLine(_firstActiveLine), lastActiveLine(_lastActiveLine)
 {
 }

--- a/tools/ld-chroma-decoder/framecanvas.h
+++ b/tools/ld-chroma-decoder/framecanvas.h
@@ -25,17 +25,18 @@
 #ifndef FRAMECANVAS_H
 #define FRAMECANVAS_H
 
-#include <QByteArray>
 #include <QtGlobal>
 
 #include "lddecodemetadata.h"
+
+#include "rgbframe.h"
 
 // Context for drawing on top of a full-frame RGB image.
 class FrameCanvas {
 public:
     // rgbFrame is the frame to draw upon, and videoParameters gives its dimensions.
     // (Both parameters are captured by reference, not copied.)
-    FrameCanvas(QByteArray &rgbFrame, const LdDecodeMetaData::VideoParameters &videoParameters,
+    FrameCanvas(RGBFrame &rgbFrame, const LdDecodeMetaData::VideoParameters &videoParameters,
                 qint32 firstActiveLine, qint32 lastActiveLine);
 
     // Return the edges of the active area.

--- a/tools/ld-chroma-decoder/ld-chroma-decoder.pro
+++ b/tools/ld-chroma-decoder/ld-chroma-decoder.pro
@@ -46,6 +46,7 @@ HEADERS += \
     palcolour.h \
     paldecoder.h \
     rgb.h \
+    rgbframe.h \
     sourcefield.h \
     transformpal.h \
     transformpal2d.h \

--- a/tools/ld-chroma-decoder/monodecoder.cpp
+++ b/tools/ld-chroma-decoder/monodecoder.cpp
@@ -58,12 +58,12 @@ MonoThread::MonoThread(QAtomicInt& _abort, DecoderPool& _decoderPool,
 {
     // Resize and clear the output buffer
     const qint32 frameHeight = (config.videoParameters.fieldHeight * 2) - 1;
-    outputFrame.resize(config.videoParameters.fieldWidth * frameHeight * 6);
+    outputFrame.resize(config.videoParameters.fieldWidth * frameHeight * 3);
     outputFrame.fill(0);
 }
 
 void MonoThread::decodeFrames(const QVector<SourceField> &inputFields, qint32 startIndex, qint32 endIndex,
-                             QVector<QByteArray> &outputFrames)
+                              QVector<RGBFrame> &outputFrames)
 {
     // Work out black-white scaling factors
     const LdDecodeMetaData::VideoParameters &videoParameters = config.videoParameters;
@@ -77,8 +77,7 @@ void MonoThread::decodeFrames(const QVector<SourceField> &inputFields, qint32 st
 
             // Each quint16 input becomes three quint16 outputs
             const quint16 *inputLine = inputFieldData.data() + ((y / 2) * videoParameters.fieldWidth);
-            quint16 *outputLine =      reinterpret_cast<quint16 *>(outputFrame.data())
-                                       + (y * videoParameters.fieldWidth * 3);
+            quint16 *outputLine = outputFrame.data() + (y * videoParameters.fieldWidth * 3);
 
             for (qint32 x = videoParameters.activeVideoStart; x < videoParameters.activeVideoEnd; x++) {
                 const quint16 value = static_cast<quint16>(qBound(0.0, (inputLine[x] - blackOffset) * whiteScale, 65535.0));

--- a/tools/ld-chroma-decoder/monodecoder.cpp
+++ b/tools/ld-chroma-decoder/monodecoder.cpp
@@ -73,11 +73,10 @@ void MonoThread::decodeFrames(const QVector<SourceField> &inputFields, qint32 st
     for (qint32 fieldIndex = startIndex, frameIndex = 0; fieldIndex < endIndex; fieldIndex += 2, frameIndex++) {
         // Interlace the active lines of the two input fields to produce an output frame
         for (qint32 y = config.firstActiveLine; y < config.lastActiveLine; y++) {
-            const QByteArray &inputFieldData = (y % 2) == 0 ? inputFields[fieldIndex].data : inputFields[fieldIndex + 1].data;
+            const SourceVideo::Data &inputFieldData = (y % 2) == 0 ? inputFields[fieldIndex].data : inputFields[fieldIndex + 1].data;
 
             // Each quint16 input becomes three quint16 outputs
-            const quint16 *inputLine = reinterpret_cast<const quint16 *>(inputFieldData.data())
-                                       + ((y / 2) * videoParameters.fieldWidth);
+            const quint16 *inputLine = inputFieldData.data() + ((y / 2) * videoParameters.fieldWidth);
             quint16 *outputLine =      reinterpret_cast<quint16 *>(outputFrame.data())
                                        + (y * videoParameters.fieldWidth * 3);
 

--- a/tools/ld-chroma-decoder/monodecoder.h
+++ b/tools/ld-chroma-decoder/monodecoder.h
@@ -58,14 +58,14 @@ public:
 
 protected:
     void decodeFrames(const QVector<SourceField> &inputFields, qint32 startIndex, qint32 endIndex,
-                      QVector<QByteArray> &outputFrames) override;
+                      QVector<RGBFrame> &outputFrames) override;
 
 private:
     // Settings
     const MonoDecoder::Configuration &config;
 
     // The frame being assembled
-    QByteArray outputFrame;
+    RGBFrame outputFrame;
 };
 
 #endif // MONODECODER

--- a/tools/ld-chroma-decoder/ntscdecoder.cpp
+++ b/tools/ld-chroma-decoder/ntscdecoder.cpp
@@ -70,7 +70,7 @@ NtscThread::NtscThread(QAtomicInt& _abort, DecoderPool &_decoderPool,
 }
 
 void NtscThread::decodeFrames(const QVector<SourceField> &inputFields, qint32 startIndex, qint32 endIndex,
-                              QVector<QByteArray> &outputFrames)
+                              QVector<RGBFrame> &outputFrames)
 {
     // Decode lookahead fields, discarding the result
     for (qint32 i = 0; i < startIndex; i += 2) {
@@ -80,7 +80,7 @@ void NtscThread::decodeFrames(const QVector<SourceField> &inputFields, qint32 st
     // Decode real fields to frames
     for (qint32 i = startIndex, j = 0; i < endIndex; i += 2, j++) {
         // Filter the frame
-        QByteArray outputData = comb.decodeFrame(inputFields[i], inputFields[i + 1]);
+        RGBFrame outputData = comb.decodeFrame(inputFields[i], inputFields[i + 1]);
 
         // The NTSC filter outputs the whole frame, so here we crop it to the required dimensions
         outputFrames[j] = NtscDecoder::cropOutputFrame(config, outputData);

--- a/tools/ld-chroma-decoder/ntscdecoder.h
+++ b/tools/ld-chroma-decoder/ntscdecoder.h
@@ -68,7 +68,7 @@ public:
 
 protected:
     void decodeFrames(const QVector<SourceField> &inputFields, qint32 startIndex, qint32 endIndex,
-                      QVector<QByteArray> &outputFrames) override;
+                      QVector<RGBFrame> &outputFrames) override;
 
 private:
     // Settings

--- a/tools/ld-chroma-decoder/palcolour.cpp
+++ b/tools/ld-chroma-decoder/palcolour.cpp
@@ -299,7 +299,7 @@ void PalColour::decodeFrames(const QVector<SourceField> &inputFields, qint32 sta
 void PalColour::decodeField(const SourceField &inputField, const double *chromaData, double chromaGain, QByteArray &outputFrame)
 {
     // Pointer to the composite signal data
-    const quint16 *compPtr = reinterpret_cast<const quint16 *>(inputField.data.data());
+    const quint16 *compPtr = inputField.data.data();
 
     const qint32 firstLine = inputField.getFirstActiveLine(configuration.firstActiveLine);
     const qint32 lastLine = inputField.getLastActiveLine(configuration.lastActiveLine);
@@ -494,7 +494,7 @@ void PalColour::decodeLine(const SourceField &inputField, const ChromaSample *ch
     }
 
     // Pointer to composite signal data
-    const quint16 *comp = reinterpret_cast<const quint16 *>(inputField.data.data()) + (line.number * videoParameters.fieldWidth);
+    const quint16 *comp = inputField.data.data() + (line.number * videoParameters.fieldWidth);
 
     // Define scan line pointer to output buffer using 16 bit unsigned words
     quint16 *ptr = reinterpret_cast<quint16 *>(outputFrame.data()

--- a/tools/ld-chroma-decoder/palcolour.cpp
+++ b/tools/ld-chroma-decoder/palcolour.cpp
@@ -240,10 +240,10 @@ void PalColour::buildLookUpTables()
     }
 }
 
-QByteArray PalColour::decodeFrame(const SourceField &firstField, const SourceField &secondField)
+RGBFrame PalColour::decodeFrame(const SourceField &firstField, const SourceField &secondField)
 {
     QVector<SourceField> inputFields {firstField, secondField};
-    QVector<QByteArray> outputFrames(1);
+    QVector<RGBFrame> outputFrames(1);
 
     decodeFrames(inputFields, 0, 2, outputFrames);
 
@@ -251,7 +251,7 @@ QByteArray PalColour::decodeFrame(const SourceField &firstField, const SourceFie
 }
 
 void PalColour::decodeFrames(const QVector<SourceField> &inputFields, qint32 startIndex, qint32 endIndex,
-                             QVector<QByteArray> &outputFrames)
+                             QVector<RGBFrame> &outputFrames)
 {
     assert(configurationSet);
     assert((outputFrames.size() * 2) == (endIndex - startIndex));
@@ -265,7 +265,7 @@ void PalColour::decodeFrames(const QVector<SourceField> &inputFields, qint32 sta
     // Resize and clear the output buffers
     const qint32 frameHeight = (videoParameters.fieldHeight * 2) - 1;
     for (qint32 i = 0; i < outputFrames.size(); i++) {
-        outputFrames[i].resize(videoParameters.fieldWidth * frameHeight * 6);
+        outputFrames[i].resize(videoParameters.fieldWidth * frameHeight * 3);
         outputFrames[i].fill(0);
     }
 
@@ -296,7 +296,7 @@ void PalColour::decodeFrames(const QVector<SourceField> &inputFields, qint32 sta
 }
 
 // Decode one field into outputFrame
-void PalColour::decodeField(const SourceField &inputField, const double *chromaData, double chromaGain, QByteArray &outputFrame)
+void PalColour::decodeField(const SourceField &inputField, const double *chromaData, double chromaGain, RGBFrame &outputFrame)
 {
     // Pointer to the composite signal data
     const quint16 *compPtr = inputField.data.data();
@@ -399,7 +399,7 @@ void PalColour::detectBurst(LineInfo &line, const quint16 *inputData)
 // inputField, or it may be pre-filtered down to chroma.
 template <typename ChromaSample, bool PREFILTERED_CHROMA>
 void PalColour::decodeLine(const SourceField &inputField, const ChromaSample *chromaData, const LineInfo &line, double chromaGain,
-                           QByteArray &outputFrame)
+                           RGBFrame &outputFrame)
 {
     // Dummy black line, used when the filter needs to look outside the active region.
     static constexpr ChromaSample blackLine[MAX_WIDTH] = {0};
@@ -497,8 +497,7 @@ void PalColour::decodeLine(const SourceField &inputField, const ChromaSample *ch
     const quint16 *comp = inputField.data.data() + (line.number * videoParameters.fieldWidth);
 
     // Define scan line pointer to output buffer using 16 bit unsigned words
-    quint16 *ptr = reinterpret_cast<quint16 *>(outputFrame.data()
-                                               + (((line.number * 2) + inputField.getOffset()) * videoParameters.fieldWidth * 6));
+    quint16 *ptr = outputFrame.data() + (((line.number * 2) + inputField.getOffset()) * videoParameters.fieldWidth * 3);
 
     // Gain for the Y component, to put reference black at 0 and reference white at 65535
     const double scaledContrast = 65535.0 / (videoParameters.white16bIre - videoParameters.black16bIre);

--- a/tools/ld-chroma-decoder/palcolour.h
+++ b/tools/ld-chroma-decoder/palcolour.h
@@ -34,6 +34,7 @@
 
 #include "lddecodemetadata.h"
 
+#include "rgbframe.h"
 #include "sourcefield.h"
 #include "transformpal.h"
 
@@ -81,11 +82,11 @@ public:
                              const Configuration &configuration);
 
     // Decode two fields to produce an interlaced frame.
-    QByteArray decodeFrame(const SourceField &firstField, const SourceField &secondField);
+    RGBFrame decodeFrame(const SourceField &firstField, const SourceField &secondField);
 
     // Decode a sequence of fields into a sequence of interlaced frames
     void decodeFrames(const QVector<SourceField> &inputFields, qint32 startIndex, qint32 endIndex,
-                      QVector<QByteArray> &outputFrames);
+                      QVector<RGBFrame> &outputFrames);
 
     // Maximum frame size, based on PAL
     static constexpr qint32 MAX_WIDTH = 1135;
@@ -101,11 +102,11 @@ private:
     };
 
     void buildLookUpTables();
-    void decodeField(const SourceField &inputField, const double *chromaData, double chromaGain, QByteArray &outputFrame);
+    void decodeField(const SourceField &inputField, const double *chromaData, double chromaGain, RGBFrame &outputFrame);
     void detectBurst(LineInfo &line, const quint16 *inputData);
     template <typename ChromaSample, bool PREFILTERED_CHROMA>
     void decodeLine(const SourceField &inputField, const ChromaSample *chromaData, const LineInfo &line, double chromaGain,
-                    QByteArray &outputFrame);
+                    RGBFrame &outputFrame);
 
     // Configuration parameters
     bool configurationSet;

--- a/tools/ld-chroma-decoder/paldecoder.cpp
+++ b/tools/ld-chroma-decoder/paldecoder.cpp
@@ -68,9 +68,9 @@ PalThread::PalThread(QAtomicInt& _abort, DecoderPool& _decoderPool,
 }
 
 void PalThread::decodeFrames(const QVector<SourceField> &inputFields, qint32 startIndex, qint32 endIndex,
-                             QVector<QByteArray> &outputFrames)
+                             QVector<RGBFrame> &outputFrames)
 {
-    QVector<QByteArray> decodedFrames(outputFrames.size());
+    QVector<RGBFrame> decodedFrames(outputFrames.size());
 
     // Perform the PALcolour filtering
     palColour.decodeFrames(inputFields, startIndex, endIndex, decodedFrames);

--- a/tools/ld-chroma-decoder/paldecoder.h
+++ b/tools/ld-chroma-decoder/paldecoder.h
@@ -68,7 +68,7 @@ public:
 
 protected:
     void decodeFrames(const QVector<SourceField> &inputFields, qint32 startIndex, qint32 endIndex,
-                      QVector<QByteArray> &outputFrames) override;
+                      QVector<RGBFrame> &outputFrames) override;
 
 private:
     // Settings

--- a/tools/ld-chroma-decoder/rgbframe.h
+++ b/tools/ld-chroma-decoder/rgbframe.h
@@ -1,0 +1,34 @@
+/************************************************************************
+
+    rgbframe.h
+
+    ld-chroma-decoder - Colourisation filter for ld-decode
+    Copyright (C) 2020 Adam Sampson
+
+    This file is part of ld-decode-tools.
+
+    ld-chroma-decoder is free software: you can redistribute it and/or
+    modify it under the terms of the GNU General Public License as
+    published by the Free Software Foundation, either version 3 of the
+    License, or (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+************************************************************************/
+
+#ifndef RGBFRAME_H
+#define RGBFRAME_H
+
+#include <QtGlobal>
+#include <QVector>
+
+// A decoded frame, containing triples of (R, G, B) samples
+using RGBFrame = QVector<quint16>;
+
+#endif // RGBFRAME_H

--- a/tools/ld-chroma-decoder/sourcefield.cpp
+++ b/tools/ld-chroma-decoder/sourcefield.cpp
@@ -24,17 +24,7 @@
 
 #include "sourcefield.h"
 
-#include <algorithm>
-
 #include "sourcevideo.h"
-
-// Fill a SourceField's data with a colour
-static void fillField(SourceField &field, quint16 colour)
-{
-    quint16 *start = reinterpret_cast<quint16 *>(field.data.data());
-    quint16 *end = start + (field.data.size() / 2);
-    std::fill(start, end, colour);
-}
 
 void SourceField::loadFields(SourceVideo &sourceVideo, LdDecodeMetaData &ldDecodeMetaData,
                              qint32 firstFrameNumber, qint32 numFrames,
@@ -67,10 +57,8 @@ void SourceField::loadFields(SourceVideo &sourceVideo, LdDecodeMetaData &ldDecod
         if (useBlankFrame) {
             // Fill both fields with black
             const quint16 black = ldDecodeMetaData.getVideoParameters().black16bIre;
-            fields[i].data.resize(sourceVideo.getFieldByteLength());
-            fields[i + 1].data.resize(sourceVideo.getFieldByteLength());
-            fillField(fields[i], black);
-            fillField(fields[i + 1], black);
+            fields[i].data.fill(black, sourceVideo.getFieldLength());
+            fields[i + 1].data.fill(black, sourceVideo.getFieldLength());
         } else {
             // Fetch the input fields
             fields[i].data = sourceVideo.getVideoField(firstFieldNumber);

--- a/tools/ld-chroma-decoder/sourcefield.h
+++ b/tools/ld-chroma-decoder/sourcefield.h
@@ -25,16 +25,13 @@
 #ifndef SOURCEFIELD_H
 #define SOURCEFIELD_H
 
-#include <QByteArray>
-
 #include "lddecodemetadata.h"
-
-class SourceVideo;
+#include "sourcevideo.h"
 
 // A field read from the input, with metadata and data
 struct SourceField {
     LdDecodeMetaData::Field field;
-    QByteArray data;
+    SourceVideo::Data data;
 
     // Load a sequence of frames from the input files.
     //

--- a/tools/ld-chroma-decoder/transformpal.cpp
+++ b/tools/ld-chroma-decoder/transformpal.cpp
@@ -70,7 +70,7 @@ void TransformPal::updateConfiguration(const LdDecodeMetaData::VideoParameters &
 
 void TransformPal::overlayFFT(qint32 positionX, qint32 positionY,
                               const QVector<SourceField> &inputFields, qint32 startIndex, qint32 endIndex,
-                              QVector<QByteArray> &rgbFrames)
+                              QVector<RGBFrame> &rgbFrames)
 {
     // Visualise the first field for each output frame
     for (int fieldIndex = startIndex, outputIndex = 0; fieldIndex < endIndex; fieldIndex += 2, outputIndex++) {

--- a/tools/ld-chroma-decoder/transformpal.h
+++ b/tools/ld-chroma-decoder/transformpal.h
@@ -28,13 +28,13 @@
 #ifndef TRANSFORMPAL_H
 #define TRANSFORMPAL_H
 
-#include <QByteArray>
 #include <QVector>
 #include <fftw3.h>
 
 #include "lddecodemetadata.h"
 
 #include "framecanvas.h"
+#include "rgbframe.h"
 #include "sourcefield.h"
 
 // Abstract base class for Transform PAL filters.
@@ -79,14 +79,14 @@ public:
     // frame coordinates.
     void overlayFFT(qint32 positionX, qint32 positionY,
                     const QVector<SourceField> &inputFields, qint32 startIndex, qint32 endIndex,
-                    QVector<QByteArray> &rgbFrames);
+                    QVector<RGBFrame> &rgbFrames);
 
 protected:
     // Overlay a visualisation of one field's FFT.
     // Calls back to overlayFFTArrays to draw the arrays.
     virtual void overlayFFTFrame(qint32 positionX, qint32 positionY,
                                  const QVector<SourceField> &inputFields, qint32 fieldIndex,
-                                 QByteArray &rgbFrame) = 0;
+                                 RGBFrame &rgbFrame) = 0;
 
     void overlayFFTArrays(const fftw_complex *fftIn, const fftw_complex *fftOut,
                           FrameCanvas &canvas);

--- a/tools/ld-chroma-decoder/transformpal2d.cpp
+++ b/tools/ld-chroma-decoder/transformpal2d.cpp
@@ -317,7 +317,7 @@ void TransformPal2D::applyFilter()
 
 void TransformPal2D::overlayFFTFrame(qint32 positionX, qint32 positionY,
                                      const QVector<SourceField> &inputFields, qint32 fieldIndex,
-                                     QByteArray &rgbFrame)
+                                     RGBFrame &rgbFrame)
 {
     // Do nothing if the tile isn't within the frame
     if (positionX < 0 || positionX + XTILE > videoParameters.fieldWidth

--- a/tools/ld-chroma-decoder/transformpal2d.cpp
+++ b/tools/ld-chroma-decoder/transformpal2d.cpp
@@ -107,7 +107,7 @@ void TransformPal2D::filterFields(const QVector<SourceField> &inputFields, qint3
     // Check we have a valid vector of input fields, and a matching output vector
     assert((inputFields.size() % 2) == 0);
     for (qint32 i = 0; i < inputFields.size(); i++) {
-        assert(!inputFields[i].data.isNull());
+        assert(!inputFields[i].data.empty());
     }
     assert(outputFields.size() == (endIndex - startIndex));
 
@@ -166,7 +166,7 @@ void TransformPal2D::filterField(const SourceField& inputField, qint32 outputInd
 void TransformPal2D::forwardFFTTile(qint32 tileX, qint32 tileY, qint32 startY, qint32 endY, const SourceField &inputField)
 {
     // Copy the input signal into fftReal, applying the window function
-    const quint16 *inputPtr = reinterpret_cast<const quint16 *>(inputField.data.data());
+    const quint16 *inputPtr = inputField.data.data();
     for (qint32 y = 0; y < YTILE; y++) {
         // If this frame line is above/below the active region, fill it with
         // black instead.

--- a/tools/ld-chroma-decoder/transformpal2d.h
+++ b/tools/ld-chroma-decoder/transformpal2d.h
@@ -31,6 +31,7 @@
 #include <QVector>
 #include <fftw3.h>
 
+#include "rgbframe.h"
 #include "sourcefield.h"
 #include "transformpal.h"
 
@@ -53,7 +54,7 @@ protected:
     void applyFilter();
     void overlayFFTFrame(qint32 positionX, qint32 positionY,
                          const QVector<SourceField> &inputFields, qint32 fieldIndex,
-                         QByteArray &rgbFrame) override;
+                         RGBFrame &rgbFrame) override;
 
     // FFT input and output sizes.
     // The input field is divided into tiles of XTILE x YTILE, with adjacent

--- a/tools/ld-chroma-decoder/transformpal3d.cpp
+++ b/tools/ld-chroma-decoder/transformpal3d.cpp
@@ -128,7 +128,7 @@ void TransformPal3D::filterFields(const QVector<SourceField> &inputFields, qint3
     // Check we have a valid vector of input fields, and a matching output vector
     assert((inputFields.size() % 2) == 0);
     for (qint32 i = 0; i < inputFields.size(); i++) {
-        assert(!inputFields[i].data.isNull());
+        assert(!inputFields[i].data.empty());
     }
     assert(outputFields.size() == (endIndex - startIndex));
 
@@ -186,7 +186,7 @@ void TransformPal3D::forwardFFTTile(qint32 tileX, qint32 tileY, qint32 tileZ, co
     // Copy the input signal into fftReal, applying the window function
     for (qint32 z = 0; z < ZTILE; z++) {
         const qint32 fieldIndex = tileZ + z;
-        const quint16 *inputPtr = reinterpret_cast<const quint16 *>(inputFields[fieldIndex].data.data());
+        const quint16 *inputPtr = inputFields[fieldIndex].data.data();
 
         for (qint32 y = 0; y < YTILE; y++) {
             // If this frame line is not available in the field

--- a/tools/ld-chroma-decoder/transformpal3d.cpp
+++ b/tools/ld-chroma-decoder/transformpal3d.cpp
@@ -363,7 +363,7 @@ void TransformPal3D::applyFilter()
 
 void TransformPal3D::overlayFFTFrame(qint32 positionX, qint32 positionY,
                                      const QVector<SourceField> &inputFields, qint32 fieldIndex,
-                                     QByteArray &rgbFrame)
+                                     RGBFrame &rgbFrame)
 {
     // Do nothing if the tile isn't within the frame
     if (positionX < 0 || positionX + XTILE > videoParameters.fieldWidth

--- a/tools/ld-chroma-decoder/transformpal3d.h
+++ b/tools/ld-chroma-decoder/transformpal3d.h
@@ -31,6 +31,7 @@
 #include <QVector>
 #include <fftw3.h>
 
+#include "rgbframe.h"
 #include "sourcefield.h"
 #include "transformpal.h"
 
@@ -57,7 +58,7 @@ protected:
     void applyFilter();
     void overlayFFTFrame(qint32 positionX, qint32 positionY,
                          const QVector<SourceField> &inputFields, qint32 fieldIndex,
-                         QByteArray &rgbFrame) override;
+                         RGBFrame &rgbFrame) override;
 
     // FFT input and output sizes.
     //

--- a/tools/ld-diffdod/tbcsources.cpp
+++ b/tools/ld-diffdod/tbcsources.cpp
@@ -261,8 +261,8 @@ void TbcSources::performFrameDiffDod(qint32 targetVbiFrame, qint32 dodThreshold,
     qDebug() << "TbcSources::performFrameDiffDod(): Processing VBI Frame" << targetVbiFrame << "-" << availableSourcesForFrame.size() << "sources available";
 
     // Get the field data for the frame from all of the available sources and copy locally ----------------------------
-    QVector<QByteArray> firstFields;
-    QVector<QByteArray> secondFields;
+    QVector<SourceVideo::Data> firstFields;
+    QVector<SourceVideo::Data> secondFields;
     firstFields.resize(availableSourcesForFrame.size());
     secondFields.resize(availableSourcesForFrame.size());
 
@@ -282,8 +282,8 @@ void TbcSources::performFrameDiffDod(qint32 targetVbiFrame, qint32 dodThreshold,
         secondFields[sourceNo] = (sourceVideos[availableSourcesForFrame[sourceNo]]->sourceVideo.getVideoField(secondFieldNumber));
 
         // Define a pointer to the data
-        sourceFirstFieldPointer[sourceNo] = reinterpret_cast<quint16*>(firstFields[sourceNo].data());
-        sourceSecondFieldPointer[sourceNo] = reinterpret_cast<quint16*>(secondFields[sourceNo].data());
+        sourceFirstFieldPointer[sourceNo] = firstFields[sourceNo].data();
+        sourceSecondFieldPointer[sourceNo] = secondFields[sourceNo].data();
 
         // Filter out the chroma information from the fields leaving just luma
         Filters filters;

--- a/tools/ld-dropout-correct/correctorpool.h
+++ b/tools/ld-dropout-correct/correctorpool.h
@@ -27,7 +27,6 @@
 
 #include <QObject>
 #include <QAtomicInt>
-#include <QByteArray>
 #include <QElapsedTimer>
 #include <QMutex>
 #include <QThread>
@@ -48,13 +47,13 @@ public:
 
     // Member functions used by worker threads
     bool getInputFrame(qint32& frameNumber,
-                       QVector<qint32> &firstFieldNumber, QVector<QByteArray> &firstFieldVideoData, QVector<LdDecodeMetaData::Field> &firstFieldMetadata,
-                       QVector<qint32> &secondFieldNumber, QVector<QByteArray> &secondFieldVideoData, QVector<LdDecodeMetaData::Field> &secondFieldMetadata,
+                       QVector<qint32> &firstFieldNumber, QVector<SourceVideo::Data> &firstFieldVideoData, QVector<LdDecodeMetaData::Field> &firstFieldMetadata,
+                       QVector<qint32> &secondFieldNumber, QVector<SourceVideo::Data> &secondFieldVideoData, QVector<LdDecodeMetaData::Field> &secondFieldMetadata,
                        QVector<LdDecodeMetaData::VideoParameters> &videoParameters,
                        bool& _reverse, bool& _intraField, bool& _overCorrect, QVector<qint32> &availableSourcesForFrame, QVector<qreal> &sourceFrameQuality);
 
     bool setOutputFrame(qint32 frameNumber,
-                        QByteArray firstTargetFieldData, QByteArray secondTargetFieldData,
+                        SourceVideo::Data firstTargetFieldData, SourceVideo::Data secondTargetFieldData,
                         qint32 firstFieldSeqNo, qint32 secondFieldSeqNo,
                         qint32 sameSourceReplacement, qint32 multiSourceReplacement, qint32 totalReplacementDistance);
 
@@ -82,8 +81,8 @@ private:
     QMutex outputMutex;
 
     struct OutputFrame {
-        QByteArray firstTargetFieldData;
-        QByteArray secondTargetFieldData;
+        SourceVideo::Data firstTargetFieldData;
+        SourceVideo::Data secondTargetFieldData;
         qint32 firstFieldSeqNo;
         qint32 secondFieldSeqNo;
 
@@ -106,6 +105,7 @@ private:
     qint32 convertSequentialFrameNumberToVbi(qint32 sequentialFrameNumber, qint32 sourceNumber);
     qint32 convertVbiFrameNumberToSequential(qint32 vbiFrameNumber, qint32 sourceNumber);
     QVector<qint32> getAvailableSourcesForFrame(qint32 vbiFrameNumber);
+    bool writeOutputField(const SourceVideo::Data &fieldData);
 };
 
 #endif // CORRECTORPOOL_H

--- a/tools/ld-dropout-correct/dropoutcorrect.h
+++ b/tools/ld-dropout-correct/dropoutcorrect.h
@@ -88,7 +88,7 @@ private:
 
     void correctField(const QVector<QVector<DropOutLocation> > &thisFieldDropouts,
                       const QVector<QVector<DropOutLocation> > &otherFieldDropouts,
-                      QVector<QByteArray> &thisFieldData, const QVector<QByteArray> &otherFieldData,
+                      QVector<SourceVideo::Data> &thisFieldData, const QVector<SourceVideo::Data> &otherFieldData,
                       bool thisFieldIsFirst, bool intraField, QVector<qint32> &availableSourcesForFrame,
                       QVector<qreal> &sourceFrameQuality, Statistics &statistics);
     QVector<DropOutLocation> populateDropoutsVector(LdDecodeMetaData::Field field, bool overCorrect);
@@ -105,7 +105,8 @@ private:
                                       QVector<Replacement> &candidates, qint32 sourceNo, QVector<qreal> sourceFrameQuality);
     void correctDropOut(const DropOutLocation &dropOut,
                         const Replacement &replacement, const Replacement &chromaReplacement,
-                        QVector<QByteArray> &thisFieldData, const QVector<QByteArray> &otherFieldData, Statistics &statistics);
+                        QVector<SourceVideo::Data> &thisFieldData, const QVector<SourceVideo::Data> &otherFieldData,
+                        Statistics &statistics);
 };
 
 #endif // DROPOUTCORRECT_H

--- a/tools/ld-process-vbi/closedcaption.cpp
+++ b/tools/ld-process-vbi/closedcaption.cpp
@@ -25,7 +25,7 @@
 #include "closedcaption.h"
 
 // Public method to read CEA-608 Closed Captioning data (NTSC only)
-ClosedCaption::CcData ClosedCaption::getData(QByteArray lineData, LdDecodeMetaData::VideoParameters videoParameters)
+ClosedCaption::CcData ClosedCaption::getData(const SourceVideo::Data &lineData, LdDecodeMetaData::VideoParameters videoParameters)
 {
     CcData ccData;
     ccData.byte0 = 0;
@@ -128,7 +128,7 @@ bool ClosedCaption::isEvenParity(uchar data)
 }
 
 // Private method to get the map of transitions across the sample and reject noise
-QVector<bool> ClosedCaption::getTransitionMap(QByteArray lineData, qint32 zcPoint)
+QVector<bool> ClosedCaption::getTransitionMap(const SourceVideo::Data &lineData, qint32 zcPoint)
 {
     // First read the data into a boolean array using debounce to remove transition noise
     bool previousState = false;
@@ -137,9 +137,8 @@ QVector<bool> ClosedCaption::getTransitionMap(QByteArray lineData, qint32 zcPoin
     QVector<bool> transitionMap;
 
     // Each value is 2 bytes (16-bit greyscale data)
-    for (qint32 xPoint = 0; xPoint < lineData.size(); xPoint += 2) {
-        qint32 pixelValue = (static_cast<uchar>(lineData[xPoint + 1]) * 256) + static_cast<uchar>(lineData[xPoint]);
-        if (pixelValue > zcPoint) currentState = true; else currentState = false;
+    for (qint32 xPoint = 0; xPoint < lineData.size(); xPoint++) {
+        if (lineData[xPoint] > zcPoint) currentState = true; else currentState = false;
 
         if (currentState != previousState) debounce++;
 

--- a/tools/ld-process-vbi/closedcaption.h
+++ b/tools/ld-process-vbi/closedcaption.h
@@ -37,11 +37,11 @@ public:
         bool isValid;
     };
 
-    CcData getData(QByteArray lineData, LdDecodeMetaData::VideoParameters videoParameters);
+    CcData getData(const SourceVideo::Data &lineData, LdDecodeMetaData::VideoParameters videoParameters);
 
 private:
     bool isEvenParity(uchar data);
-    QVector<bool> getTransitionMap(QByteArray lineData, qint32 zcPoint);
+    QVector<bool> getTransitionMap(const SourceVideo::Data &lineData, qint32 zcPoint);
 };
 
 #endif // CLOSEDCAPTION_H

--- a/tools/ld-process-vbi/decoderpool.cpp
+++ b/tools/ld-process-vbi/decoderpool.cpp
@@ -100,8 +100,8 @@ bool DecoderPool::process()
 //
 // Returns true if a field was returned, false if the end of the input has been
 // reached.
-bool DecoderPool::getInputField(qint32 &fieldNumber, QByteArray& fieldVideoData,
-                                LdDecodeMetaData::Field& fieldMetadata, LdDecodeMetaData::VideoParameters& videoParameters)
+bool DecoderPool::getInputField(qint32 &fieldNumber, SourceVideo::Data &fieldVideoData,
+                                LdDecodeMetaData::Field &fieldMetadata, LdDecodeMetaData::VideoParameters &videoParameters)
 {
     QMutexLocker locker(&inputMutex);
 

--- a/tools/ld-process-vbi/decoderpool.h
+++ b/tools/ld-process-vbi/decoderpool.h
@@ -26,7 +26,6 @@
 #define DECODERPOOL_H
 
 #include <QAtomicInt>
-#include <QByteArray>
 #include <QElapsedTimer>
 #include <QMutex>
 #include <QThread>
@@ -44,7 +43,7 @@ public:
     bool process();
 
     // Member functions used by worker threads
-    bool getInputField(qint32& fieldNumber, QByteArray& fieldVideoData, LdDecodeMetaData::Field &fieldMetadata, LdDecodeMetaData::VideoParameters &videoParameters);
+    bool getInputField(qint32 &fieldNumber, SourceVideo::Data &fieldVideoData, LdDecodeMetaData::Field &fieldMetadata, LdDecodeMetaData::VideoParameters &videoParameters);
     bool setOutputField(qint32 fieldNumber, LdDecodeMetaData::Field fieldMetadata);
 
 private:

--- a/tools/ld-process-vbi/fmcode.cpp
+++ b/tools/ld-process-vbi/fmcode.cpp
@@ -25,7 +25,7 @@
 #include "fmcode.h"
 
 // Public method to read a 40-bit FM coded signal from a field line
-FmCode::FmDecode FmCode::fmDecoder(QByteArray lineData, LdDecodeMetaData::VideoParameters videoParameters)
+FmCode::FmDecode FmCode::fmDecoder(const SourceVideo::Data &lineData, LdDecodeMetaData::VideoParameters videoParameters)
 {
     FmDecode fmDecode;
     fmDecode.receiverClockSyncBits = 0;
@@ -170,7 +170,7 @@ bool FmCode::isEvenParity(quint64 data)
 }
 
 // Private method to get the map of transitions across the sample and reject noise
-QVector<bool> FmCode::getTransitionMap(QByteArray lineData, qint32 zcPoint)
+QVector<bool> FmCode::getTransitionMap(const SourceVideo::Data &lineData, qint32 zcPoint)
 {
     // First read the data into a boolean array using debounce to remove transition noise
     bool previousState = false;
@@ -179,9 +179,8 @@ QVector<bool> FmCode::getTransitionMap(QByteArray lineData, qint32 zcPoint)
     QVector<bool> fmData;
 
     qint32 fmPointer = 0;
-    for (qint32 xPoint = 0; xPoint < lineData.size(); xPoint += 2) {
-        qint32 pixelValue = (static_cast<uchar>(lineData[xPoint + 1]) * 256) + static_cast<uchar>(lineData[xPoint]);
-        if (pixelValue > zcPoint) currentState = true; else currentState = false;
+    for (qint32 xPoint = 0; xPoint < lineData.size(); xPoint++) {
+        if (lineData[xPoint] > zcPoint) currentState = true; else currentState = false;
 
         if (currentState != previousState) debounce++;
 

--- a/tools/ld-process-vbi/fmcode.h
+++ b/tools/ld-process-vbi/fmcode.h
@@ -40,11 +40,11 @@ public:
         quint64 trailingDataRecognitionBits;
     };
 
-    FmCode::FmDecode fmDecoder(QByteArray lineData, LdDecodeMetaData::VideoParameters videoParameters);
+    FmCode::FmDecode fmDecoder(const SourceVideo::Data &lineData, LdDecodeMetaData::VideoParameters videoParameters);
 
 private:
     bool isEvenParity(quint64 data);
-    QVector<bool> getTransitionMap(QByteArray lineData, qint32 zcPoint);
+    QVector<bool> getTransitionMap(const SourceVideo::Data &lineData, qint32 zcPoint);
 };
 
 #endif // FMCODE_H

--- a/tools/ld-process-vbi/vbilinedecoder.h
+++ b/tools/ld-process-vbi/vbilinedecoder.h
@@ -31,6 +31,7 @@
 #include <QDebug>
 
 #include "lddecodemetadata.h"
+#include "sourcevideo.h"
 #include "fmcode.h"
 #include "whiteflag.h"
 #include "closedcaption.h"
@@ -58,9 +59,11 @@ private:
     // Temporary output buffer
     LdDecodeMetaData::Field outputData;
 
-    QByteArray getActiveVideoLine(QByteArray *sourceFrame, qint32 scanLine, LdDecodeMetaData::VideoParameters videoParameters);
-    qint32 manchesterDecoder(QByteArray lineData, qint32 zcPoint, LdDecodeMetaData::VideoParameters videoParameters);
-    QVector<bool> getTransitionMap(QByteArray lineData, qint32 zcPoint);
+    SourceVideo::Data getActiveVideoLine(const SourceVideo::Data& sourceFrame, qint32 scanLine,
+                                         LdDecodeMetaData::VideoParameters videoParameters);
+    qint32 manchesterDecoder(const SourceVideo::Data& lineData, qint32 zcPoint,
+                             LdDecodeMetaData::VideoParameters videoParameters);
+    QVector<bool> getTransitionMap(const SourceVideo::Data& lineData, qint32 zcPoint);
 };
 
 #endif // VBILINEDECODER_H

--- a/tools/ld-process-vbi/whiteflag.cpp
+++ b/tools/ld-process-vbi/whiteflag.cpp
@@ -25,15 +25,14 @@
 #include "whiteflag.h"
 
 // Public method to read the white flag status from a field-line
-bool WhiteFlag::getWhiteFlag(QByteArray lineData, LdDecodeMetaData::VideoParameters videoParameters)
+bool WhiteFlag::getWhiteFlag(const SourceVideo::Data &lineData, LdDecodeMetaData::VideoParameters videoParameters)
 {
     // Determine the 16-bit zero-crossing point
     qint32 zcPoint = videoParameters.white16bIre - videoParameters.black16bIre;
 
     qint32 whiteCount = 0;
     for (qint32 x = videoParameters.activeVideoStart; x < videoParameters.activeVideoEnd; x++) {
-        qint32 pixelValue = (static_cast<uchar>(lineData[x + 1]) * 256) + static_cast<uchar>(lineData[x]);
-        if (pixelValue > zcPoint) whiteCount++;
+        if (lineData[x] > zcPoint) whiteCount++;
     }
 
     // Mark the line as a white flag if at least 50% of the data is above the zc point

--- a/tools/ld-process-vbi/whiteflag.h
+++ b/tools/ld-process-vbi/whiteflag.h
@@ -31,7 +31,7 @@
 class WhiteFlag
 {
 public:
-    bool getWhiteFlag(QByteArray lineData, LdDecodeMetaData::VideoParameters videoParameters);
+    bool getWhiteFlag(const SourceVideo::Data &lineData, LdDecodeMetaData::VideoParameters videoParameters);
 };
 
 #endif // WHITEFLAG_H

--- a/tools/library/tbc/lddecodemetadata.h
+++ b/tools/library/tbc/lddecodemetadata.h
@@ -141,8 +141,9 @@ public:
 
     LdDecodeMetaData();
 
-    // Prevent implicit copying
-    LdDecodeMetaData(const LdDecodeMetaData &src) = delete;
+    // Prevent copying or assignment
+    LdDecodeMetaData(const LdDecodeMetaData &) = delete;
+    LdDecodeMetaData& operator=(const LdDecodeMetaData &) = delete;
 
     bool read(QString fileName);
     bool write(QString fileName);

--- a/tools/library/tbc/sourcevideo.h
+++ b/tools/library/tbc/sourcevideo.h
@@ -42,8 +42,9 @@ public:
     SourceVideo();
     ~SourceVideo();
 
-    // Prevent implicit copying
-    SourceVideo(const SourceVideo &src) = delete;
+    // Prevent copying or assignment
+    SourceVideo(const SourceVideo &) = delete;
+    SourceVideo& operator=(const SourceVideo &) = delete;
 
     // File handling methods
     bool open(QString filename, qint32 _fieldLength, qint32 _fieldLineLength = -1);

--- a/tools/library/tbc/sourcevideo.h
+++ b/tools/library/tbc/sourcevideo.h
@@ -60,7 +60,7 @@ public:
 
 private:
     // File handling globals
-    QFile *inputFile;
+    QFile inputFile;
     qint64 inputFilePos;
     bool isSourceVideoOpen;
     qint32 availableFields;
@@ -71,7 +71,7 @@ private:
     Data outputFieldData;
 
     // Field caching
-    QCache<qint32, Data> *fieldCache;
+    QCache<qint32, Data> fieldCache;
 };
 
 #endif // SOURCEVIDEO_H

--- a/tools/library/tbc/sourcevideo.h
+++ b/tools/library/tbc/sourcevideo.h
@@ -28,10 +28,17 @@
 #include <QFile>
 #include <QCache>
 #include <QDebug>
+#include <QVector>
 
 class SourceVideo
 {
 public:
+    // A QVector of timebase-corrected video samples.
+    // This is usually a complete field, but it may be a partial field if
+    // you've requested fewer lines from getVideoField (or if you've sliced it
+    // yourself).
+    using Data = QVector<quint16>;
+
     SourceVideo();
     ~SourceVideo();
 
@@ -43,12 +50,12 @@ public:
     void close(void);
 
     // Field handling methods
-    QByteArray getVideoField(qint32 fieldNumber, qint32 startFieldLine = -1, qint32 endFieldLine = -1);
+    Data getVideoField(qint32 fieldNumber, qint32 startFieldLine = -1, qint32 endFieldLine = -1);
 
     // Get and set methods
     bool isSourceValid();
     qint32 getNumberOfAvailableFields();
-    qint32 getFieldByteLength();
+    qint32 getFieldLength();
 
 private:
     // File handling globals
@@ -56,13 +63,14 @@ private:
     qint64 inputFilePos;
     bool isSourceVideoOpen;
     qint32 availableFields;
+    qint32 fieldLength;
     qint32 fieldByteLength;
     qint32 fieldLineLength;
 
-    QByteArray outputFieldData;
+    Data outputFieldData;
 
     // Field caching
-    QCache<qint32, QByteArray> *fieldCache;
+    QCache<qint32, Data> *fieldCache;
 };
 
 #endif // SOURCEVIDEO_H


### PR DESCRIPTION
This is a respin of a patch I started last year...

The general idea is to use (named typedefs of) QVector<quint16> rather than QByteArray for 16-bit TBC and RGB samples. This substantially reduces the number of places where the tools need to use reinterpret_cast, and generally simplifies the code working with fields and decoded frames - the only remaining unsafe casts in the video tools are when doing file IO. ld-chroma-decoder gets the most benefit from this, but most of the tools are affected to some degree.

I'm reasonably confident in the chroma-decoder/dropout-correct/process-vbi changes, but my testsuite doesn't do anything much with diffdod/discmap yet - please check those changes look OK!

See the commit messages for a couple of other minor improvements rolled into this.

One more thing I spotted but haven't changed: several functions in ld-process-vbi compute the zero crossing point as `videoParameters.white16bIre - videoParameters.black16bIre` - should that actually be `(videoParameters.white16bIre + videoParameters.black16bIre) / 2` (the midpoint)?