### PR TITLE
fix scope on mac

### DIFF
--- a/tools/ld-analyse/mainwindow.cpp
+++ b/tools/ld-analyse/mainwindow.cpp
@@ -331,6 +331,10 @@ void MainWindow::updateFrameViewer()
     ui->frameViewerLabel->setPixmap(QPixmap::fromImage(frameImage));
     ui->frameViewerLabel->setPixmap(ui->frameViewerLabel->pixmap()->scaled(scaleFactor * ui->frameViewerLabel->pixmap()->size(),
                                                                            Qt::IgnoreAspectRatio, Qt::SmoothTransformation));
+    // QT Bug workaround for some macOS versions
+    #if defined(Q_OS_MACOS)
+    	repaint();
+    #endif
 }
 
 // Method to hide the current frame

--- a/tools/ld-analyse/oscilloscopedialog.cpp
+++ b/tools/ld-analyse/oscilloscopedialog.cpp
@@ -82,6 +82,10 @@ void OscilloscopeDialog::showTraceImage(TbcSource::ScanLineData scanLineData, qi
 
     // Update the maximum scan-lines limit
     maximumScanLines = frameHeight;
+    // QT Bug workaround for some macOS versions
+    #if defined(Q_OS_MACOS)
+    	repaint();
+    #endif
 }
 
 QImage OscilloscopeDialog::getFieldLineTraceImage(TbcSource::ScanLineData scanLineData, qint32 pictureDot)


### PR DESCRIPTION
Work around QT bug on some mac versions where the oscilloscope chart wouldn't update when pressing the previous/next line buttons, and crosshairs wouldn't show up/clear when toggling the mouse scope button.