### PR TITLE
Remove burst-based chroma gain calculation

### DIFF
--- a/tools/ld-analyse/chromadecoderconfigdialog.cpp
+++ b/tools/ld-analyse/chromadecoderconfigdialog.cpp
@@ -1,6 +1,6 @@
 /************************************************************************
 
-    palchromadecoderconfigdialog.cpp
+    chromadecoderconfigdialog.cpp
 
     ld-analyse - TBC output analysis
     Copyright (C) 2019 Simon Inns
@@ -22,12 +22,12 @@
 
 ************************************************************************/
 
-#include "palchromadecoderconfigdialog.h"
-#include "ui_palchromadecoderconfigdialog.h"
+#include "chromadecoderconfigdialog.h"
+#include "ui_chromadecoderconfigdialog.h"
 
-PalChromaDecoderConfigDialog::PalChromaDecoderConfigDialog(QWidget *parent) :
+ChromaDecoderConfigDialog::ChromaDecoderConfigDialog(QWidget *parent) :
     QDialog(parent),
-    ui(new Ui::PalChromaDecoderConfigDialog)
+    ui(new Ui::ChromaDecoderConfigDialog)
 {
     ui->setupUi(this);
     setWindowFlags(Qt::Window);
@@ -39,12 +39,12 @@ PalChromaDecoderConfigDialog::PalChromaDecoderConfigDialog(QWidget *parent) :
     updateDialog();
 }
 
-PalChromaDecoderConfigDialog::~PalChromaDecoderConfigDialog()
+ChromaDecoderConfigDialog::~ChromaDecoderConfigDialog()
 {
     delete ui;
 }
 
-void PalChromaDecoderConfigDialog::setConfiguration(const PalColour::Configuration &_palChromaDecoderConfig)
+void ChromaDecoderConfigDialog::setConfiguration(const PalColour::Configuration &_palChromaDecoderConfig)
 {
     palChromaDecoderConfig = _palChromaDecoderConfig;
 
@@ -57,15 +57,15 @@ void PalChromaDecoderConfigDialog::setConfiguration(const PalColour::Configurati
     }
 
     updateDialog();
-    emit palChromaDecoderConfigChanged();
+    emit chromaDecoderConfigChanged();
 }
 
-const PalColour::Configuration &PalChromaDecoderConfigDialog::getConfiguration()
+const PalColour::Configuration &ChromaDecoderConfigDialog::getConfiguration()
 {
     return palChromaDecoderConfig;
 }
 
