### PR TITLE
Make all operator member functions const

### DIFF
--- a/tools/ld-chroma-decoder/yiq.cpp
+++ b/tools/ld-chroma-decoder/yiq.cpp
@@ -30,7 +30,7 @@ YIQ::YIQ(qreal _y, qreal _i, qreal _q)
 {
 }
 
-YIQ YIQ::operator*=(qreal x)
+YIQ YIQ::operator*=(qreal x) const
 {
     YIQ o;
 
@@ -41,7 +41,7 @@ YIQ YIQ::operator*=(qreal x)
     return o;
 }
 
-YIQ YIQ::operator+=(const YIQ &p)
+YIQ YIQ::operator+=(const YIQ &p) const
 {
     YIQ o;
 

--- a/tools/ld-chroma-decoder/yiq.h
+++ b/tools/ld-chroma-decoder/yiq.h
@@ -34,8 +34,8 @@ public:
     qreal y, i, q;
 
     YIQ(qreal y = 0.0, qreal i = 0.0, qreal q = 0.0);
-    YIQ operator*=(qreal x);
-    YIQ operator+=(const YIQ &p);
+    YIQ operator*=(qreal x) const;
+    YIQ operator+=(const YIQ &p) const;
 
 private:
 

--- a/tools/ld-discmap/frame.cpp
+++ b/tools/ld-discmap/frame.cpp
@@ -168,7 +168,7 @@ void Frame::secondField(qint32 value)
 }
 
 // Overide less than operator for sorting
-bool Frame::operator<(const Frame& other)
+bool Frame::operator<(const Frame& other) const
 {
     return (m_vbiFrameNumber < other.m_vbiFrameNumber) ||
             ((m_vbiFrameNumber == other.m_vbiFrameNumber) && (other.m_isPullDown));

--- a/tools/ld-discmap/frame.h
+++ b/tools/ld-discmap/frame.h
@@ -37,7 +37,7 @@ public:
           const qint32 &firstField = -1, const qint32 &secondField = -1);
     ~Frame() = default;
     Frame(const Frame &) = default;
-    Frame &operator =(const Frame &) = default;
+    Frame &operator=(const Frame &) = default;
 
     // Get
     qint32 seqFrameNumber() const;
@@ -66,7 +66,7 @@ public:
     void secondField(qint32 value);
 
     // Operators
-    bool operator <(const Frame &);
+    bool operator<(const Frame &) const;
 
 private:
     qint32 m_seqFrameNumber;


### PR DESCRIPTION
LLVM libcxx's std::sort requires operator< to be const, but it's good practice to do this for all of them.

Fixes #460.