### PR TITLE
Enable 3D decoders in ld-analyse

### DIFF
--- a/tools/ld-analyse/chromadecoderconfigdialog.cpp
+++ b/tools/ld-analyse/chromadecoderconfigdialog.cpp
@@ -4,6 +4,7 @@
 
     ld-analyse - TBC output analysis
     Copyright (C) 2019 Simon Inns
+    Copyright (C) 2020 Adam Sampson
 
     This file is part of ld-decode-tools.
 
@@ -137,7 +138,10 @@ void ChromaDecoderConfigDialog::updateDialog()
     ui->whitePoint75CheckBox->setEnabled(isSourceNtsc);
     ui->whitePoint75CheckBox->setChecked(ntscConfiguration.whitePoint75);
 
-    ui->colorLpfHqCheckBox->setEnabled(isSourceNtsc);
+    ui->colorLpfCheckBox->setEnabled(isSourceNtsc);
+    ui->colorLpfCheckBox->setChecked(ntscConfiguration.colorlpf);
+
+    ui->colorLpfHqCheckBox->setEnabled(isSourceNtsc && ntscConfiguration.colorlpf);
     ui->colorLpfHqCheckBox->setChecked(ntscConfiguration.colorlpf_hq);
 
     ui->cNRLabel->setEnabled(isSourceNtsc);
@@ -213,6 +217,13 @@ void ChromaDecoderConfigDialog::on_simplePALCheckBox_clicked()
 void ChromaDecoderConfigDialog::on_whitePoint75CheckBox_clicked()
 {
     ntscConfiguration.whitePoint75 = ui->whitePoint75CheckBox->isChecked();
+    emit chromaDecoderConfigChanged();
+}
+
+void ChromaDecoderConfigDialog::on_colorLpfCheckBox_clicked()
+{
+    ntscConfiguration.colorlpf = ui->colorLpfCheckBox->isChecked();
+    updateDialog();
     emit chromaDecoderConfigChanged();
 }
 

--- a/tools/ld-analyse/chromadecoderconfigdialog.cpp
+++ b/tools/ld-analyse/chromadecoderconfigdialog.cpp
@@ -161,8 +161,6 @@ void ChromaDecoderConfigDialog::updateDialog()
     ui->yNRValueLabel->setText(QString::number(ntscConfiguration.yNRLevel, 'f', 1) + " IRE");
 }
 
-// XXX Select the right tab when first opened
-
 // Methods to handle changes to the dialogue
 
 void ChromaDecoderConfigDialog::on_chromaGainHorizontalSlider_valueChanged(int value)

--- a/tools/ld-analyse/chromadecoderconfigdialog.h
+++ b/tools/ld-analyse/chromadecoderconfigdialog.h
@@ -59,6 +59,7 @@ private slots:
     void on_simplePALCheckBox_clicked();
 
     void on_whitePoint75CheckBox_clicked();
+    void on_colorLpfCheckBox_clicked();
     void on_colorLpfHqCheckBox_clicked();
     void on_cNRHorizontalSlider_valueChanged(int value);
     void on_yNRHorizontalSlider_valueChanged(int value);

--- a/tools/ld-analyse/chromadecoderconfigdialog.h
+++ b/tools/ld-analyse/chromadecoderconfigdialog.h
@@ -25,6 +25,7 @@
 #ifndef CHROMADECODERCONFIGDIALOG_H
 #define CHROMADECODERCONFIGDIALOG_H
 
+#include <QAbstractButton>
 #include <QDialog>
 
 #include "comb.h"
@@ -52,12 +53,13 @@ signals:
 private slots:
     void on_chromaGainHorizontalSlider_valueChanged(int value);
 
-    void on_twoDeeTransformCheckBox_clicked();
+    void on_palFilterButtonGroup_buttonClicked(QAbstractButton *button);
     void on_thresholdModeCheckBox_clicked();
     void on_thresholdHorizontalSlider_valueChanged(int value);
     void on_showFFTsCheckBox_clicked();
     void on_simplePALCheckBox_clicked();
 
