### PR TITLE
Added first and last fieldNumber to the videoParameters metadata

### DIFF
--- a/tools/ld-chroma-decoder/comb.cpp
+++ b/tools/ld-chroma-decoder/comb.cpp
@@ -59,6 +59,10 @@ void Comb::updateConfiguration(const LdDecodeMetaData::VideoParameters &_videoPa
     // Set the frame height
     frameHeight = ((videoParameters.fieldHeight * 2) - 1);
 
+    // Set the first and last active line
+    configuration.firstActiveLine = videoParameters.firstActiveFrameLine;
+    configuration.lastActiveLine = videoParameters.lastActiveFrameLine;
+
     configurationSet = true;
 }
 

--- a/tools/ld-chroma-decoder/palcolour.cpp
+++ b/tools/ld-chroma-decoder/palcolour.cpp
@@ -114,6 +114,10 @@ void PalColour::updateConfiguration(const LdDecodeMetaData::VideoParameters &_vi
     // Build the look-up tables
     buildLookUpTables();
 
+    // Set the frame area
+    configuration.firstActiveLine = videoParameters.firstActiveFrameLine;
+    configuration.lastActiveLine = videoParameters.lastActiveFrameLine;
+
     if (configuration.chromaFilter == transform2DFilter || configuration.chromaFilter == transform3DFilter) {
         // Create the Transform PAL filter
         if (configuration.chromaFilter == transform2DFilter) {

--- a/tools/ld-diffdod/tbcsources.cpp
+++ b/tools/ld-diffdod/tbcsources.cpp
@@ -363,18 +363,8 @@ void TbcSources::performLumaClip(QVector<SourceVideo::Data> &fields, QVector<QVe
     // Get the metadata for the video parameters (all sources are the same, so just grab from the first)
     LdDecodeMetaData::VideoParameters videoParameters = sourceVideos[0]->ldDecodeMetaData.getVideoParameters();
 
-    qint32 firstActiveFieldLine;
-    qint32 lastActiveFieldLine;
-    if (videoParameters.isSourcePal) {
-        firstActiveFieldLine = 22;
-        lastActiveFieldLine = 308;
-    } else {
-        firstActiveFieldLine = 20;
-        lastActiveFieldLine = 259;
-    }
-
     // Process the fields one line at a time
-    for (qint32 y = firstActiveFieldLine; y < lastActiveFieldLine; y++) {
+    for (qint32 y = videoParameters.firstActiveFieldLine; y < videoParameters.lastActiveFieldLine; y++) {
         qint32 startOfLinePointer = y * videoParameters.fieldWidth;
 
         for (qint32 sourceCounter = 0; sourceCounter < fields.size(); sourceCounter++) {

--- a/tools/ld-dropout-correct/dropoutcorrect.cpp
+++ b/tools/ld-dropout-correct/dropoutcorrect.cpp
@@ -257,17 +257,6 @@ DropOutCorrect::Replacement DropOutCorrect::findReplacementLine(const QVector<QV
                                                                 bool isColourBurst, bool intraField, QVector<qint32> &availableSourcesForFrame,
                                                                 QVector<qreal> &sourceFrameQuality)
 {
-    // Determine the first and last active scan line based on the source format
-    qint32 firstActiveFieldLine;
-    qint32 lastActiveFieldLine;
-    if (videoParameters[0].isSourcePal) {
-        firstActiveFieldLine = 22;
-        lastActiveFieldLine = 308;
-    } else {
-        firstActiveFieldLine = 20;
-        lastActiveFieldLine = 259;
-    }
-
     // Define the minimum step size to use when searching for replacement
     // lines, and the offset to the nearest replacement line in the other
     // field.
@@ -330,13 +319,13 @@ DropOutCorrect::Replacement DropOutCorrect::findReplacementLine(const QVector<QV
         // Look up the field for a replacement
         findPotentialReplacementLine(thisFieldDropouts, dropOutIndex,
                                      thisFieldDropouts, true, 0, -stepAmount,
-                                     firstActiveFieldLine, lastActiveFieldLine,
+                                     videoParameters[0].firstActiveFieldLine, videoParameters[0].lastActiveFieldLine,
                                      candidates, currentSource, sourceFrameQuality);
 
         // Look down the field for a replacement
         findPotentialReplacementLine(thisFieldDropouts, dropOutIndex,
                                      thisFieldDropouts, true, stepAmount, stepAmount,
-                                     firstActiveFieldLine, lastActiveFieldLine,
+                                     videoParameters[0].firstActiveFieldLine, videoParameters[0].lastActiveFieldLine,
                                      candidates, currentSource, sourceFrameQuality);
 
         // Only check the other field for visible line replacements
@@ -346,13 +335,13 @@ DropOutCorrect::Replacement DropOutCorrect::findReplacementLine(const QVector<QV
             // Look up the field for a replacement
             findPotentialReplacementLine(thisFieldDropouts, dropOutIndex,
                                          otherFieldDropouts, false, otherFieldOffset, -stepAmount,
-                                         firstActiveFieldLine, lastActiveFieldLine,
+                                         videoParameters[0].firstActiveFieldLine, videoParameters[0].lastActiveFieldLine,
                                          candidates, currentSource, sourceFrameQuality);
 
             // Look down the field for a replacement
             findPotentialReplacementLine(thisFieldDropouts, dropOutIndex,
                                          otherFieldDropouts, false, otherFieldOffset + stepAmount, stepAmount,
-                                         firstActiveFieldLine, lastActiveFieldLine,
+                                         videoParameters[0].firstActiveFieldLine, videoParameters[0].lastActiveFieldLine,
                                          candidates, currentSource, sourceFrameQuality);
         }
     }

--- a/tools/library/tbc/lddecodemetadata.cpp
+++ b/tools/library/tbc/lddecodemetadata.cpp
@@ -91,6 +91,21 @@ LdDecodeMetaData::VideoParameters LdDecodeMetaData::getVideoParameters()
         return videoParameters;
     }
 
+    // Add in the active field line range psuedo-metadata
+    if (videoParameters.isSourcePal) {
+        // PAL
+        videoParameters.firstActiveFieldLine = 22;
+        videoParameters.lastActiveFieldLine = 308;
+        videoParameters.firstActiveFrameLine = 44;
+        videoParameters.lastActiveFrameLine = 620;
+    } else {
+        // NTSC
+        videoParameters.firstActiveFieldLine = 20;
+        videoParameters.lastActiveFieldLine = 259;
+        videoParameters.firstActiveFrameLine = 40;
+        videoParameters.lastActiveFrameLine = 525;
+    }
+
     return videoParameters;
 }
 

--- a/tools/library/tbc/lddecodemetadata.cpp
+++ b/tools/library/tbc/lddecodemetadata.cpp
@@ -96,13 +96,19 @@ LdDecodeMetaData::VideoParameters LdDecodeMetaData::getVideoParameters()
         // PAL
         videoParameters.firstActiveFieldLine = 22;
         videoParameters.lastActiveFieldLine = 308;
+
+        // Interlaced line 44 is PAL line 23 (the first active half-line)
         videoParameters.firstActiveFrameLine = 44;
+        // Interlaced line 619 is PAL line 623 (the last active half-line)
         videoParameters.lastActiveFrameLine = 620;
     } else {
         // NTSC
         videoParameters.firstActiveFieldLine = 20;
         videoParameters.lastActiveFieldLine = 259;
+
+        // Interlaced line 40 is NTSC line 21 (the closed-caption line before the first active half-line)
         videoParameters.firstActiveFrameLine = 40;
+        // Interlaced line 524 is NTSC line 263 (the last active half-line).
         videoParameters.lastActiveFrameLine = 525;
     }
 

--- a/tools/library/tbc/lddecodemetadata.h
+++ b/tools/library/tbc/lddecodemetadata.h
@@ -65,6 +65,13 @@ public:
         qint32 fsc;
 
         bool isMapped;
+
+        // Note: These are psuedo metadata items
+        // The values are populated by the library
+        qint32 firstActiveFieldLine;
+        qint32 lastActiveFieldLine;
+        qint32 firstActiveFrameLine;
+        qint32 lastActiveFrameLine;
     };
 
     // Drop-outs metadata definition

--- a/tools/library/tbc/lddecodemetadata.h
+++ b/tools/library/tbc/lddecodemetadata.h
@@ -66,8 +66,9 @@ public:
 
         bool isMapped;
 
-        // Note: These are psuedo metadata items
-        // The values are populated by the library
+        // Note: These are psuedo metadata items - The values are populated by the library
+        // These are half-open ranges, where lines are numbered sequentially from 0 within
+        // each field or interlaced frame
         qint32 firstActiveFieldLine;
         qint32 lastActiveFieldLine;
         qint32 firstActiveFrameLine;


### PR DESCRIPTION
Added some psuedo videoParameters to the LdDecodeMetaData class to provide the first and last active frame/field numbers.  This is set automatcally according to the isSourcePal flag.

The idea is to only have these constants in one place which I think will help towards issue #401 