-void PalChromaDecoderConfigDialog::updateDialog()
+void ChromaDecoderConfigDialog::updateDialog()
 {
     ui->chromaGainHorizontalSlider->setValue(static_cast<qint32>(palChromaDecoderConfig.chromaGain * 100));
     ui->chromaGainValueLabel->setText(QString::number(palChromaDecoderConfig.chromaGain, 'f', 2));
@@ -107,14 +107,14 @@ void PalChromaDecoderConfigDialog::updateDialog()
 
 // Methods to handle changes to the dialogue
 
-void PalChromaDecoderConfigDialog::on_chromaGainHorizontalSlider_valueChanged(int value)
+void ChromaDecoderConfigDialog::on_chromaGainHorizontalSlider_valueChanged(int value)
 {
     palChromaDecoderConfig.chromaGain = static_cast<double>(value) / 100;
     ui->chromaGainValueLabel->setText(QString::number(palChromaDecoderConfig.chromaGain, 'f', 2));
-    emit palChromaDecoderConfigChanged();
+    emit chromaDecoderConfigChanged();
 }
 
-void PalChromaDecoderConfigDialog::on_twoDeeTransformCheckBox_clicked()
+void ChromaDecoderConfigDialog::on_twoDeeTransformCheckBox_clicked()
 {
     if (ui->twoDeeTransformCheckBox->isChecked()) {
         palChromaDecoderConfig.chromaFilter = PalColour::transform2DFilter;
@@ -122,10 +122,10 @@ void PalChromaDecoderConfigDialog::on_twoDeeTransformCheckBox_clicked()
         palChromaDecoderConfig.chromaFilter = PalColour::palColourFilter;
     }
     updateDialog();
-    emit palChromaDecoderConfigChanged();
+    emit chromaDecoderConfigChanged();
 }
 
-void PalChromaDecoderConfigDialog::on_thresholdModeCheckBox_clicked()
+void ChromaDecoderConfigDialog::on_thresholdModeCheckBox_clicked()
 {
     if (ui->thresholdModeCheckBox->isChecked()) {
         palChromaDecoderConfig.transformMode = TransformPal::thresholdMode;
@@ -133,26 +133,26 @@ void PalChromaDecoderConfigDialog::on_thresholdModeCheckBox_clicked()
         palChromaDecoderConfig.transformMode = TransformPal::levelMode;
     }
     updateDialog();
-    emit palChromaDecoderConfigChanged();
+    emit chromaDecoderConfigChanged();
 }
 
-void PalChromaDecoderConfigDialog::on_thresholdHorizontalSlider_valueChanged(int value)
+void ChromaDecoderConfigDialog::on_thresholdHorizontalSlider_valueChanged(int value)
 {
     palChromaDecoderConfig.transformThreshold = static_cast<double>(value) / 100;
     ui->thresholdValueLabel->setText(QString::number(palChromaDecoderConfig.transformThreshold, 'f', 2));
-    emit palChromaDecoderConfigChanged();
+    emit chromaDecoderConfigChanged();
 }
 
-void PalChromaDecoderConfigDialog::on_showFFTsCheckBox_clicked()
+void ChromaDecoderConfigDialog::on_showFFTsCheckBox_clicked()
 {
     if (ui->showFFTsCheckBox->isChecked()) palChromaDecoderConfig.showFFTs = true;
     else palChromaDecoderConfig.showFFTs = false;
-    emit palChromaDecoderConfigChanged();
+    emit chromaDecoderConfigChanged();
 }
 
-void PalChromaDecoderConfigDialog::on_simplePALCheckBox_clicked()
+void ChromaDecoderConfigDialog::on_simplePALCheckBox_clicked()
 {
     if (ui->simplePALCheckBox->isChecked()) palChromaDecoderConfig.simplePAL = true;
     else palChromaDecoderConfig.simplePAL = false;
-    emit palChromaDecoderConfigChanged();
+    emit chromaDecoderConfigChanged();
 }

--- a/tools/ld-analyse/chromadecoderconfigdialog.h
+++ b/tools/ld-analyse/chromadecoderconfigdialog.h
@@ -1,6 +1,6 @@
 /************************************************************************
 
-    palchromadecoderconfigdialog.h
+    chromadecoderconfigdialog.h
 
     ld-analyse - TBC output analysis
     Copyright (C) 2019 Simon Inns
@@ -22,30 +22,30 @@
 
 ************************************************************************/
 
-#ifndef PALCHROMADECODERCONFIGDIALOG_H
-#define PALCHROMADECODERCONFIGDIALOG_H
+#ifndef CHROMADECODERCONFIGDIALOG_H
+#define CHROMADECODERCONFIGDIALOG_H
 
 #include <QDialog>
 
 #include "palcolour.h"
 
 namespace Ui {
-class PalChromaDecoderConfigDialog;
+class ChromaDecoderConfigDialog;
 }
 
-class PalChromaDecoderConfigDialog : public QDialog
+class ChromaDecoderConfigDialog : public QDialog
 {
     Q_OBJECT
 
 public:
-    explicit PalChromaDecoderConfigDialog(QWidget *parent = nullptr);
-    ~PalChromaDecoderConfigDialog();
+    explicit ChromaDecoderConfigDialog(QWidget *parent = nullptr);
+    ~ChromaDecoderConfigDialog();
 
     void setConfiguration(const PalColour::Configuration &_palChromaDecoderConfig);
     const PalColour::Configuration &getConfiguration();
 
 signals:
-    void palChromaDecoderConfigChanged();
+    void chromaDecoderConfigChanged();
 
 private slots:
     void on_chromaGainHorizontalSlider_valueChanged(int value);
@@ -56,10 +56,10 @@ private slots:
     void on_simplePALCheckBox_clicked();
 
 private:
-    Ui::PalChromaDecoderConfigDialog *ui;
+    Ui::ChromaDecoderConfigDialog *ui;
     PalColour::Configuration palChromaDecoderConfig;
 
     void updateDialog();
 };
 
-#endif // PALCHROMADECODERCONFIGDIALOG_H
+#endif // CHROMADECODERCONFIGDIALOG_H

--- a/tools/ld-analyse/chromadecoderconfigdialog.h
+++ b/tools/ld-analyse/chromadecoderconfigdialog.h
@@ -27,6 +27,7 @@
 
 #include <QDialog>
 
+#include "comb.h"
 #include "palcolour.h"
 
 namespace Ui {
@@ -41,8 +42,9 @@ public:
     explicit ChromaDecoderConfigDialog(QWidget *parent = nullptr);
     ~ChromaDecoderConfigDialog();
 
-    void setConfiguration(const PalColour::Configuration &_palChromaDecoderConfig);
-    const PalColour::Configuration &getConfiguration();
+    void setConfiguration(bool isSourcePal, const PalColour::Configuration &palConfiguration, const Comb::Configuration &ntscConfiguration);
+    const PalColour::Configuration &getPalConfiguration();
+    const Comb::Configuration &getNtscConfiguration();
 
 signals:
     void chromaDecoderConfigChanged();
@@ -57,7 +59,9 @@ private slots:
 
 private:
     Ui::ChromaDecoderConfigDialog *ui;
-    PalColour::Configuration palChromaDecoderConfig;
+    bool isSourcePal;
+    PalColour::Configuration palConfiguration;
+    Comb::Configuration ntscConfiguration;
 
     void updateDialog();
 };

--- a/tools/ld-analyse/chromadecoderconfigdialog.h
+++ b/tools/ld-analyse/chromadecoderconfigdialog.h
@@ -51,11 +51,17 @@ signals:
 
 private slots:
     void on_chromaGainHorizontalSlider_valueChanged(int value);
+
     void on_twoDeeTransformCheckBox_clicked();
     void on_thresholdModeCheckBox_clicked();
     void on_thresholdHorizontalSlider_valueChanged(int value);
     void on_showFFTsCheckBox_clicked();
     void on_simplePALCheckBox_clicked();
+
+    void on_whitePoint75CheckBox_clicked();
+    void on_colorLpfHqCheckBox_clicked();
+    void on_cNRHorizontalSlider_valueChanged(int value);
+    void on_yNRHorizontalSlider_valueChanged(int value);
 
 private:
     Ui::ChromaDecoderConfigDialog *ui;

--- a/tools/ld-analyse/chromadecoderconfigdialog.ui
+++ b/tools/ld-analyse/chromadecoderconfigdialog.ui
@@ -65,7 +65,7 @@
       </widget>
      </item>
      <item>
-      <widget class="QLabel" name="label">
+      <widget class="QLabel" name="thresholdLabel">
        <property name="text">
         <string>Transform threshold:</string>
        </property>

--- a/tools/ld-analyse/chromadecoderconfigdialog.ui
+++ b/tools/ld-analyse/chromadecoderconfigdialog.ui
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ui version="4.0">
- <class>PalChromaDecoderConfigDialog</class>
- <widget class="QDialog" name="PalChromaDecoderConfigDialog">
+ <class>ChromaDecoderConfigDialog</class>
+ <widget class="QDialog" name="ChromaDecoderConfigDialog">
   <property name="geometry">
    <rect>
     <x>0</x>
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string>PAL Chroma-Decoder Configuration</string>
+   <string>Chroma Decoder Configuration</string>
   </property>
   <layout class="QHBoxLayout" name="horizontalLayout">
    <item>

--- a/tools/ld-analyse/chromadecoderconfigdialog.ui
+++ b/tools/ld-analyse/chromadecoderconfigdialog.ui
@@ -13,112 +13,262 @@
   <property name="windowTitle">
    <string>Chroma Decoder Configuration</string>
   </property>
-  <layout class="QHBoxLayout" name="horizontalLayout">
+  <layout class="QVBoxLayout" name="outerVerticalLayout">
    <item>
-    <layout class="QVBoxLayout" name="verticalLayout">
-     <item>
-      <widget class="QLabel" name="label">
-       <property name="text">
-        <string>Chroma gain:</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QSlider" name="chromaGainHorizontalSlider">
-       <property name="maximum">
-        <number>200</number>
-       </property>
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QLabel" name="chromaGainValueLabel">
-       <property name="text">
-        <string>1.0</string>
-       </property>
-       <property name="alignment">
-        <set>Qt::AlignCenter</set>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QCheckBox" name="twoDeeTransformCheckBox">
-       <property name="text">
-        <string>Use Transform PAL 2D filter</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QCheckBox" name="thresholdModeCheckBox">
-       <property name="text">
-        <string>Use threshold comparison mode</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QLabel" name="label_3">
-       <property name="text">
-        <string/>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QLabel" name="thresholdLabel">
-       <property name="text">
-        <string>Transform threshold:</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QSlider" name="thresholdHorizontalSlider">
-       <property name="maximum">
-        <number>100</number>
-       </property>
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QLabel" name="thresholdValueLabel">
-       <property name="text">
-        <string>0.4</string>
-       </property>
-       <property name="alignment">
-        <set>Qt::AlignCenter</set>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QCheckBox" name="showFFTsCheckBox">
-       <property name="text">
-        <string>Overlay FFT visualisation</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QCheckBox" name="simplePALCheckBox">
-       <property name="text">
-        <string>Use Simple PAL decoder</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <spacer name="verticalSpacer">
-       <property name="orientation">
-        <enum>Qt::Vertical</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>20</width>
-         <height>40</height>
-        </size>
-       </property>
-      </spacer>
-     </item>
-    </layout>
+    <widget class="QLabel" name="chromaGainLabel">
+     <property name="text">
+      <string>Chroma gain:</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QSlider" name="chromaGainHorizontalSlider">
+     <property name="maximum">
+      <number>200</number>
+     </property>
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QLabel" name="chromaGainValueLabel">
+     <property name="text">
+      <string>1.0</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignCenter</set>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <spacer name="verticalSpacer_1">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item>
+    <widget class="QTabWidget" name="standardTabs">
+     <property name="currentIndex">
+      <number>1</number>
+     </property>
+     <widget class="QWidget" name="palTab">
+      <attribute name="title">
+       <string>PAL</string>
+      </attribute>
+      <layout class="QVBoxLayout" name="palVerticalLayout">
+       <item>
+        <widget class="QCheckBox" name="twoDeeTransformCheckBox">
+         <property name="text">
+          <string>Use Transform PAL 2D filter</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QCheckBox" name="thresholdModeCheckBox">
+         <property name="text">
+          <string>Use threshold comparison mode</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <spacer name="verticalSpacer_2">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>40</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item>
+        <widget class="QLabel" name="thresholdLabel">
+         <property name="text">
+          <string>Transform threshold:</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QSlider" name="thresholdHorizontalSlider">
+         <property name="maximum">
+          <number>100</number>
+         </property>
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QLabel" name="thresholdValueLabel">
+         <property name="text">
+          <string>0.4</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignCenter</set>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <spacer name="verticalSpacer_3">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>40</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item>
+        <widget class="QCheckBox" name="showFFTsCheckBox">
+         <property name="text">
+          <string>Overlay FFT visualisation</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QCheckBox" name="simplePALCheckBox">
+         <property name="text">
+          <string>Use Simple PAL decoder</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <spacer name="verticalSpacer_4">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>40</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+      </layout>
+     </widget>
+     <widget class="QWidget" name="ntscTab">
+      <attribute name="title">
+       <string>NTSC</string>
+      </attribute>
+      <layout class="QVBoxLayout" name="ntscVerticalLayout">
+       <item>
+        <widget class="QCheckBox" name="whitePoint75CheckBox">
+         <property name="text">
+          <string>Use 75 IRE white point</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QCheckBox" name="colorLpfHqCheckBox">
+         <property name="text">
+          <string>Use full bandwidth Q channel filter</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <spacer name="verticalSpacer_5">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>40</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item>
+        <widget class="QLabel" name="cNRLabel">
+         <property name="text">
+          <string>Chroma noise reduction:</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QSlider" name="cNRHorizontalSlider">
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QLabel" name="cNRValueLabel">
+         <property name="text">
+          <string>0.00 IRE</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignCenter</set>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <spacer name="verticalSpacer_6">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>40</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item>
+        <widget class="QLabel" name="yNRLabel">
+         <property name="text">
+          <string>Luma noise reduction:</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QSlider" name="yNRHorizontalSlider">
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QLabel" name="yNRValueLabel">
+         <property name="text">
+          <string>0.00 IRE</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignCenter</set>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <spacer name="verticalSpacer">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>40</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+      </layout>
+     </widget>
+    </widget>
    </item>
   </layout>
  </widget>

--- a/tools/ld-analyse/configuration.cpp
+++ b/tools/ld-analyse/configuration.cpp
@@ -75,7 +75,7 @@ void Configuration::writeConfiguration(void)
     configuration->setValue("dropoutAnalysisDialogGeometry", settings.windows.dropoutAnalysisDialogGeometry);
     configuration->setValue("snrAnalysisDialogGeometry", settings.windows.snrAnalysisDialogGeometry);
     configuration->setValue("closedCaptionDialogGeometry", settings.windows.closedCaptionDialogGeometry);
-    configuration->setValue("palChromaDecoderConfigDialogGeometry", settings.windows.palChromaDecoderConfigDialogGeometry);
+    configuration->setValue("chromaDecoderConfigDialogGeometry", settings.windows.chromaDecoderConfigDialogGeometry);
     configuration->setValue("captureQualityIndexDialogGeometry", settings.windows.captureQualityIndexDialogGeometry);
     configuration->endGroup();
 
@@ -106,7 +106,7 @@ void Configuration::readConfiguration(void)
     settings.windows.dropoutAnalysisDialogGeometry = configuration->value("dropoutAnalysisDialogGeometry").toByteArray();
     settings.windows.snrAnalysisDialogGeometry = configuration->value("snrAnalysisDialogGeometry").toByteArray();
     settings.windows.closedCaptionDialogGeometry = configuration->value("closedCaptionDialogGeometry").toByteArray();
-    settings.windows.palChromaDecoderConfigDialogGeometry = configuration->value("palChromaDecoderConfigDialogGeometry").toByteArray();
+    settings.windows.chromaDecoderConfigDialogGeometry = configuration->value("chromaDecoderConfigDialogGeometry").toByteArray();
     settings.windows.captureQualityIndexDialogGeometry = configuration->value("captureQualityIndexDialogGeometry").toByteArray();
     configuration->endGroup();
 }