+    void on_ntscFilterButtonGroup_buttonClicked(QAbstractButton *button);
     void on_whitePoint75CheckBox_clicked();
     void on_colorLpfCheckBox_clicked();
     void on_colorLpfHqCheckBox_clicked();

--- a/tools/ld-analyse/chromadecoderconfigdialog.ui
+++ b/tools/ld-analyse/chromadecoderconfigdialog.ui
@@ -173,6 +173,13 @@
         </widget>
        </item>
        <item>
+        <widget class="QCheckBox" name="colorLpfCheckBox">
+         <property name="text">
+          <string>Use chroma post-filter</string>
+         </property>
+        </widget>
+       </item>
+       <item>
         <widget class="QCheckBox" name="colorLpfHqCheckBox">
          <property name="text">
           <string>Use full bandwidth Q channel filter</string>

--- a/tools/ld-analyse/chromadecoderconfigdialog.ui
+++ b/tools/ld-analyse/chromadecoderconfigdialog.ui
@@ -42,22 +42,9 @@
     </widget>
    </item>
    <item>
-    <spacer name="verticalSpacer_1">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>20</width>
-       <height>40</height>
-      </size>
-     </property>
-    </spacer>
-   </item>
-   <item>
     <widget class="QTabWidget" name="standardTabs">
      <property name="currentIndex">
-      <number>1</number>
+      <number>0</number>
      </property>
      <widget class="QWidget" name="palTab">
       <attribute name="title">
@@ -65,11 +52,54 @@
       </attribute>
       <layout class="QVBoxLayout" name="palVerticalLayout">
        <item>
-        <widget class="QCheckBox" name="twoDeeTransformCheckBox">
+        <widget class="QLabel" name="palFilterLabel">
          <property name="text">
-          <string>Use Transform PAL 2D filter</string>
+          <string>Chroma filter:</string>
          </property>
         </widget>
+       </item>
+       <item>
+        <widget class="QRadioButton" name="palFilterPalColourRadioButton">
+         <property name="text">
+          <string>PalColour 2D</string>
+         </property>
+         <attribute name="buttonGroup">
+          <string notr="true">palFilterButtonGroup</string>
+         </attribute>
+        </widget>
+       </item>
+       <item>
+        <widget class="QRadioButton" name="palFilterTransform2DRadioButton">
+         <property name="text">
+          <string>Transform PAL 2D</string>
+         </property>
+         <attribute name="buttonGroup">
+          <string notr="true">palFilterButtonGroup</string>
+         </attribute>
+        </widget>
+       </item>
+       <item>
+        <widget class="QRadioButton" name="palFilterTransform3DRadioButton">
+         <property name="text">
+          <string>Transform PAL 3D</string>
+         </property>
+         <attribute name="buttonGroup">
+          <string notr="true">palFilterButtonGroup</string>
+         </attribute>
+        </widget>
+       </item>
+       <item>
+        <spacer name="verticalSpacer_7">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>40</height>
+          </size>
+         </property>
+        </spacer>
        </item>
        <item>
         <widget class="QCheckBox" name="thresholdModeCheckBox">
@@ -165,6 +195,46 @@
        <string>NTSC</string>
       </attribute>
       <layout class="QVBoxLayout" name="ntscVerticalLayout">
+       <item>
+        <widget class="QLabel" name="ntscFilterLabel">
+         <property name="text">
+          <string>Chroma filter:</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QRadioButton" name="ntscFilter2DRadioButton">
+         <property name="text">
+          <string>2D</string>
+         </property>
+         <attribute name="buttonGroup">
+          <string notr="true">ntscFilterButtonGroup</string>
+         </attribute>
+        </widget>
+       </item>
+       <item>
+        <widget class="QRadioButton" name="ntscFilter3DRadioButton">
+         <property name="text">
+          <string>3D</string>
+         </property>
+         <attribute name="buttonGroup">
+          <string notr="true">ntscFilterButtonGroup</string>
+         </attribute>
+        </widget>
+       </item>
+       <item>
+        <spacer name="verticalSpacer_9">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>40</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
        <item>
         <widget class="QCheckBox" name="whitePoint75CheckBox">
          <property name="text">
