### PR TITLE
Use an odd number of taps for PAL/NTSC LPFs

### DIFF
--- a/tools/library/filter/firfilter.h
+++ b/tools/library/filter/firfilter.h
@@ -3,7 +3,7 @@
     firfilter.h
 
     ld-decode-tools filter library
-    Copyright (C) 2019 Adam Sampson
+    Copyright (C) 2019-2020 Adam Sampson
 
     This file is part of ld-decode-tools.
 
@@ -53,6 +53,10 @@ public:
         // input data.
         const int numTaps = coeffs.size();
         const int overlap = numTaps / 2;
+
+        // Check that the number of taps is odd. (If it was even, then the
+        // output would be delayed by half a sample.)
+        assert((numTaps % 2) == 1);
 
         // At the left end of the input, we definitely overlap to the left.
         // We might overlap to the right too if numSamples < numTaps, in which

--- a/tools/library/tbc/filters.cpp
+++ b/tools/library/tbc/filters.cpp
@@ -29,23 +29,21 @@
 #include <array>
 
 // PAL - Filter at Fsc/2 (Fsc = 4433618 (/2 = 2,216,809), sample rate = 17,734,472)
-// 2.2 MHz LPF - 6 Taps
+// 2.2 MHz LPF - 7 Taps
 // import scipy.signal
-// scipy.signal.firwin(6, [2.2e6/17734472], window='hamming')
-static constexpr std::array<double, 6> palLumaFilterCoeffs {
-    0.02516142,  0.13911332,  0.33572527,  0.33572527,  0.13911332,
-    0.02516142
+// scipy.signal.firwin(7, [2.2e6/17734472], window='hamming')
+static constexpr std::array<double, 7> palLumaFilterCoeffs {
+    0.01976541, 0.0877332, 0.23558317, 0.31383644, 0.23558317, 0.0877332, 0.01976541
 };
 
 static constexpr auto palLumaFilter = makeFIRFilter(palLumaFilterCoeffs);
 
 // NTSC - Filter at Fsc/2 (Fsc = 3579545 (/2 = 1,789,772.5), sample rate = 14,318,180)
-// 1.8 MHz LPF - 6 Taps
+// 1.8 MHz LPF - 7 Taps
 // import scipy.signal
-// scipy.signal.firwin(6, [1.8e6/14318180], window='hamming')
-static constexpr std::array<double, 6> ntscLumaFilterCoeffs {
-    0.0250663,  0.1390033,  0.3359304,  0.3359304,  0.1390033,
-    0.0250663
+// scipy.signal.firwin(7, [1.8e6/14318180], window='hamming')
+static constexpr std::array<double, 7> ntscLumaFilterCoeffs {
+    0.01965292, 0.08757913, 0.23567812, 0.31417965, 0.23567812, 0.08757913, 0.01965292
 };
 static constexpr auto ntscLumaFilter = makeFIRFilter(ntscLumaFilterCoeffs);
 


### PR DESCRIPTION
I'd wondered why the LPF view in ld-analyse didn't quite line up with the other two views - it's because the filters had an even number of taps, so FIRFilter can't compensate for the leftover 0.5-sample delay.

Switch from 6 to 7 taps, and add an assert to FIRFilter to catch this in the future.

@simoninns - this might affect the DoD stuff you're working on; 5 taps would also work if you'd prefer that to 7.