@@ -128,7 +128,7 @@ void Configuration::setDefault(void)
     settings.windows.dropoutAnalysisDialogGeometry = QByteArray();
     settings.windows.snrAnalysisDialogGeometry = QByteArray();
     settings.windows.closedCaptionDialogGeometry = QByteArray();
-    settings.windows.palChromaDecoderConfigDialogGeometry = QByteArray();
+    settings.windows.chromaDecoderConfigDialogGeometry = QByteArray();
     settings.windows.captureQualityIndexDialogGeometry = QByteArray();
 
     // Write the configuration
@@ -229,14 +229,14 @@ QByteArray Configuration::getClosedCaptionDialogGeometry(void)
     return settings.windows.closedCaptionDialogGeometry;
 }
 
-void Configuration::setPalChromaDecoderConfigDialogGeometry(QByteArray palChromaDecoderConfigDialogGeometry)
+void Configuration::setChromaDecoderConfigDialogGeometry(QByteArray chromaDecoderConfigDialogGeometry)
 {
-    settings.windows.palChromaDecoderConfigDialogGeometry = palChromaDecoderConfigDialogGeometry;
+    settings.windows.chromaDecoderConfigDialogGeometry = chromaDecoderConfigDialogGeometry;
 }
 
-QByteArray Configuration::getPalChromaDecoderConfigDialogGeometry(void)
+QByteArray Configuration::getChromaDecoderConfigDialogGeometry(void)
 {
-    return settings.windows.palChromaDecoderConfigDialogGeometry;
+    return settings.windows.chromaDecoderConfigDialogGeometry;
 }
 
 void Configuration::setCaptureQualityIndexDialogGeometry(QByteArray captureQualityIndexDialogGeometry)

--- a/tools/ld-analyse/configuration.h
+++ b/tools/ld-analyse/configuration.h
@@ -64,8 +64,8 @@ public:
     QByteArray getSnrAnalysisDialogGeometry(void);
     void setClosedCaptionDialogGeometry(QByteArray closedCaptionDialogGeometry);
     QByteArray getClosedCaptionDialogGeometry(void);
-    void setPalChromaDecoderConfigDialogGeometry(QByteArray palChromaDecoderConfigDialogGeometry);
-    QByteArray getPalChromaDecoderConfigDialogGeometry(void);
+    void setChromaDecoderConfigDialogGeometry(QByteArray chromaDecoderConfigDialogGeometry);
+    QByteArray getChromaDecoderConfigDialogGeometry(void);
     void setCaptureQualityIndexDialogGeometry(QByteArray captureQualityIndexDialogGeometry);
     QByteArray getCaptureQualityIndexDialogGeometry(void);
 