@@ -277,8 +347,25 @@
      </widget>
     </widget>
    </item>
+   <item>
+    <spacer name="verticalSpacer_1">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
   </layout>
  </widget>
  <resources/>
  <connections/>
+ <buttongroups>
+  <buttongroup name="ntscFilterButtonGroup"/>
+  <buttongroup name="palFilterButtonGroup"/>
+ </buttongroups>
 </ui>

--- a/tools/ld-analyse/tbcsource.h
+++ b/tools/ld-analyse/tbcsource.h
@@ -159,7 +159,7 @@ private:
     // Chapter map
     QVector<qint32> chapterMap;
 
-    QImage generateQImage(qint32 firstFieldNumber, qint32 secondFieldNumber);
+    QImage generateQImage(qint32 frameNumber);
     void generateData(qint32 _targetDataPoints);
     void startBackgroundLoad(QString sourceFilename);
 };

--- a/tools/ld-chroma-decoder/comb.cpp
+++ b/tools/ld-chroma-decoder/comb.cpp
@@ -5,6 +5,7 @@
     ld-chroma-decoder - Colourisation filter for ld-decode
     Copyright (C) 2018 Chad Page
     Copyright (C) 2018-2019 Simon Inns
+    Copyright (C) 2020 Adam Sampson
 
     This file is part of ld-decode-tools.
 
@@ -32,6 +33,19 @@
 Comb::Comb()
     : configurationSet(false)
 {
+}
+
+qint32 Comb::Configuration::getLookBehind() const {
+    if (use3D) {
+        // In 3D mode, we need to see the previous frame
+        return 1;
+    }
+
+    return 0;
+}
+
+qint32 Comb::Configuration::getLookAhead() const {
+    return 0;
 }
 
 // Return the current configuration

--- a/tools/ld-chroma-decoder/comb.cpp
+++ b/tools/ld-chroma-decoder/comb.cpp
@@ -391,7 +391,7 @@ void Comb::filterIQ(YiqBuffer &yiqBuffer)
         iFilter.clear();
         qFilter.clear();
 
-        qint32 qoffset = 2; // f_colorlpf_hq ? f_colorlpi_offset : f_colorlpq_offset;
+        qint32 qoffset = configuration.colorlpf_hq ? f_colorlpi_offset : f_colorlpq_offset;
 
         qreal filti = 0, filtq = 0;
 

