### PR TITLE
Initial support for subcarrier-locked sampling.

### DIFF
--- a/tools/ld-chroma-decoder/encoder/palencoder.cpp
+++ b/tools/ld-chroma-decoder/encoder/palencoder.cpp
@@ -54,6 +54,7 @@ PALEncoder::PALEncoder(QFile &_rgbFile, QFile &_tbcFile, LdDecodeMetaData &_meta
     // Initialise video parameters based on ld-decode's usual output.
     // numberOfSequentialFields will be computed automatically.
     videoParameters.isSourcePal = true;
+    videoParameters.isSubcarrierLocked = false;
     videoParameters.colourBurstStart = 98;
     videoParameters.colourBurstEnd = 138;
     videoParameters.activeVideoStart = 185;

--- a/tools/library/tbc/lddecodemetadata.cpp
+++ b/tools/library/tbc/lddecodemetadata.cpp
@@ -71,6 +71,7 @@ LdDecodeMetaData::VideoParameters LdDecodeMetaData::getVideoParameters()
     if (json.size({"videoParameters"}) > 0) {
         videoParameters.numberOfSequentialFields = json.value({"videoParameters", "numberOfSequentialFields"}).toInt();
         videoParameters.isSourcePal = json.value({"videoParameters", "isSourcePal"}).toBool();
+        videoParameters.isSubcarrierLocked = json.value({"videoParameters", "isSubcarrierLocked"}).toBool();
 
         videoParameters.colourBurstStart = json.value({"videoParameters", "colourBurstStart"}).toInt();
         videoParameters.colourBurstEnd = json.value({"videoParameters", "colourBurstEnd"}).toInt();
@@ -121,6 +122,7 @@ void LdDecodeMetaData::setVideoParameters (LdDecodeMetaData::VideoParameters _vi
     // Write the video parameters
     json.setValue({"videoParameters", "numberOfSequentialFields"}, getNumberOfFields());
     json.setValue({"videoParameters", "isSourcePal"}, _videoParameters.isSourcePal);
+    json.setValue({"videoParameters", "isSubcarrierLocked"}, _videoParameters.isSubcarrierLocked);
 
     json.setValue({"videoParameters", "colourBurstStart"}, _videoParameters.colourBurstStart);
     json.setValue({"videoParameters", "colourBurstEnd"}, _videoParameters.colourBurstEnd);

--- a/tools/library/tbc/lddecodemetadata.h
+++ b/tools/library/tbc/lddecodemetadata.h
@@ -50,6 +50,7 @@ public:
         qint32 numberOfSequentialFields;
 
         bool isSourcePal;
+        bool isSubcarrierLocked;
 
         qint32 colourBurstStart;
         qint32 colourBurstEnd;


### PR DESCRIPTION
For 4fSC subcarrier-locked PAL, the TBC file contains four more samples than usual over the course of 625 lines, so the two fields are horizontally misaligned by two samples (see discussion in #242). This shifts the second field to the left to compensate.

This is only an initial fix for now, since the same problem will apply to ld-dropout-correct and the other tools -- it really needs dealing with in the library.

No change for existing files; it's only enabled if the video parameters contain `isSubcarrierLocked: true`.