@@ -91,7 +91,7 @@ private:
         QByteArray dropoutAnalysisDialogGeometry;
         QByteArray snrAnalysisDialogGeometry;
         QByteArray closedCaptionDialogGeometry;
-        QByteArray palChromaDecoderConfigDialogGeometry;
+        QByteArray chromaDecoderConfigDialogGeometry;
         QByteArray captureQualityIndexDialogGeometry;
     };
 

--- a/tools/ld-analyse/ld-analyse.pro
+++ b/tools/ld-analyse/ld-analyse.pro
@@ -32,7 +32,7 @@ SOURCES += \
     mainwindow.cpp \
     oscilloscopedialog.cpp \
     aboutdialog.cpp \
-    palchromadecoderconfigdialog.cpp \
+    chromadecoderconfigdialog.cpp \
     snranalysisdialog.cpp \
     tbcsource.cpp \
     vbidialog.cpp \
@@ -61,7 +61,7 @@ HEADERS += \
     mainwindow.h \
     oscilloscopedialog.h \
     aboutdialog.h \
-    palchromadecoderconfigdialog.h \
+    chromadecoderconfigdialog.h \
     snranalysisdialog.h \
     tbcsource.h \
     vbidialog.h \
@@ -93,7 +93,7 @@ FORMS += \
     mainwindow.ui \
     oscilloscopedialog.ui \
     aboutdialog.ui \
-    palchromadecoderconfigdialog.ui \
+    chromadecoderconfigdialog.ui \
     snranalysisdialog.ui \
     vbidialog.ui \
     dropoutanalysisdialog.ui

--- a/tools/ld-analyse/mainwindow.cpp
+++ b/tools/ld-analyse/mainwindow.cpp
@@ -159,8 +159,7 @@ void MainWindow::updateGuiLoaded()
     ui->actionCapture_Quality_Index->setEnabled(true);
     ui->actionSave_frame_as_PNG->setEnabled(true);
     ui->actionClosed_Captions->setEnabled(true);
-    if (tbcSource.getIsSourcePal()) ui->actionChroma_decoder_configuration->setEnabled(true);
-    else ui->actionChroma_decoder_configuration->setEnabled(false);
+    ui->actionChroma_decoder_configuration->setEnabled(true);
     ui->actionReload_TBC->setEnabled(true);
 
     // Set option button states
@@ -190,7 +189,7 @@ void MainWindow::updateGuiLoaded()
     sourceVideoStatus.setText(statusText);
 
     // Update the chroma decoder configuration dialogue
-    chromaDecoderConfigDialog->setConfiguration(tbcSource.getPalColourConfiguration());
+    chromaDecoderConfigDialog->setConfiguration(tbcSource.getIsSourcePal(), tbcSource.getPalConfiguration(), tbcSource.getNtscConfiguration());
 
     // Show the current frame
     showFrame();
@@ -817,7 +816,7 @@ void MainWindow::mouseScanLineSelect(qint32 oX, qint32 oY)
 void MainWindow::chromaDecoderConfigChangedSignalHandler()
 {
     // Set the new configuration
-    tbcSource.setPalColourConfiguration(chromaDecoderConfigDialog->getConfiguration());
+    tbcSource.setChromaConfiguration(chromaDecoderConfigDialog->getPalConfiguration(), chromaDecoderConfigDialog->getNtscConfiguration());
 
     // Update the frame viewer;
     updateFrameViewer();

--- a/tools/ld-analyse/mainwindow.cpp
+++ b/tools/ld-analyse/mainwindow.cpp
@@ -39,7 +39,7 @@ MainWindow::MainWindow(QString inputFilenameParam, QWidget *parent) :
     snrAnalysisDialog = new SnrAnalysisDialog(this);
     busyDialog = new BusyDialog(this);
     closedCaptionDialog = new ClosedCaptionsDialog(this);
-    palChromaDecoderConfigDialog = new PalChromaDecoderConfigDialog(this);
+    chromaDecoderConfigDialog = new ChromaDecoderConfigDialog(this);
     captureQualityIndexDialog = new CaptureQualityIndexDialog(this);
 
     // Add a status bar to show the state of the source video file
@@ -56,8 +56,8 @@ MainWindow::MainWindow(QString inputFilenameParam, QWidget *parent) :
     lastScopeLine = 1;
     lastScopeDot = 1;
 
-    // Connect to the PAL decoder configuration changed signal
-    connect(palChromaDecoderConfigDialog, &PalChromaDecoderConfigDialog::palChromaDecoderConfigChanged, this, &MainWindow::palConfigurationChangedSignalHandler);
+    // Connect to the chroma decoder configuration changed signal
+    connect(chromaDecoderConfigDialog, &ChromaDecoderConfigDialog::chromaDecoderConfigChanged, this, &MainWindow::chromaDecoderConfigChangedSignalHandler);
 
     // Connect to the TbcSource signals (busy loading and finished loading)
     connect(&tbcSource, &TbcSource::busyLoading, this, &MainWindow::on_busyLoading);
@@ -71,7 +71,7 @@ MainWindow::MainWindow(QString inputFilenameParam, QWidget *parent) :
     dropoutAnalysisDialog->restoreGeometry(configuration.getDropoutAnalysisDialogGeometry());
     snrAnalysisDialog->restoreGeometry(configuration.getSnrAnalysisDialogGeometry());
     closedCaptionDialog->restoreGeometry(configuration.getClosedCaptionDialogGeometry());
-    palChromaDecoderConfigDialog->restoreGeometry(configuration.getPalChromaDecoderConfigDialogGeometry());
+    chromaDecoderConfigDialog->restoreGeometry(configuration.getChromaDecoderConfigDialogGeometry());
     captureQualityIndexDialog->restoreGeometry(configuration.getCaptureQualityIndexDialogGeometry());
 
     // Store the current button palette for the show dropouts button
@@ -99,7 +99,7 @@ MainWindow::~MainWindow()
     configuration.setDropoutAnalysisDialogGeometry(dropoutAnalysisDialog->saveGeometry());
     configuration.setSnrAnalysisDialogGeometry(snrAnalysisDialog->saveGeometry());
     configuration.setClosedCaptionDialogGeometry(closedCaptionDialog->saveGeometry());
-    configuration.setPalChromaDecoderConfigDialogGeometry(palChromaDecoderConfigDialog->saveGeometry());
+    configuration.setChromaDecoderConfigDialogGeometry(chromaDecoderConfigDialog->saveGeometry());
     configuration.setCaptureQualityIndexDialogGeometry(captureQualityIndexDialog->saveGeometry());
     configuration.writeConfiguration();
 
@@ -159,8 +159,8 @@ void MainWindow::updateGuiLoaded()
     ui->actionCapture_Quality_Index->setEnabled(true);
     ui->actionSave_frame_as_PNG->setEnabled(true);
     ui->actionClosed_Captions->setEnabled(true);
-    if (tbcSource.getIsSourcePal()) ui->actionPAL_Chroma_decoder->setEnabled(true);
-    else ui->actionPAL_Chroma_decoder->setEnabled(false);
+    if (tbcSource.getIsSourcePal()) ui->actionChroma_decoder_configuration->setEnabled(true);
+    else ui->actionChroma_decoder_configuration->setEnabled(false);
     ui->actionReload_TBC->setEnabled(true);
 
     // Set option button states
@@ -189,8 +189,8 @@ void MainWindow::updateGuiLoaded()
     statusText += " sequential frames available";
     sourceVideoStatus.setText(statusText);
 
-    // Update the PAL chroma configuration dialogue
-    palChromaDecoderConfigDialog->setConfiguration(tbcSource.getPalColourConfiguration());
+    // Update the chroma decoder configuration dialogue
+    chromaDecoderConfigDialog->setConfiguration(tbcSource.getPalColourConfiguration());
 
     // Show the current frame
     showFrame();
@@ -241,7 +241,7 @@ void MainWindow::updateGuiUnloaded()
     ui->actionCapture_Quality_Index->setEnabled(false);
     ui->actionSave_frame_as_PNG->setEnabled(false);
     ui->actionClosed_Captions->setEnabled(false);
-    ui->actionPAL_Chroma_decoder->setEnabled(false);
+    ui->actionChroma_decoder_configuration->setEnabled(false);
     ui->actionReload_TBC->setEnabled(false);
 
     // Set option button states
@@ -263,7 +263,7 @@ void MainWindow::updateGuiUnloaded()
     captureQualityIndexDialog->hide();
 
     // Hide configuration dialogues
-    palChromaDecoderConfigDialog->hide();
+    chromaDecoderConfigDialog->hide();
 }
 
 // Frame display methods ----------------------------------------------------------------------------------------------