--- a/tools/ld-chroma-decoder/comb.cpp
+++ b/tools/ld-chroma-decoder/comb.cpp
@@ -125,13 +125,13 @@ RGBFrame Comb::decodeFrame(const SourceField &firstField, const SourceField &sec
         adjustY(&currentFrameBuffer, tempYiqBuffer);
 
         // Post-filter I/Q
-        if (configuration.colorlpf) filterIQ(currentFrameBuffer.yiqBuffer);
+        if (configuration.colorlpf) filterIQ(tempYiqBuffer);
 
         // Apply noise reduction
         doYNR(tempYiqBuffer);
         doCNR(tempYiqBuffer);
 
-        opticalFlow.denseOpticalFlow(currentFrameBuffer.yiqBuffer, currentFrameBuffer.kValues);
+        opticalFlow.denseOpticalFlow(tempYiqBuffer, currentFrameBuffer.kValues);
 #endif
 
         // Extract chroma using 3D filter
@@ -152,7 +152,7 @@ RGBFrame Comb::decodeFrame(const SourceField &firstField, const SourceField &sec
     adjustY(&currentFrameBuffer, tempYiqBuffer);
 
     // Post-filter I/Q
-    if (configuration.colorlpf) filterIQ(currentFrameBuffer.yiqBuffer);
+    if (configuration.colorlpf) filterIQ(tempYiqBuffer);
 
     // Apply noise reduction
     doYNR(tempYiqBuffer);

--- a/tools/ld-chroma-decoder/comb.h
+++ b/tools/ld-chroma-decoder/comb.h
@@ -65,8 +65,9 @@ public:
     void updateConfiguration(const LdDecodeMetaData::VideoParameters &videoParameters,
                              const Configuration &configuration);
 
-    // Decode two fields to produce an interlaced frame.
-    RGBFrame decodeFrame(const SourceField &firstField, const SourceField &secondField);
+    // Decode a sequence of fields into a sequence of interlaced frames
+    void decodeFrames(const QVector<SourceField> &inputFields, qint32 startIndex, qint32 endIndex,
+                      QVector<RGBFrame> &outputFrames);
 
 protected:
 
@@ -97,9 +98,6 @@ private:
         qint32 firstFieldPhaseID; // The phase of the frame's first field
         qint32 secondFieldPhaseID; // The phase of the frame's second field
     };
-
-    // Previous and next frame for 3D processing
-    FrameBuffer previousFrameBuffer;
 
     inline qint32 GetFieldID(FrameBuffer *frameBuffer, qint32 lineNumber);
     inline bool GetLinePhase(FrameBuffer *frameBuffer, qint32 lineNumber);

--- a/tools/ld-chroma-decoder/comb.h
+++ b/tools/ld-chroma-decoder/comb.h
@@ -47,7 +47,7 @@ public:
     // Comb filter configuration parameters
     struct Configuration {
         double chromaGain = 1.0;
-        bool colorlpf = true;
+        bool colorlpf = false;
         bool colorlpf_hq = true;
         bool whitePoint75 = false;
         bool use3D = false;

--- a/tools/ld-chroma-decoder/comb.h
+++ b/tools/ld-chroma-decoder/comb.h
@@ -5,6 +5,7 @@
     ld-chroma-decoder - Colourisation filter for ld-decode
     Copyright (C) 2018 Chad Page
     Copyright (C) 2018-2019 Simon Inns
+    Copyright (C) 2020 Adam Sampson
 
     This file is part of ld-decode-tools.
 
@@ -55,6 +56,9 @@ public:
 
         qreal cNRLevel = 0.0;
         qreal yNRLevel = 1.0;
+
+        qint32 getLookBehind() const;
+        qint32 getLookAhead() const;
     };
 
     const Configuration &getConfiguration() const;

--- a/tools/ld-chroma-decoder/ntscdecoder.cpp
+++ b/tools/ld-chroma-decoder/ntscdecoder.cpp
@@ -48,12 +48,12 @@ bool NtscDecoder::configure(const LdDecodeMetaData::VideoParameters &videoParame
 
 qint32 NtscDecoder::getLookBehind() const
 {
-    if (config.combConfig.use3D) {
-        // In 3D mode, we need to see the previous frame
-        return 1;
-    }
+    return config.combConfig.getLookBehind();
+}
 
-    return 0;
+qint32 NtscDecoder::getLookAhead() const
+{
+    return config.combConfig.getLookAhead();
 }
 
 QThread *NtscDecoder::makeThread(QAtomicInt& abort, DecoderPool& decoderPool)

--- a/tools/ld-chroma-decoder/ntscdecoder.cpp
+++ b/tools/ld-chroma-decoder/ntscdecoder.cpp
@@ -5,7 +5,7 @@
     ld-chroma-decoder - Colourisation filter for ld-decode
     Copyright (C) 2018 Chad Page
     Copyright (C) 2018-2019 Simon Inns
-    Copyright (C) 2019 Adam Sampson
+    Copyright (C) 2019-2020 Adam Sampson
 
     This file is part of ld-decode-tools.
 
@@ -72,17 +72,13 @@ NtscThread::NtscThread(QAtomicInt& _abort, DecoderPool &_decoderPool,
 void NtscThread::decodeFrames(const QVector<SourceField> &inputFields, qint32 startIndex, qint32 endIndex,
                               QVector<RGBFrame> &outputFrames)
 {
-    // Decode lookahead fields, discarding the result
-    for (qint32 i = 0; i < startIndex; i += 2) {
-        comb.decodeFrame(inputFields[i], inputFields[i + 1]);
-    }
+    QVector<RGBFrame> decodedFrames(outputFrames.size());
 
-    // Decode real fields to frames
-    for (qint32 i = startIndex, j = 0; i < endIndex; i += 2, j++) {
-        // Filter the frame
-        RGBFrame outputData = comb.decodeFrame(inputFields[i], inputFields[i + 1]);
+    // Decode fields to frames
+    comb.decodeFrames(inputFields, startIndex, endIndex, decodedFrames);
 
-        // The NTSC filter outputs the whole frame, so here we crop it to the required dimensions
-        outputFrames[j] = NtscDecoder::cropOutputFrame(config, outputData);
+    for (qint32 i = 0; i < outputFrames.size(); i++) {
+        // Crop the frame to just the active area
+        outputFrames[i] = NtscDecoder::cropOutputFrame(config, decodedFrames[i]);
     }
 }

--- a/tools/ld-chroma-decoder/ntscdecoder.h
+++ b/tools/ld-chroma-decoder/ntscdecoder.h
@@ -5,7 +5,7 @@
     ld-chroma-decoder - Colourisation filter for ld-decode
     Copyright (C) 2018 Chad Page
     Copyright (C) 2018-2019 Simon Inns
-    Copyright (C) 2019 Adam Sampson
+    Copyright (C) 2019-2020 Adam Sampson
 
     This file is part of ld-decode-tools.
 
@@ -47,6 +47,7 @@ public:
     NtscDecoder(const Comb::Configuration &combConfig);
     bool configure(const LdDecodeMetaData::VideoParameters &videoParameters) override;
     qint32 getLookBehind() const override;
+    qint32 getLookAhead() const override;
     QThread *makeThread(QAtomicInt& abort, DecoderPool& decoderPool) override;
 
     // Parameters used by NtscDecoder and NtscThread

--- a/tools/ld-chroma-decoder/palcolour.cpp
+++ b/tools/ld-chroma-decoder/palcolour.cpp
@@ -242,16 +242,6 @@ void PalColour::buildLookUpTables()
     }
 }
 
-RGBFrame PalColour::decodeFrame(const SourceField &firstField, const SourceField &secondField)
-{
-    QVector<SourceField> inputFields {firstField, secondField};
-    QVector<RGBFrame> outputFrames(1);
-
-    decodeFrames(inputFields, 0, 2, outputFrames);
-
-    return outputFrames[0];
-}
-
 void PalColour::decodeFrames(const QVector<SourceField> &inputFields, qint32 startIndex, qint32 endIndex,
                              QVector<RGBFrame> &outputFrames)
 {

--- a/tools/ld-chroma-decoder/palcolour.h
+++ b/tools/ld-chroma-decoder/palcolour.h
@@ -75,9 +75,6 @@ public:
     void updateConfiguration(const LdDecodeMetaData::VideoParameters &videoParameters,
                              const Configuration &configuration);
 
-    // Decode two fields to produce an interlaced frame.
-    RGBFrame decodeFrame(const SourceField &firstField, const SourceField &secondField);
-
     // Decode a sequence of fields into a sequence of interlaced frames
     void decodeFrames(const QVector<SourceField> &inputFields, qint32 startIndex, qint32 endIndex,
                       QVector<RGBFrame> &outputFrames);


### PR DESCRIPTION
~~This is on top of the changes in #512, so don't merge until that one's been approved - it may need a rebase.~~

The main thing here is reworking `Comb` so that it provides the same `decodeFrames` interface for 3D decoding as `PalColour`, then making ld-analyse use it. Because `Comb` now has access to the complete batch of fields being decoded it should make future NTSC 3D work a bit easier too.

There are now radio buttons in the chroma decoder dialog that allow you to select 3D decoding for NTSC and PAL. I've left the defaults as 2D, because NTSC 3D isn't generally useful and Transform PAL 3D is a bit slow for interactive use.

This also includes a fix for the `Comb::filterIQ` problem in #513, and adds a checkbox for `colorLpf` so you can experiment with it.