### PR TITLE
setup.py: add matplotlib dep

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,7 @@ setup(
     # see the documentation for the full list of dependencies.
     provides=['lddecode'],
     requires=[
+        'matplotlib',
         'numba',
         'numpy',
         'scipy',


### PR DESCRIPTION
This is used in a bunch of the library code, but didn't make it into the top-level `setup.py` dependencies.