### PR TITLE
Remove unused MacOS definition of M_PIl

### DIFF
--- a/tools/ld-chroma-decoder/comb.h
+++ b/tools/ld-chroma-decoder/comb.h
@@ -40,12 +40,6 @@
 #include "yiq.h"
 #include "yiqbuffer.h"
 
-// Fix required for Mac OS compilation - environment doesn't seem to set up
-// the expected definitions properly
-#ifndef M_PIl
-#define M_PIl 0xc.90fdaa22168c235p-2L
-#endif
-
 class Comb
 {
 public:


### PR DESCRIPTION
This was added to fix #59, but the only code that used it was removed in b59f64bad715851f3e43fb25eb492ff9976be757. Thanks to @Gamnn for confirming that it's no longer needed on MacOS.