### PR TITLE
Use VideoParameters::first/lastActiveFrameLine directly in more places

### DIFF
--- a/tools/ld-analyse/tbcsource.cpp
+++ b/tools/ld-analyse/tbcsource.cpp
@@ -555,23 +555,13 @@ QImage TbcSource::generateQImage(qint32 firstFieldNumber, qint32 secondFieldNumb
         firstField.data = sourceVideo.getVideoField(firstFieldNumber);
         secondField.data = sourceVideo.getVideoField(secondFieldNumber);
 
-        qint32 firstActiveLine, lastActiveLine;
-        RGBFrame rgbFrame;
-
         // Decode colour for the current frame, to RGB 16-16-16 interlaced output
+        RGBFrame rgbFrame;
         if (videoParameters.isSourcePal) {
             // PAL source
-
-            firstActiveLine = palColourConfiguration.firstActiveLine;
-            lastActiveLine = palColourConfiguration.lastActiveLine;
-
             rgbFrame = palColour.decodeFrame(firstField, secondField);
         } else {
             // NTSC source
-
-            firstActiveLine = ntscColour.getConfiguration().firstActiveLine;
-            lastActiveLine = ntscColour.getConfiguration().lastActiveLine;
-
             rgbFrame = ntscColour.decodeFrame(firstField, secondField);
         }
 
@@ -582,7 +572,7 @@ QImage TbcSource::generateQImage(qint32 firstFieldNumber, qint32 secondFieldNumb
         frameImage.fill(Qt::black);
 
         // Copy the RGB16-16-16 data into the RGB888 QImage
-        for (qint32 y = firstActiveLine; y < lastActiveLine; y++) {
+        for (qint32 y = videoParameters.firstActiveFrameLine; y < videoParameters.lastActiveFrameLine; y++) {
             for (qint32 x = videoParameters.activeVideoStart; x < videoParameters.activeVideoEnd; x++) {
                 qint32 pixelOffset = ((y * videoParameters.fieldWidth) + x) * 3;
 

--- a/tools/ld-chroma-decoder/comb.h
+++ b/tools/ld-chroma-decoder/comb.h
@@ -54,11 +54,6 @@ public:
         bool use3D = false;
         bool showOpticalFlowMap = false;
 
-        // Interlaced line 40 is NTSC line 21 (the closed-caption line before the first active half-line)
-        qint32 firstActiveLine = 40;
-        // Interlaced line 524 is NTSC line 263 (the last active half-line).
-        qint32 lastActiveLine = 525;
-
         qreal cNRLevel = 0.0;
         qreal yNRLevel = 1.0;
     };

--- a/tools/ld-chroma-decoder/decoder.cpp
+++ b/tools/ld-chroma-decoder/decoder.cpp
@@ -36,12 +36,8 @@ qint32 Decoder::getLookAhead() const
     return 0;
 }
 
-void Decoder::setVideoParameters(Decoder::Configuration &config, const LdDecodeMetaData::VideoParameters &videoParameters,
-                                 qint32 firstActiveLine, qint32 lastActiveLine) {
-
+void Decoder::setVideoParameters(Decoder::Configuration &config, const LdDecodeMetaData::VideoParameters &videoParameters) {
     config.videoParameters = videoParameters;
-    config.firstActiveLine = firstActiveLine;
-    config.lastActiveLine = lastActiveLine;
     config.topPadLines = 0;
     config.bottomPadLines = 0;
 
@@ -65,7 +61,8 @@ void Decoder::setVideoParameters(Decoder::Configuration &config, const LdDecodeM
     // Insert empty padding lines so the height is divisible by 8
     qint32 outputHeight;
     while (true) {
-        outputHeight = config.topPadLines + (config.lastActiveLine - config.firstActiveLine) + config.bottomPadLines;
+        const qint32 numActiveLines = videoParameters.lastActiveFrameLine - videoParameters.firstActiveFrameLine;
+        outputHeight = config.topPadLines + numActiveLines + config.bottomPadLines;
         if ((outputHeight % 8) == 0) {
             break;
         }
@@ -97,7 +94,7 @@ RGBFrame Decoder::cropOutputFrame(const Decoder::Configuration &config, const RG
     }
 
     // Copy the active region from the decoded image
-    for (qint32 y = config.firstActiveLine; y < config.lastActiveLine; y++) {
+    for (qint32 y = config.videoParameters.firstActiveFrameLine; y < config.videoParameters.lastActiveFrameLine; y++) {
         croppedData.append(outputData.mid((y * config.videoParameters.fieldWidth * 3) + (activeVideoStart * 3),
                                           outputLineLength));
     }

--- a/tools/ld-chroma-decoder/decoder.h
+++ b/tools/ld-chroma-decoder/decoder.h
@@ -81,16 +81,13 @@ public:
     struct Configuration {
         // Parameters computed from the video metadata
         LdDecodeMetaData::VideoParameters videoParameters;
-        qint32 firstActiveLine;
-        qint32 lastActiveLine;
         qint32 topPadLines;
         qint32 bottomPadLines;
     };
 
     // Compute the output frame size in Configuration, adjusting the active
     // video region as required
-    static void setVideoParameters(Configuration &config, const LdDecodeMetaData::VideoParameters &videoParameters,
-                                   qint32 firstActiveLine, qint32 lastActiveLine);
+    static void setVideoParameters(Configuration &config, const LdDecodeMetaData::VideoParameters &videoParameters);
 
     // Crop a full decoded frame to the output frame size
     static RGBFrame cropOutputFrame(const Configuration &config, const RGBFrame &outputData);

--- a/tools/ld-chroma-decoder/framecanvas.cpp
+++ b/tools/ld-chroma-decoder/framecanvas.cpp
@@ -28,21 +28,19 @@
 // pre-C++17 compilers
 constexpr FrameCanvas::RGB FrameCanvas::green;
 
-FrameCanvas::FrameCanvas(RGBFrame &_rgbFrame, const LdDecodeMetaData::VideoParameters &_videoParameters,
-                         qint32 _firstActiveLine, qint32 _lastActiveLine)
-    : rgbData(_rgbFrame.data()), rgbSize(_rgbFrame.size()),
-      videoParameters(_videoParameters), firstActiveLine(_firstActiveLine), lastActiveLine(_lastActiveLine)
+FrameCanvas::FrameCanvas(RGBFrame &_rgbFrame, const LdDecodeMetaData::VideoParameters &_videoParameters)
+    : rgbData(_rgbFrame.data()), rgbSize(_rgbFrame.size()), videoParameters(_videoParameters)
 {
 }
 
 qint32 FrameCanvas::top()
 {
-    return firstActiveLine;
+    return videoParameters.firstActiveFrameLine;
 }
 
 qint32 FrameCanvas::bottom()
 {
-    return lastActiveLine;
+    return videoParameters.lastActiveFrameLine;
 }
 
 qint32 FrameCanvas::left()

--- a/tools/ld-chroma-decoder/framecanvas.h
+++ b/tools/ld-chroma-decoder/framecanvas.h
@@ -36,8 +36,7 @@ class FrameCanvas {
 public:
     // rgbFrame is the frame to draw upon, and videoParameters gives its dimensions.
     // (Both parameters are captured by reference, not copied.)
-    FrameCanvas(RGBFrame &rgbFrame, const LdDecodeMetaData::VideoParameters &videoParameters,
-                qint32 firstActiveLine, qint32 lastActiveLine);
+    FrameCanvas(RGBFrame &rgbFrame, const LdDecodeMetaData::VideoParameters &videoParameters);
 
     // Return the edges of the active area.
     qint32 top();
@@ -65,8 +64,6 @@ private:
     quint16 *rgbData;
     qint32 rgbSize;
     const LdDecodeMetaData::VideoParameters &videoParameters;
-    qint32 firstActiveLine;
-    qint32 lastActiveLine;
 };
 
 #endif

--- a/tools/ld-chroma-decoder/monodecoder.cpp
+++ b/tools/ld-chroma-decoder/monodecoder.cpp
@@ -30,20 +30,9 @@
 
 bool MonoDecoder::configure(const LdDecodeMetaData::VideoParameters &videoParameters) {
     // This decoder works for both PAL and NTSC.
-    // Get the active line range from either Comb or PalColour.
-    qint32 firstActiveLine, lastActiveLine;
-    if (videoParameters.isSourcePal) {
-        PalColour::Configuration palConfig;
-        firstActiveLine = palConfig.firstActiveLine;
-        lastActiveLine = palConfig.lastActiveLine;
-    } else {
-        Comb::Configuration combConfig;
-        firstActiveLine = combConfig.firstActiveLine;
-        lastActiveLine = combConfig.lastActiveLine;
-    }
 
     // Compute cropping parameters
-    setVideoParameters(config, videoParameters, firstActiveLine, lastActiveLine);
+    setVideoParameters(config, videoParameters);
 
     return true;
 }
@@ -72,7 +61,7 @@ void MonoThread::decodeFrames(const QVector<SourceField> &inputFields, qint32 st
 
     for (qint32 fieldIndex = startIndex, frameIndex = 0; fieldIndex < endIndex; fieldIndex += 2, frameIndex++) {
         // Interlace the active lines of the two input fields to produce an output frame
-        for (qint32 y = config.firstActiveLine; y < config.lastActiveLine; y++) {
+        for (qint32 y = config.videoParameters.firstActiveFrameLine; y < config.videoParameters.lastActiveFrameLine; y++) {
             const SourceVideo::Data &inputFieldData = (y % 2) == 0 ? inputFields[fieldIndex].data : inputFields[fieldIndex + 1].data;
 
             // Each quint16 input becomes three quint16 outputs

--- a/tools/ld-chroma-decoder/ntscdecoder.cpp
+++ b/tools/ld-chroma-decoder/ntscdecoder.cpp
@@ -41,7 +41,7 @@ bool NtscDecoder::configure(const LdDecodeMetaData::VideoParameters &videoParame
     }
 
     // Compute cropping parameters
-    setVideoParameters(config, videoParameters, config.combConfig.firstActiveLine, config.combConfig.lastActiveLine);
+    setVideoParameters(config, videoParameters);
 
     return true;
 }

--- a/tools/ld-chroma-decoder/palcolour.cpp
+++ b/tools/ld-chroma-decoder/palcolour.cpp
@@ -114,10 +114,6 @@ void PalColour::updateConfiguration(const LdDecodeMetaData::VideoParameters &_vi
     // Build the look-up tables
     buildLookUpTables();
 
-    // Set the frame area
-    configuration.firstActiveLine = videoParameters.firstActiveFrameLine;
-    configuration.lastActiveLine = videoParameters.lastActiveFrameLine;
-
     if (configuration.chromaFilter == transform2DFilter || configuration.chromaFilter == transform3DFilter) {
         // Create the Transform PAL filter
         if (configuration.chromaFilter == transform2DFilter) {
@@ -127,8 +123,7 @@ void PalColour::updateConfiguration(const LdDecodeMetaData::VideoParameters &_vi
         }
 
         // Configure the filter
-        transformPal->updateConfiguration(videoParameters, configuration.firstActiveLine, configuration.lastActiveLine,
-                                          configuration.transformMode, configuration.transformThreshold,
+        transformPal->updateConfiguration(videoParameters, configuration.transformMode, configuration.transformThreshold,
                                           configuration.transformThresholds);
     }
 
@@ -305,8 +300,8 @@ void PalColour::decodeField(const SourceField &inputField, const double *chromaD
     // Pointer to the composite signal data
     const quint16 *compPtr = inputField.data.data();
 
-    const qint32 firstLine = inputField.getFirstActiveLine(configuration.firstActiveLine);
-    const qint32 lastLine = inputField.getLastActiveLine(configuration.lastActiveLine);
+    const qint32 firstLine = inputField.getFirstActiveLine(videoParameters);
+    const qint32 lastLine = inputField.getLastActiveLine(videoParameters);
     for (qint32 fieldLine = firstLine; fieldLine < lastLine; fieldLine++) {
         LineInfo line(fieldLine);
 
@@ -410,8 +405,8 @@ void PalColour::decodeLine(const SourceField &inputField, const ChromaSample *ch
 
     // Get pointers to the surrounding lines of input data.
     // If a line we need is outside the active area, use blackLine instead.
-    const qint32 firstLine = inputField.getFirstActiveLine(configuration.firstActiveLine);
-    const qint32 lastLine = inputField.getLastActiveLine(configuration.lastActiveLine);
+    const qint32 firstLine = inputField.getFirstActiveLine(videoParameters);
+    const qint32 lastLine = inputField.getLastActiveLine(videoParameters);
     const ChromaSample *in0, *in1, *in2, *in3, *in4, *in5, *in6;
     in0 =                                               chromaData +  (line.number      * videoParameters.fieldWidth);
     in1 = (line.number - 1) <  firstLine ? blackLine : (chromaData + ((line.number - 1) * videoParameters.fieldWidth));

--- a/tools/ld-chroma-decoder/palcolour.h
+++ b/tools/ld-chroma-decoder/palcolour.h
@@ -67,11 +67,6 @@ public:
         qint32 showPositionX = 200;
         qint32 showPositionY = 200;
 
-        // Interlaced line 44 is PAL line 23 (the first active half-line)
-        qint32 firstActiveLine = 44;
-        // Interlaced line 619 is PAL line 623 (the last active half-line)
-        qint32 lastActiveLine = 620;
-
         qint32 getThresholdsSize() const;
         qint32 getLookBehind() const;
         qint32 getLookAhead() const;

--- a/tools/ld-chroma-decoder/paldecoder.cpp
+++ b/tools/ld-chroma-decoder/paldecoder.cpp
@@ -40,7 +40,7 @@ bool PalDecoder::configure(const LdDecodeMetaData::VideoParameters &videoParamet
     }
 
     // Compute cropping parameters
-    setVideoParameters(config, videoParameters, config.pal.firstActiveLine, config.pal.lastActiveLine);
+    setVideoParameters(config, videoParameters);
 
     return true;
 }

--- a/tools/ld-chroma-decoder/sourcefield.h
+++ b/tools/ld-chroma-decoder/sourcefield.h
@@ -49,12 +49,12 @@ struct SourceField {
     }
 
     // Return the first/last active line numbers within this field's data,
-    // given the first/last frame line numbers.
-    qint32 getFirstActiveLine(qint32 firstActiveFrameLine) const {
-        return (firstActiveFrameLine + 1 - getOffset()) / 2;
+    // given the video parameters.
+    qint32 getFirstActiveLine(const LdDecodeMetaData::VideoParameters &videoParameters) const {
+        return (videoParameters.firstActiveFrameLine + 1 - getOffset()) / 2;
     }
-    qint32 getLastActiveLine(qint32 lastActiveFrameLine) const {
-        return (lastActiveFrameLine + 1 - getOffset()) / 2;
+    qint32 getLastActiveLine(const LdDecodeMetaData::VideoParameters &videoParameters) const {
+        return (videoParameters.lastActiveFrameLine + 1 - getOffset()) / 2;
     }
 };
 

--- a/tools/ld-chroma-decoder/transformpal.cpp
+++ b/tools/ld-chroma-decoder/transformpal.cpp
@@ -40,13 +40,10 @@ TransformPal::~TransformPal()
 }
 
 void TransformPal::updateConfiguration(const LdDecodeMetaData::VideoParameters &_videoParameters,
-                                       qint32 _firstActiveLine, qint32 _lastActiveLine,
                                        TransformPal::TransformMode _mode, double threshold,
                                        const QVector<double> &_thresholds)
 {
     videoParameters = _videoParameters;
-    firstActiveLine = _firstActiveLine;
-    lastActiveLine = _lastActiveLine;
     mode = _mode;
 
     // Resize thresholds to match the number of FFT bins we will consider in

--- a/tools/ld-chroma-decoder/transformpal.h
+++ b/tools/ld-chroma-decoder/transformpal.h
@@ -60,7 +60,6 @@ public:
     // Values from 0-1 are meaningful, with higher values requiring signals to
     // be more similar to be considered chroma. 0.6 is pyctools-pal's default.
     void updateConfiguration(const LdDecodeMetaData::VideoParameters &videoParameters,
-                             qint32 firstActiveLine, qint32 lastActiveLine,
                              TransformMode mode, double threshold,
                              const QVector<double> &thresholds);
 
@@ -99,8 +98,6 @@ protected:
     // Configuration parameters
     bool configurationSet;
     LdDecodeMetaData::VideoParameters videoParameters;
-    qint32 firstActiveLine;
-    qint32 lastActiveLine;
     QVector<double> thresholds;
     TransformMode mode;
 };

--- a/tools/ld-chroma-decoder/transformpal2d.cpp
+++ b/tools/ld-chroma-decoder/transformpal2d.cpp
@@ -135,8 +135,8 @@ void TransformPal2D::filterFields(const QVector<SourceField> &inputFields, qint3
 // Process one field, writing the reuslt into chromaBuf[outputIndex]
 void TransformPal2D::filterField(const SourceField& inputField, qint32 outputIndex)
 {
-    const qint32 firstFieldLine = inputField.getFirstActiveLine(firstActiveLine);
-    const qint32 lastFieldLine = inputField.getLastActiveLine(lastActiveLine);
+    const qint32 firstFieldLine = inputField.getFirstActiveLine(videoParameters);
+    const qint32 lastFieldLine = inputField.getLastActiveLine(videoParameters);
 
     // Iterate through the overlapping tile positions, covering the active area.
     // (See TransformPal2D member variable documentation for how the tiling works.)
@@ -327,8 +327,8 @@ void TransformPal2D::overlayFFTFrame(qint32 positionX, qint32 positionY,
 
     // Work out which field lines to use (as the input is in frame lines)
     const SourceField &inputField = inputFields[fieldIndex];
-    const qint32 firstFieldLine = inputField.getFirstActiveLine(firstActiveLine);
-    const qint32 lastFieldLine = inputField.getLastActiveLine(lastActiveLine);
+    const qint32 firstFieldLine = inputField.getFirstActiveLine(videoParameters);
+    const qint32 lastFieldLine = inputField.getLastActiveLine(videoParameters);
     const qint32 tileY = positionY / 2;
     const qint32 startY = qMax(firstFieldLine - tileY, 0);
     const qint32 endY = qMin(lastFieldLine - tileY, YTILE);
@@ -344,7 +344,7 @@ void TransformPal2D::overlayFFTFrame(qint32 positionX, qint32 positionY,
     }
 
     // Create a canvas
-    FrameCanvas canvas(rgbFrame, videoParameters, firstActiveLine, lastActiveLine);
+    FrameCanvas canvas(rgbFrame, videoParameters);
 
     // Outline the selected tile
     canvas.drawRectangle(positionX - 1, positionY + inputField.getOffset() - 1, XTILE + 1, (YTILE * 2) + 1, FrameCanvas::green);

--- a/tools/ld-chroma-decoder/transformpal3d.cpp
+++ b/tools/ld-chroma-decoder/transformpal3d.cpp
@@ -157,7 +157,7 @@ void TransformPal3D::filterFields(const QVector<SourceField> &inputFields, qint3
     // (See TransformPal3D member variable documentation for how the tiling works;
     // if you change the Z tiling here, also review getLookBehind/getLookAhead above.)
     for (qint32 tileZ = startIndex - HALFZTILE; tileZ < endIndex; tileZ += HALFZTILE) {
-        for (qint32 tileY = firstActiveLine - HALFYTILE; tileY < lastActiveLine; tileY += HALFYTILE) {
+        for (qint32 tileY = videoParameters.firstActiveFrameLine - HALFYTILE; tileY < videoParameters.lastActiveFrameLine; tileY += HALFYTILE) {
             for (qint32 tileX = videoParameters.activeVideoStart - HALFXTILE; tileX < videoParameters.activeVideoEnd; tileX += HALFXTILE) {
                 // Compute the forward FFT
                 forwardFFTTile(tileX, tileY, tileZ, inputFields);
@@ -180,8 +180,8 @@ void TransformPal3D::filterFields(const QVector<SourceField> &inputFields, qint3
 void TransformPal3D::forwardFFTTile(qint32 tileX, qint32 tileY, qint32 tileZ, const QVector<SourceField> &inputFields)
 {
     // Work out which lines of this tile are within the active region
-    const qint32 startY = qMax(firstActiveLine - tileY, 0);
-    const qint32 endY = qMin(lastActiveLine - tileY, YTILE);
+    const qint32 startY = qMax(videoParameters.firstActiveFrameLine - tileY, 0);
+    const qint32 endY = qMin(videoParameters.lastActiveFrameLine - tileY, YTILE);
 
     // Copy the input signal into fftReal, applying the window function
     for (qint32 z = 0; z < ZTILE; z++) {
@@ -218,8 +218,8 @@ void TransformPal3D::inverseFFTTile(qint32 tileX, qint32 tileY, qint32 tileZ, qi
     // Work out what portion of this tile is inside the active area
     const qint32 startX = qMax(videoParameters.activeVideoStart - tileX, 0);
     const qint32 endX = qMin(videoParameters.activeVideoEnd - tileX, XTILE);
-    const qint32 startY = qMax(firstActiveLine - tileY, 0);
-    const qint32 endY = qMin(lastActiveLine - tileY, YTILE);
+    const qint32 startY = qMax(videoParameters.firstActiveFrameLine - tileY, 0);
+    const qint32 endY = qMin(videoParameters.lastActiveFrameLine - tileY, YTILE);
     const qint32 startZ = qMax(startIndex - tileZ, 0);
     const qint32 endZ = qMin(endIndex - tileZ, ZTILE);
 
@@ -382,7 +382,7 @@ void TransformPal3D::overlayFFTFrame(qint32 positionX, qint32 positionY,
     }
 
     // Create a canvas
-    FrameCanvas canvas(rgbFrame, videoParameters, firstActiveLine, lastActiveLine);
+    FrameCanvas canvas(rgbFrame, videoParameters);
 
     // Outline the selected tile
     canvas.drawRectangle(positionX - 1, positionY - 1, XTILE + 1, YTILE + 1, FrameCanvas::green);

--- a/tools/ld-dropout-correct/dropoutcorrect.cpp
+++ b/tools/ld-dropout-correct/dropoutcorrect.cpp
@@ -320,14 +320,12 @@ DropOutCorrect::Replacement DropOutCorrect::findReplacementLine(const QVector<QV
         // Look up the field for a replacement
         findPotentialReplacementLine(thisFieldDropouts, dropOutIndex,
                                      thisFieldDropouts, true, 0, -stepAmount,
-                                     videoParameters[0].firstActiveFieldLine, videoParameters[0].lastActiveFieldLine,
                                      currentSource, sourceFrameQuality,
                                      candidates);
 
         // Look down the field for a replacement
         findPotentialReplacementLine(thisFieldDropouts, dropOutIndex,
                                      thisFieldDropouts, true, stepAmount, stepAmount,
-                                     videoParameters[0].firstActiveFieldLine, videoParameters[0].lastActiveFieldLine,
                                      currentSource, sourceFrameQuality,
                                      candidates);
 
@@ -338,14 +336,12 @@ DropOutCorrect::Replacement DropOutCorrect::findReplacementLine(const QVector<QV
             // Look up the field for a replacement
             findPotentialReplacementLine(thisFieldDropouts, dropOutIndex,
                                          otherFieldDropouts, false, otherFieldOffset, -stepAmount,
-                                         videoParameters[0].firstActiveFieldLine, videoParameters[0].lastActiveFieldLine,
                                          currentSource, sourceFrameQuality,
                                          candidates);
 
             // Look down the field for a replacement
             findPotentialReplacementLine(thisFieldDropouts, dropOutIndex,
                                          otherFieldDropouts, false, otherFieldOffset + stepAmount, stepAmount,
-                                         videoParameters[0].firstActiveFieldLine, videoParameters[0].lastActiveFieldLine,
                                          currentSource, sourceFrameQuality,
                                          candidates);
         }
@@ -409,7 +405,6 @@ DropOutCorrect::Replacement DropOutCorrect::findReplacementLine(const QVector<QV
 void DropOutCorrect::findPotentialReplacementLine(const QVector<QVector<DropOutLocation>> &targetDropouts, qint32 targetIndex,
                                                   const QVector<QVector<DropOutLocation>> &sourceDropouts, bool isSameField,
                                                   qint32 sourceOffset, qint32 stepAmount,
-                                                  qint32 firstActiveFieldLine, qint32 lastActiveFieldLine,
                                                   qint32 sourceNo, const QVector<qreal> &sourceFrameQuality,
                                                   QVector<Replacement> &candidates)
 {    
@@ -418,13 +413,13 @@ void DropOutCorrect::findPotentialReplacementLine(const QVector<QVector<DropOutL
     if (sourceNo == 0) sourceLine += sourceOffset;
 
     // Is the line within the active range?
-    if (sourceLine < firstActiveFieldLine || sourceLine >= lastActiveFieldLine) {
+    if (sourceLine < videoParameters[sourceNo].firstActiveFieldLine || sourceLine >= videoParameters[sourceNo].lastActiveFieldLine) {
         qDebug() << "Line" << sourceLine << "is not in active range - ignoring";
         return;
     }
 
     // Hunt for a replacement
-    while (sourceLine >= firstActiveFieldLine && sourceLine < lastActiveFieldLine) {
+    while (sourceLine >= videoParameters[sourceNo].firstActiveFieldLine && sourceLine < videoParameters[sourceNo].lastActiveFieldLine) {
         // Is there a dropout that overlaps the one we're trying to replace?
         bool hasOverlap = false;
         for (qint32 sourceIndex = 0; sourceIndex < sourceDropouts[sourceNo].size(); sourceIndex++) {

--- a/tools/ld-dropout-correct/dropoutcorrect.cpp
+++ b/tools/ld-dropout-correct/dropoutcorrect.cpp
@@ -121,8 +121,8 @@ void DropOutCorrect::run()
 void DropOutCorrect::correctField(const QVector<QVector<DropOutLocation>> &thisFieldDropouts,
                                   const QVector<QVector<DropOutLocation>> &otherFieldDropouts,
                                   QVector<SourceVideo::Data> &thisFieldData, const QVector<SourceVideo::Data> &otherFieldData,
-                                  bool thisFieldIsFirst, bool intraField, QVector<qint32> &availableSourcesForFrame,
-                                  QVector<qreal> &sourceFrameQuality, Statistics &statistics)
+                                  bool thisFieldIsFirst, bool intraField, const QVector<qint32> &availableSourcesForFrame,
+                                  const QVector<qreal> &sourceFrameQuality, Statistics &statistics)
 {
     for (qint32 dropoutIndex = 0; dropoutIndex < thisFieldDropouts[0].size(); dropoutIndex++) {
         Replacement replacement, chromaReplacement;
@@ -254,8 +254,9 @@ QVector<DropOutCorrect::DropOutLocation> DropOutCorrect::setDropOutLocations(QVe
 DropOutCorrect::Replacement DropOutCorrect::findReplacementLine(const QVector<QVector<DropOutLocation>> &thisFieldDropouts,
                                                                 const QVector<QVector<DropOutLocation>> &otherFieldDropouts,
                                                                 qint32 dropOutIndex, bool thisFieldIsFirst, bool matchChromaPhase,
-                                                                bool isColourBurst, bool intraField, QVector<qint32> &availableSourcesForFrame,
-                                                                QVector<qreal> &sourceFrameQuality)
+                                                                bool isColourBurst, bool intraField,
+                                                                const QVector<qint32> &availableSourcesForFrame,
+                                                                const QVector<qreal> &sourceFrameQuality)
 {
     // Define the minimum step size to use when searching for replacement
     // lines, and the offset to the nearest replacement line in the other
@@ -320,13 +321,15 @@ DropOutCorrect::Replacement DropOutCorrect::findReplacementLine(const QVector<QV
         findPotentialReplacementLine(thisFieldDropouts, dropOutIndex,
                                      thisFieldDropouts, true, 0, -stepAmount,
                                      videoParameters[0].firstActiveFieldLine, videoParameters[0].lastActiveFieldLine,
-                                     candidates, currentSource, sourceFrameQuality);
+                                     currentSource, sourceFrameQuality,
+                                     candidates);
 
         // Look down the field for a replacement
         findPotentialReplacementLine(thisFieldDropouts, dropOutIndex,
                                      thisFieldDropouts, true, stepAmount, stepAmount,
                                      videoParameters[0].firstActiveFieldLine, videoParameters[0].lastActiveFieldLine,
-                                     candidates, currentSource, sourceFrameQuality);
+                                     currentSource, sourceFrameQuality,
+                                     candidates);
 
         // Only check the other field for visible line replacements
         if (!isColourBurst && !intraField) {
@@ -336,13 +339,15 @@ DropOutCorrect::Replacement DropOutCorrect::findReplacementLine(const QVector<QV
             findPotentialReplacementLine(thisFieldDropouts, dropOutIndex,
                                          otherFieldDropouts, false, otherFieldOffset, -stepAmount,
                                          videoParameters[0].firstActiveFieldLine, videoParameters[0].lastActiveFieldLine,
-                                         candidates, currentSource, sourceFrameQuality);
+                                         currentSource, sourceFrameQuality,
+                                         candidates);
 
             // Look down the field for a replacement
             findPotentialReplacementLine(thisFieldDropouts, dropOutIndex,
                                          otherFieldDropouts, false, otherFieldOffset + stepAmount, stepAmount,
                                          videoParameters[0].firstActiveFieldLine, videoParameters[0].lastActiveFieldLine,
-                                         candidates, currentSource, sourceFrameQuality);
+                                         currentSource, sourceFrameQuality,
+                                         candidates);
         }
     }
 
@@ -405,8 +410,8 @@ void DropOutCorrect::findPotentialReplacementLine(const QVector<QVector<DropOutL
                                                   const QVector<QVector<DropOutLocation>> &sourceDropouts, bool isSameField,
                                                   qint32 sourceOffset, qint32 stepAmount,
                                                   qint32 firstActiveFieldLine, qint32 lastActiveFieldLine,
-                                                  QVector<Replacement> &candidates, qint32 sourceNo,
-                                                  QVector<qreal> sourceFrameQuality)
+                                                  qint32 sourceNo, const QVector<qreal> &sourceFrameQuality,
+                                                  QVector<Replacement> &candidates)
 {    
     // Calculate the start source line (which is the same line as the dropout unless the source number is 0
     qint32 sourceLine = targetDropouts[0][targetIndex].fieldLine;

--- a/tools/ld-dropout-correct/dropoutcorrect.h
+++ b/tools/ld-dropout-correct/dropoutcorrect.h
@@ -83,7 +83,6 @@ private:
     QAtomicInt& abort;
     CorrectorPool& correctorPool;
 
-    LdDecodeMetaData ldDecodeMetaData;
     QVector<LdDecodeMetaData::VideoParameters> videoParameters;
 
     void correctField(const QVector<QVector<DropOutLocation> > &thisFieldDropouts,

--- a/tools/ld-dropout-correct/dropoutcorrect.h
+++ b/tools/ld-dropout-correct/dropoutcorrect.h
@@ -100,7 +100,6 @@ private:
     void findPotentialReplacementLine(const QVector<QVector<DropOutLocation>> &targetDropouts, qint32 targetIndex,
                                       const QVector<QVector<DropOutLocation>> &sourceDropouts, bool isSameField,
                                       qint32 sourceOffset, qint32 stepAmount,
-                                      qint32 firstActiveFieldLine, qint32 lastActiveFieldLine,
                                       qint32 sourceNo, const QVector<qreal> &sourceFrameQuality,
                                       QVector<Replacement> &candidates);
     void correctDropOut(const DropOutLocation &dropOut,

--- a/tools/ld-dropout-correct/dropoutcorrect.h
+++ b/tools/ld-dropout-correct/dropoutcorrect.h
@@ -88,20 +88,21 @@ private:
     void correctField(const QVector<QVector<DropOutLocation> > &thisFieldDropouts,
                       const QVector<QVector<DropOutLocation> > &otherFieldDropouts,
                       QVector<SourceVideo::Data> &thisFieldData, const QVector<SourceVideo::Data> &otherFieldData,
-                      bool thisFieldIsFirst, bool intraField, QVector<qint32> &availableSourcesForFrame,
-                      QVector<qreal> &sourceFrameQuality, Statistics &statistics);
+                      bool thisFieldIsFirst, bool intraField, const QVector<qint32> &availableSourcesForFrame,
+                      const QVector<qreal> &sourceFrameQuality, Statistics &statistics);
     QVector<DropOutLocation> populateDropoutsVector(LdDecodeMetaData::Field field, bool overCorrect);
     QVector<DropOutLocation> setDropOutLocations(QVector<DropOutLocation> dropOuts);
     Replacement findReplacementLine(const QVector<QVector<DropOutLocation>> &thisFieldDropouts,
                                     const QVector<QVector<DropOutLocation>> &otherFieldDropouts,
                                     qint32 dropOutIndex, bool thisFieldIsFirst, bool matchChromaPhase,
-                                    bool isColourBurst, bool intraField, QVector<qint32> &availableSourcesForFrame,
-                                    QVector<qreal> &sourceFrameQuality);
+                                    bool isColourBurst, bool intraField, const QVector<qint32> &availableSourcesForFrame,
+                                    const QVector<qreal> &sourceFrameQuality);
     void findPotentialReplacementLine(const QVector<QVector<DropOutLocation>> &targetDropouts, qint32 targetIndex,
                                       const QVector<QVector<DropOutLocation>> &sourceDropouts, bool isSameField,
                                       qint32 sourceOffset, qint32 stepAmount,
                                       qint32 firstActiveFieldLine, qint32 lastActiveFieldLine,
-                                      QVector<Replacement> &candidates, qint32 sourceNo, QVector<qreal> sourceFrameQuality);
+                                      qint32 sourceNo, const QVector<qreal> &sourceFrameQuality,
+                                      QVector<Replacement> &candidates);
     void correctDropOut(const DropOutLocation &dropOut,
                         const Replacement &replacement, const Replacement &chromaReplacement,
                         QVector<SourceVideo::Data> &thisFieldData, const QVector<SourceVideo::Data> &otherFieldData,


### PR DESCRIPTION
Following #444, it's now possible to simplify ld-chroma-decoder's active region handling quite a bit -- the classes that used to keep track of the active region can just use the VideoParameters object they already have. Ditto for one place in ld-dropout-correct.
