### PR TITLE
Add "Use Simple PAL decoder" checkbox in ld-analyse

### DIFF
--- a/tools/ld-analyse/palchromadecoderconfigdialog.cpp
+++ b/tools/ld-analyse/palchromadecoderconfigdialog.cpp
@@ -74,10 +74,12 @@ void PalChromaDecoderConfigDialog::updateDialog()
         ui->twoDeeTransformCheckBox->setChecked(true);
         ui->thresholdModeCheckBox->setEnabled(true);
         ui->showFFTsCheckBox->setEnabled(true);
+        ui->simplePALCheckBox->setEnabled(true);
     } else {
         ui->twoDeeTransformCheckBox->setChecked(false);
         ui->thresholdModeCheckBox->setEnabled(false);
         ui->showFFTsCheckBox->setEnabled(false);
+        ui->simplePALCheckBox->setEnabled(false);
     }
 
     if (palChromaDecoderConfig.transformMode == TransformPal::thresholdMode) {
@@ -99,6 +101,8 @@ void PalChromaDecoderConfigDialog::updateDialog()
 
     if (palChromaDecoderConfig.showFFTs) ui->showFFTsCheckBox->setChecked(true);
     else ui->showFFTsCheckBox->setChecked(false);
+    if (palChromaDecoderConfig.simplePAL) ui->simplePALCheckBox->setChecked(true);
+    else ui->simplePALCheckBox->setChecked(false);
 }
 
 // Methods to handle changes to the dialogue
@@ -143,5 +147,12 @@ void PalChromaDecoderConfigDialog::on_showFFTsCheckBox_clicked()
 {
     if (ui->showFFTsCheckBox->isChecked()) palChromaDecoderConfig.showFFTs = true;
     else palChromaDecoderConfig.showFFTs = false;
+    emit palChromaDecoderConfigChanged();
+}
+
+void PalChromaDecoderConfigDialog::on_simplePALCheckBox_clicked()
+{
+    if (ui->simplePALCheckBox->isChecked()) palChromaDecoderConfig.simplePAL = true;
+    else palChromaDecoderConfig.simplePAL = false;
     emit palChromaDecoderConfigChanged();
 }

--- a/tools/ld-analyse/palchromadecoderconfigdialog.h
+++ b/tools/ld-analyse/palchromadecoderconfigdialog.h
@@ -53,6 +53,7 @@ private slots:
     void on_thresholdModeCheckBox_clicked();
     void on_thresholdHorizontalSlider_valueChanged(int value);
     void on_showFFTsCheckBox_clicked();
+    void on_simplePALCheckBox_clicked();
 
 private:
     Ui::PalChromaDecoderConfigDialog *ui;

--- a/tools/ld-analyse/palchromadecoderconfigdialog.ui
+++ b/tools/ld-analyse/palchromadecoderconfigdialog.ui
@@ -79,6 +79,13 @@
       </widget>
      </item>
      <item>
+      <widget class="QCheckBox" name="simplePALCheckBox">
+       <property name="text">
+        <string>Use Simple PAL decoder</string>
+       </property>
+      </widget>
+     </item>
+     <item>
       <spacer name="verticalSpacer">
        <property name="orientation">
         <enum>Qt::Vertical</enum>


### PR DESCRIPTION
This is equivalent to ld-chroma-decoder --simple-pal - with it turned on, you can see the phase errors in the input as Hanover bars.

Off (as usual):

![pald](https://user-images.githubusercontent.com/436317/79011332-b8bf3300-7b5b-11ea-8747-5ccc505121ea.png)

On:

![pals](https://user-images.githubusercontent.com/436317/79011347-bd83e700-7b5b-11ea-9f5a-1050f1c482fb.png)