@@ -533,10 +533,10 @@ void MainWindow::on_actionClosed_Captions_triggered()
     closedCaptionDialog->show();
 }
 
-// Show PAL Chroma-Decoder configuration
-void MainWindow::on_actionPAL_Chroma_decoder_triggered()
+// Show chroma decoder configuration
+void MainWindow::on_actionChroma_decoder_configuration_triggered()
 {
-    palChromaDecoderConfigDialog->show();
+    chromaDecoderConfigDialog->show();
 }
 
 // Media control frame signal handlers --------------------------------------------------------------------------------
@@ -813,11 +813,11 @@ void MainWindow::mouseScanLineSelect(qint32 oX, qint32 oY)
     }
 }
 
-// Handle PAL configuration changed signal from the PAL configuration dialogue
-void MainWindow::palConfigurationChangedSignalHandler()
+// Handle configuration changed signal from the chroma decoder configuration dialogue
+void MainWindow::chromaDecoderConfigChangedSignalHandler()
 {
     // Set the new configuration
-    tbcSource.setPalColourConfiguration(palChromaDecoderConfigDialog->getConfiguration());
+    tbcSource.setPalColourConfiguration(chromaDecoderConfigDialog->getConfiguration());
 
     // Update the frame viewer;
     updateFrameViewer();

--- a/tools/ld-analyse/mainwindow.h
+++ b/tools/ld-analyse/mainwindow.h
@@ -42,7 +42,7 @@
 #include "capturequalityindexdialog.h"
 #include "busydialog.h"
 #include "closedcaptionsdialog.h"
-#include "palchromadecoderconfigdialog.h"
+#include "chromadecoderconfigdialog.h"
 #include "configuration.h"
 #include "tbcsource.h"
 
@@ -76,7 +76,7 @@ private slots:
     void on_actionZoom_2x_triggered();
     void on_actionZoom_3x_triggered();
     void on_actionClosed_Captions_triggered();
-    void on_actionPAL_Chroma_decoder_triggered();
+    void on_actionChroma_decoder_configuration_triggered();
 
     // Media control frame handlers
     void on_previousPushButton_clicked();
@@ -97,7 +97,7 @@ private slots:
     void scanLineChangedSignalHandler(qint32 scanLine, qint32 pictureDot);
     void mousePressEvent(QMouseEvent *event);
     void mouseMoveEvent(QMouseEvent *event);
-    void palConfigurationChangedSignalHandler();
+    void chromaDecoderConfigChangedSignalHandler();
 
     // Tbc Source signal handlers
     void on_busyLoading(QString infoMessage);
@@ -114,7 +114,7 @@ private:
     SnrAnalysisDialog* snrAnalysisDialog;
     BusyDialog* busyDialog;
     ClosedCaptionsDialog *closedCaptionDialog;
-    PalChromaDecoderConfigDialog *palChromaDecoderConfigDialog;
+    ChromaDecoderConfigDialog *chromaDecoderConfigDialog;
     CaptureQualityIndexDialog *captureQualityIndexDialog;
 
     // Class globals

--- a/tools/ld-analyse/mainwindow.ui
+++ b/tools/ld-analyse/mainwindow.ui
@@ -452,7 +452,7 @@
     <addaction name="actionLine_scope"/>
     <addaction name="actionClosed_Captions"/>
     <addaction name="separator"/>
-    <addaction name="actionPAL_Chroma_decoder"/>
+    <addaction name="actionChroma_decoder_configuration"/>
    </widget>
    <widget class="QMenu" name="menuHelp">
     <property name="title">
@@ -606,9 +606,9 @@
     <string>Closed Captions...</string>
    </property>
   </action>
-  <action name="actionPAL_Chroma_decoder">
+  <action name="actionChroma_decoder_configuration">
    <property name="text">
-    <string>PAL Chroma decoder...</string>
+    <string>Chroma decoder configuration...</string>
    </property>
   </action>
   <action name="actionCapture_Quality_Index">

--- a/tools/ld-analyse/palchromadecoderconfigdialog.cpp
+++ b/tools/ld-analyse/palchromadecoderconfigdialog.cpp
@@ -67,8 +67,8 @@ const PalColour::Configuration &PalChromaDecoderConfigDialog::getConfiguration()
 
 void PalChromaDecoderConfigDialog::updateDialog()
 {
-    if (palChromaDecoderConfig.blackAndWhite) ui->blackAndWhiteCheckBox->setChecked(true);
-    else ui->blackAndWhiteCheckBox->setChecked(false);
+    ui->chromaGainHorizontalSlider->setValue(static_cast<qint32>(palChromaDecoderConfig.chromaGain * 100));
+    ui->chromaGainValueLabel->setText(QString::number(palChromaDecoderConfig.chromaGain, 'f', 2));
 
     if (palChromaDecoderConfig.chromaFilter == PalColour::transform2DFilter) {
         ui->twoDeeTransformCheckBox->setChecked(true);
@@ -107,10 +107,10 @@ void PalChromaDecoderConfigDialog::updateDialog()
 
 // Methods to handle changes to the dialogue
 
-void PalChromaDecoderConfigDialog::on_blackAndWhiteCheckBox_clicked()
+void PalChromaDecoderConfigDialog::on_chromaGainHorizontalSlider_valueChanged(int value)
 {
-    if (ui->blackAndWhiteCheckBox->isChecked()) palChromaDecoderConfig.blackAndWhite = true;
-    else palChromaDecoderConfig.blackAndWhite = false;
+    palChromaDecoderConfig.chromaGain = static_cast<double>(value) / 100;
+    ui->chromaGainValueLabel->setText(QString::number(palChromaDecoderConfig.chromaGain, 'f', 2));
     emit palChromaDecoderConfigChanged();
 }
 

--- a/tools/ld-analyse/palchromadecoderconfigdialog.h
+++ b/tools/ld-analyse/palchromadecoderconfigdialog.h
@@ -48,7 +48,7 @@ signals:
     void palChromaDecoderConfigChanged();
 
 private slots:
-    void on_blackAndWhiteCheckBox_clicked();
+    void on_chromaGainHorizontalSlider_valueChanged(int value);
     void on_twoDeeTransformCheckBox_clicked();
     void on_thresholdModeCheckBox_clicked();
     void on_thresholdHorizontalSlider_valueChanged(int value);

--- a/tools/ld-analyse/palchromadecoderconfigdialog.ui
+++ b/tools/ld-analyse/palchromadecoderconfigdialog.ui
@@ -17,9 +17,29 @@
    <item>
     <layout class="QVBoxLayout" name="verticalLayout">
      <item>
-      <widget class="QCheckBox" name="blackAndWhiteCheckBox">
+      <widget class="QLabel" name="label">
        <property name="text">
-        <string>Black and white</string>
+        <string>Chroma gain:</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QSlider" name="chromaGainHorizontalSlider">
+       <property name="maximum">
+        <number>200</number>
+       </property>
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="chromaGainValueLabel">
+       <property name="text">
+        <string>1.0</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignCenter</set>
        </property>
       </widget>
      </item>

--- a/tools/ld-analyse/tbcsource.h
+++ b/tools/ld-analyse/tbcsource.h
@@ -100,8 +100,9 @@ public:
     qint32 getCcData0(qint32 frameNumber);
     qint32 getCcData1(qint32 frameNumber);
 
-    void setPalColourConfiguration(const PalColour::Configuration &palColourConfiguration);
-    const PalColour::Configuration &getPalColourConfiguration();
+    void setChromaConfiguration(const PalColour::Configuration &palConfiguration, const Comb::Configuration &ntscConfiguration);
+    const PalColour::Configuration &getPalConfiguration();
+    const Comb::Configuration &getNtscConfiguration();
 
     qint32 startOfNextChapter(qint32 currentFrameNumber);
     qint32 startOfChapter(qint32 currentFrameNumber);
@@ -151,7 +152,8 @@ private:
     qint32 frameCacheFrameNumber;
 
     // Chroma decoder configuration
-    PalColour::Configuration palColourConfiguration;
+    PalColour::Configuration palConfiguration;
+    Comb::Configuration ntscConfiguration;
     bool decoderConfigurationChanged;
 
     // Chapter map

--- a/tools/ld-analyse/tbcsource.h
+++ b/tools/ld-analyse/tbcsource.h
@@ -150,7 +150,7 @@ private:
     QImage frameCache;
     qint32 frameCacheFrameNumber;
 
-    // PAL chroma-decoder configuration
+    // Chroma decoder configuration
     PalColour::Configuration palColourConfiguration;
     bool decoderConfigurationChanged;
 

--- a/tools/ld-chroma-decoder/comb.cpp
+++ b/tools/ld-chroma-decoder/comb.cpp
@@ -90,11 +90,6 @@ RGBFrame Comb::decodeFrame(const SourceField &firstField, const SourceField &sec
         fieldLine++;
     }
 
-    // Set the frame's burst median (IRE) from the *first* field only.
-    // This is used by yiqToRgbFrame to tweak the colour saturation levels
-    // (compensating for MTF issues)
-    currentFrameBuffer.burstLevel = firstField.field.medianBurstIRE;
-
     // Set the phase IDs for the frame
     currentFrameBuffer.firstFieldPhaseID = firstField.field.fieldPhaseID;
     currentFrameBuffer.secondFieldPhaseID = secondField.field.fieldPhaseID;
@@ -123,7 +118,7 @@ RGBFrame Comb::decodeFrame(const SourceField &firstField, const SourceField &sec
         doCNR(tempYiqBuffer);
 
         // Convert the YIQ result to RGB
-        rgbOutputBuffer = yiqToRgbFrame(tempYiqBuffer, currentFrameBuffer.burstLevel);
+        rgbOutputBuffer = yiqToRgbFrame(tempYiqBuffer);
     } else {
         // 3D comb filter processing
 
@@ -161,7 +156,7 @@ RGBFrame Comb::decodeFrame(const SourceField &firstField, const SourceField &sec
         doCNR(tempYiqBuffer);
 
         // Convert the YIQ result to RGB
-        rgbOutputBuffer = yiqToRgbFrame(tempYiqBuffer, currentFrameBuffer.burstLevel);
+        rgbOutputBuffer = yiqToRgbFrame(tempYiqBuffer);
 
         // Overlay the optical flow map if required
         if (configuration.showOpticalFlowMap) overlayOpticalFlowMap(currentFrameBuffer, rgbOutputBuffer);
@@ -462,7 +457,7 @@ void Comb::doYNR(YiqBuffer &yiqBuffer)
 }
 
 // Convert buffer from YIQ to RGB 16-16-16
-RGBFrame Comb::yiqToRgbFrame(const YiqBuffer &yiqBuffer, qreal burstLevel)
+RGBFrame Comb::yiqToRgbFrame(const YiqBuffer &yiqBuffer)
 {
     RGBFrame rgbOutputFrame;
     rgbOutputFrame.resize(videoParameters.fieldWidth * frameHeight * 3); // for RGB 16-16-16
@@ -471,7 +466,8 @@ RGBFrame Comb::yiqToRgbFrame(const YiqBuffer &yiqBuffer, qreal burstLevel)
     rgbOutputFrame.fill(0);
 
     // Initialise YIQ to RGB converter
-    RGB rgb(videoParameters.white16bIre, videoParameters.black16bIre, configuration.whitePoint100, configuration.blackAndWhite, burstLevel);
+    RGB rgb(videoParameters.white16bIre, videoParameters.black16bIre, configuration.whitePoint100, configuration.blackAndWhite,
+            configuration.chromaGain);
 
     // Perform YIQ to RGB conversion
     for (qint32 lineNumber = videoParameters.firstActiveFrameLine; lineNumber < videoParameters.lastActiveFrameLine; lineNumber++) {

--- a/tools/ld-chroma-decoder/comb.cpp
+++ b/tools/ld-chroma-decoder/comb.cpp
@@ -466,8 +466,7 @@ RGBFrame Comb::yiqToRgbFrame(const YiqBuffer &yiqBuffer)
     rgbOutputFrame.fill(0);
 
     // Initialise YIQ to RGB converter
-    RGB rgb(videoParameters.white16bIre, videoParameters.black16bIre, configuration.whitePoint100, configuration.blackAndWhite,
-            configuration.chromaGain);
+    RGB rgb(videoParameters.white16bIre, videoParameters.black16bIre, configuration.whitePoint100, configuration.chromaGain);
 
     // Perform YIQ to RGB conversion
     for (qint32 lineNumber = videoParameters.firstActiveFrameLine; lineNumber < videoParameters.lastActiveFrameLine; lineNumber++) {

--- a/tools/ld-chroma-decoder/comb.cpp
+++ b/tools/ld-chroma-decoder/comb.cpp
@@ -466,7 +466,7 @@ RGBFrame Comb::yiqToRgbFrame(const YiqBuffer &yiqBuffer)
     rgbOutputFrame.fill(0);
 
     // Initialise YIQ to RGB converter
-    RGB rgb(videoParameters.white16bIre, videoParameters.black16bIre, configuration.whitePoint100, configuration.chromaGain);
+    RGB rgb(videoParameters.white16bIre, videoParameters.black16bIre, configuration.whitePoint75, configuration.chromaGain);
 
     // Perform YIQ to RGB conversion
     for (qint32 lineNumber = videoParameters.firstActiveFrameLine; lineNumber < videoParameters.lastActiveFrameLine; lineNumber++) {

--- a/tools/ld-chroma-decoder/comb.h
+++ b/tools/ld-chroma-decoder/comb.h
@@ -48,6 +48,7 @@ public:
     // Comb filter configuration parameters
     struct Configuration {
         bool blackAndWhite = false;
+        double chromaGain = 1.0;
         bool colorlpf = true;
         bool colorlpf_hq = true;
         bool whitePoint100 = false;
@@ -91,7 +92,6 @@ private:
         QVector<qreal> kValues;
         YiqBuffer yiqBuffer; // YIQ values for the frame
 
-        qreal burstLevel; // The median colour burst amplitude for the frame
         qint32 firstFieldPhaseID; // The phase of the frame's first field
         qint32 secondFieldPhaseID; // The phase of the frame's second field
     };
@@ -115,7 +115,7 @@ private:
     void doCNR(YiqBuffer &yiqBuffer);
     void doYNR(YiqBuffer &yiqBuffer);
 
-    RGBFrame yiqToRgbFrame(const YiqBuffer &yiqBuffer, qreal burstLevel);
+    RGBFrame yiqToRgbFrame(const YiqBuffer &yiqBuffer);
     void overlayOpticalFlowMap(const FrameBuffer &frameBuffer, RGBFrame &rgbOutputFrame);
     void adjustY(FrameBuffer *frameBuffer, YiqBuffer &yiqBuffer);
 };

--- a/tools/ld-chroma-decoder/comb.h
+++ b/tools/ld-chroma-decoder/comb.h
@@ -47,7 +47,6 @@ public:
 
     // Comb filter configuration parameters
     struct Configuration {
-        bool blackAndWhite = false;
         double chromaGain = 1.0;
         bool colorlpf = true;
         bool colorlpf_hq = true;

--- a/tools/ld-chroma-decoder/comb.h
+++ b/tools/ld-chroma-decoder/comb.h
@@ -50,7 +50,7 @@ public:
         double chromaGain = 1.0;
         bool colorlpf = true;
         bool colorlpf_hq = true;
-        bool whitePoint100 = false;
+        bool whitePoint75 = false;
         bool use3D = false;
         bool showOpticalFlowMap = false;
 

--- a/tools/ld-chroma-decoder/main.cpp
+++ b/tools/ld-chroma-decoder/main.cpp
@@ -301,8 +301,8 @@ int main(int argc, char *argv[])
     }
 
     if (parser.isSet(setBwModeOption)) {
-        palConfig.blackAndWhite = true;
-        combConfig.blackAndWhite = true;
+        palConfig.chromaGain = 0.0;
+        combConfig.chromaGain = 0.0;
     }
 
     if (parser.isSet(whitePointOption)) {

--- a/tools/ld-chroma-decoder/main.cpp
+++ b/tools/ld-chroma-decoder/main.cpp
@@ -306,7 +306,7 @@ int main(int argc, char *argv[])
     }
 
     if (parser.isSet(whitePointOption)) {
-        combConfig.whitePoint100 = true;
+        combConfig.whitePoint75 = true;
     }
 
     if (parser.isSet(showOpticalFlowOption)) {

--- a/tools/ld-chroma-decoder/main.cpp
+++ b/tools/ld-chroma-decoder/main.cpp
@@ -146,6 +146,12 @@ int main(int argc, char *argv[])
                                        QCoreApplication::translate("main", "Reverse the field order to second/first (default first/second)"));
     parser.addOption(setReverseOption);
 
+    // Option to specify chroma gain
+    QCommandLineOption chromaGainOption(QStringList() << "chroma-gain",
+                                        QCoreApplication::translate("main", "Gain factor applied to chroma components (default 1.0)"),
+                                        QCoreApplication::translate("main", "number"));
+    parser.addOption(chromaGainOption);
+
     // Option to set the black and white output flag (causes output to be black and white) (-b)
     QCommandLineOption setBwModeOption(QStringList() << "b" << "blackandwhite",
                                        QCoreApplication::translate("main", "Output in black and white"));
@@ -176,12 +182,6 @@ int main(int argc, char *argv[])
     parser.addOption(whitePointOption);
 
     // -- PAL decoder options --
-
-    // Option to specify chroma gain
-    QCommandLineOption chromaGainOption(QStringList() << "chroma-gain",
-                                        QCoreApplication::translate("main", "PAL: Gain factor applied to U/V chroma components (default 0.735)"),
-                                        QCoreApplication::translate("main", "number"));
-    parser.addOption(chromaGainOption);
 
     // Option to use Simple PAL UV filter
     QCommandLineOption simplePALOption(QStringList() << "simple-pal",
@@ -288,6 +288,18 @@ int main(int argc, char *argv[])
         }
     }
 
+    if (parser.isSet(chromaGainOption)) {
+        const double value = parser.value(chromaGainOption).toDouble();
+        palConfig.chromaGain = value;
+        combConfig.chromaGain = value;
+
+        if (value <= 0.0) {
+            // Quit with error
+            qCritical("Chroma gain must be greater than 0");
+            return -1;
+        }
+    }
+
     if (parser.isSet(setBwModeOption)) {
         palConfig.blackAndWhite = true;
         combConfig.blackAndWhite = true;
@@ -311,16 +323,6 @@ int main(int argc, char *argv[])
         } else {
             // Quit with error
             qCritical() << "Unknown Transform mode " << name;
-            return -1;
-        }
-    }
-
-    if (parser.isSet(chromaGainOption)) {
-        palConfig.chromaGain = parser.value(chromaGainOption).toDouble();
-
-        if (palConfig.chromaGain <= 0.0) {
-            // Quit with error
-            qCritical("Chroma gain must be greater than 0");
             return -1;
         }
     }

--- a/tools/ld-chroma-decoder/palcolour.cpp
+++ b/tools/ld-chroma-decoder/palcolour.cpp
@@ -272,16 +272,7 @@ void PalColour::decodeFrames(const QVector<SourceField> &inputFields, qint32 sta
     }
 
     for (qint32 i = startIndex, j = 0, k = 0; i < endIndex; i += 2, j += 2, k++) {
-        // Calculate the chroma gain from the burst median IRE, using the *first*
-        // field's burst amplitude to compensate both fields.
-        // Note: This code works as a temporary MTF compensator whilst ld-decode gets
-        // real MTF compensation added to it.
-        //
-        // The PAL colourburst has peak-to-peak amplitude of 3/7 of the
-        // reference black - reference white range.
-        const double nominalBurstIRE = (3.0 / 7.0) * 100.0 * 0.5;
-        double chromaGain = configuration.chromaGain * nominalBurstIRE / inputFields[i].field.medianBurstIRE;
-
+        double chromaGain = configuration.chromaGain;
         if (configuration.blackAndWhite) {
             chromaGain = 0.0;
         }

--- a/tools/ld-chroma-decoder/palcolour.cpp
+++ b/tools/ld-chroma-decoder/palcolour.cpp
@@ -271,12 +271,8 @@ void PalColour::decodeFrames(const QVector<SourceField> &inputFields, qint32 sta
         outputFrames[i].fill(0);
     }
 
+    const double chromaGain = configuration.chromaGain;
     for (qint32 i = startIndex, j = 0, k = 0; i < endIndex; i += 2, j += 2, k++) {
-        double chromaGain = configuration.chromaGain;
-        if (configuration.blackAndWhite) {
-            chromaGain = 0.0;
-        }
-
         decodeField(inputFields[i], chromaData[j], chromaGain, outputFrames[k]);
         decodeField(inputFields[i + 1], chromaData[j + 1], chromaGain, outputFrames[k]);
     }

--- a/tools/ld-chroma-decoder/palcolour.h
+++ b/tools/ld-chroma-decoder/palcolour.h
@@ -57,8 +57,7 @@ public:
 
     struct Configuration {
         bool blackAndWhite = false;
-        // This value is chosen to compensate for typical LaserDisc characteristics
-        double chromaGain = 0.735;
+        double chromaGain = 1.0;
         bool simplePAL = false;
         ChromaFilterMode chromaFilter = palColourFilter;
         TransformPal::TransformMode transformMode = TransformPal::thresholdMode;

--- a/tools/ld-chroma-decoder/palcolour.h
+++ b/tools/ld-chroma-decoder/palcolour.h
@@ -56,7 +56,6 @@ public:
     };
 
     struct Configuration {
-        bool blackAndWhite = false;
         double chromaGain = 1.0;
         bool simplePAL = false;
         ChromaFilterMode chromaFilter = palColourFilter;

--- a/tools/ld-chroma-decoder/rgb.cpp
+++ b/tools/ld-chroma-decoder/rgb.cpp
@@ -25,9 +25,9 @@
 
 #include "rgb.h"
 
-RGB::RGB(double _whiteIreLevel, double _blackIreLevel, bool _whitePoint75, bool _blackAndWhite, double _chromaGain)
+RGB::RGB(double _whiteIreLevel, double _blackIreLevel, bool _whitePoint75, double _chromaGain)
     : whiteIreLevel(_whiteIreLevel), blackIreLevel(_blackIreLevel), whitePoint75(_whitePoint75),
-      blackAndWhite(_blackAndWhite), chromaGain(_chromaGain)
+      chromaGain(_chromaGain)
 {
 }
 
@@ -42,10 +42,6 @@ void RGB::convertLine(const YIQ *begin, const YIQ *end, quint16 *out)
     // This is the same as for Y, i.e. when 7.5% setup is in use the chroma
     // scale is reduced proportionately.
     const double iqScale = yScale * chromaGain;
-    if (blackAndWhite) {
-        // Remove the colour components
-        iqScale = 0;
-    }
 
     if (whitePoint75) {
         // NTSC uses a 75% white point; so here we scale the result by

--- a/tools/ld-chroma-decoder/rgb.cpp
+++ b/tools/ld-chroma-decoder/rgb.cpp
@@ -63,13 +63,11 @@ void RGB::convertLine(const YIQ *begin, const YIQ *end, quint16 *out)
         i *= iqScale;
         q *= iqScale;
 
-        // YIQ to RGB colour-space conversion (from page 18
-        // of Video Demystified, 5th edition)
-        //
-        // For RGB 0-255: Y 0-255. I 0- +-152. Q 0- +-134 :
-        double r = y + (0.956 * i) + (0.621 * q);
-        double g = y - (0.272 * i) - (0.647 * q);
-        double b = y - (1.107 * i) + (1.704 * q);
+        // Y'IQ to R'G'B' colour-space conversion.
+        // Coefficients from Poynton, "Digital Video and HDTV" first edition, p367 eq 30.3.
+        double r = y + (0.955986 * i) + (0.620825 * q);
+        double g = y - (0.272013 * i) - (0.647204 * q);
+        double b = y - (1.106740 * i) + (1.704230 * q);
 
         r = qBound(0.0, r, 65535.0);
         g = qBound(0.0, g, 65535.0);

--- a/tools/ld-chroma-decoder/rgb.h
+++ b/tools/ld-chroma-decoder/rgb.h
@@ -37,9 +37,8 @@ public:
     // whiteIreLevel: 100 IRE 16-bit level
     // blackIreLevel: 0 or 7.5 IRE 16-bit level
     // whitePoint75: false = using 100% white point, true = 75%
-    // blackAndWhite: true = output in black and white only
     // chromaGain: gain applied to I/Q channels
-    RGB(double whiteIreLevel, double blackIreLevel, bool whitePoint75, bool blackAndWhite, double chromaGain);
+    RGB(double whiteIreLevel, double blackIreLevel, bool whitePoint75, double chromaGain);
 
     void convertLine(const YIQ *begin, const YIQ *end, quint16 *out);
 
@@ -47,7 +46,6 @@ private:
     double whiteIreLevel;
     double blackIreLevel;
     bool whitePoint75;
-    bool blackAndWhite;
     double chromaGain;
 };
 

--- a/tools/ld-chroma-decoder/rgb.h
+++ b/tools/ld-chroma-decoder/rgb.h
@@ -38,8 +38,8 @@ public:
     // blackIreLevel: 0 or 7.5 IRE 16-bit level
     // whitePoint75: false = using 100% white point, true = 75%
     // blackAndWhite: true = output in black and white only
-    // colourBurstMedian: 40 IRE burst amplitude measured by ld-decode
-    RGB(double whiteIreLevel, double blackIreLevel, bool whitePoint75, bool blackAndWhite, double colourBurstMedian);
+    // chromaGain: gain applied to I/Q channels
+    RGB(double whiteIreLevel, double blackIreLevel, bool whitePoint75, bool blackAndWhite, double chromaGain);
 
     void convertLine(const YIQ *begin, const YIQ *end, quint16 *out);
 
@@ -48,7 +48,7 @@ private:
     double blackIreLevel;
     bool whitePoint75;
     bool blackAndWhite;
-    double colourBurstMedian;
+    double chromaGain;
 };
 
 #endif // RGB_H


### PR DESCRIPTION
This is a "request for comments" PR rather than a "merge immediately" PR :-)

At the moment, the NTSC and PAL decoders adjust the gain they apply to the IQ or UV signals based on the `medianBurstIRE` value that ld-decode reports in the JSON. According to the comments, this was intended to act as a makeshift MTF compensator, before ld-decode was able to do that itself.

Now that ld-decode has working MTF compensation, I think this mechanism is probably more trouble than it's worth - the relationship between the burst size and the gain applied depends on a fudge factor (different for PAL/NTSC), and when feeding ld-chroma-decoder with known-correct data you have to provide a synthetic medianBurstIRE value and disable the fudge factor.

This set of changes stops ld-chroma-decoder from looking at `medianBurstIRE` entirely, so the chroma gain is just based on the black/white levels in the TBC (see comments in the first commit).  For troublesome discs, `--chroma-gain` now defaults to 1.0 and works for both PAL and NTSC, and ld-analyse gets a chroma gain slider.

(Somewhat related to #478 in that the current video LPF rolls off a bit more PAL chroma than it should.)