### PR TITLE
Issue 546

### DIFF
--- a/tools/ld-discmap/discmapper.cpp
+++ b/tools/ld-discmap/discmapper.cpp
@@ -570,13 +570,19 @@ bool DiscMapper::saveDiscMap(DiscMap &discMap)
 
     if (!noAudio) {
         // Open the input audio file
-        sourceAudio.open(inputFileInfo);
+        if (!sourceAudio.open(inputFileInfo)) {
+            // Could not open input audio file
+            qInfo() << "Cannot open source audio file:" << inputFileInfo.absolutePath() + "/" + inputFileInfo.baseName() + ".pcm";
+            sourceVideo.close();
+            sourceAudio.close();
+            return false;
+        }
 
         // Open the output audio file
-        targetAudio.setFileName(outputFileInfo.absolutePath() + outputFileInfo.baseName() + ".pcm");
+        targetAudio.setFileName(outputFileInfo.absolutePath() + "/" + outputFileInfo.baseName() + ".pcm");
         if (!targetAudio.open(QIODevice::WriteOnly)) {
             // Could not open target audio file
-            qInfo() << "Cannot open target audi file:" << outputFileInfo.absolutePath() + outputFileInfo.baseName() + ".pcm";
+            qInfo() << "Cannot open target audio file:" << outputFileInfo.absolutePath() + "/" + outputFileInfo.baseName() + ".pcm";
             sourceVideo.close();
             sourceAudio.close();
             return false;
@@ -683,7 +689,7 @@ bool DiscMapper::saveDiscMap(DiscMap &discMap)
         // Was the write successful?
         if (writeFail) {
             // Could not write to target TBC file
-            qInfo() << "Writing fields to the target TBC file failed on frame number" << frameNumber;
+            qWarning() << "Writing fields to the target TBC file failed on frame number" << frameNumber;
             targetVideo.close();
             sourceVideo.close();
             return false;

--- a/tools/ld-discmap/discmapper.cpp
+++ b/tools/ld-discmap/discmapper.cpp
@@ -600,13 +600,15 @@ bool DiscMapper::saveDiscMap(DiscMap &discMap)
         // 44,100 samples per second
         // 50 fields per second
         // 44,100 / 50 = 882 * 2 = 1764
-        missingFieldAudioData.fill(0, 1764);
+        // L/R channels = 1764 * 2 =
+        missingFieldAudioData.fill(0, 3528);
     } else {
         // Disc is NTSC:
         // 44,100 samples per second
         // 60000/1001 fields per second
         // 44100 / (60000/1001) = 735.735 * 2 = 1472
-        missingFieldAudioData.fill(0, 1472);
+        // L/R channels = 1472 * 2 =
+        missingFieldAudioData.fill(0, 2944);
     }
 
     // Create the output video file

--- a/tools/ld-discmap/discmapper.cpp
+++ b/tools/ld-discmap/discmapper.cpp
@@ -583,12 +583,25 @@ bool DiscMapper::saveDiscMap(DiscMap &discMap)
         }
     }
 
-    // Make a dummy video and audio field to use when outputting padded frames
+    // Make a dummy video field to use when outputting padded frames
     SourceVideo::Data missingFieldData;
     missingFieldData.fill(0, discMap.getFieldLength());
 
+    // Make a dummy audio field to use when outputting padded frames
     QVector<qint16> missingFieldAudioData;
-    missingFieldAudioData.fill(0, 100); // TODO - WHAT SIZE IS THIS ?!?!
+    if (discMap.isDiscPal()) {
+        // Disc is PAL:
+        // 44,100 samples per second
+        // 50 fields per second
+        // 44,100 / 50 = 882 * 2 = 1764
+        missingFieldAudioData.fill(0, 1764);
+    } else {
+        // Disc is NTSC:
+        // 44,100 samples per second
+        // 60000/1001 fields per second
+        // 44100 / (60000/1001) = 735.735 * 2 = 1472
+        missingFieldAudioData.fill(0, 1472);
+    }
 
     // Create the output video file
     SourceVideo::Data sourceFirstField;

--- a/tools/ld-discmap/discmapper.h
+++ b/tools/ld-discmap/discmapper.h
@@ -35,6 +35,7 @@
 #include "lddecodemetadata.h"
 
 #include "discmap.h"
+#include "sourceaudio.h"
 
 class DiscMapper
 {
@@ -43,7 +44,7 @@ public:
 
     bool process(QFileInfo _inputFileInfo, QFileInfo _inputMetadataFileInfo,
                  QFileInfo _outputFileInfo, bool _reverse, bool _mapOnly, bool _noStrict,
-                 bool _deleteUnmappable);
+                 bool _deleteUnmappable, bool _noAudio);
 
 private:
     QFileInfo inputFileInfo;
@@ -53,6 +54,7 @@ private:
     bool mapOnly;
     bool noStrict;
     bool deleteUnmappable;
+    bool noAudio;
 
     void removeLeadInOut(DiscMap &discMap);
     void correctVbiFrameNumbersUsingSequenceAnalysis(DiscMap &discMap);

--- a/tools/ld-discmap/ld-discmap.pro
+++ b/tools/ld-discmap/ld-discmap.pro
@@ -23,7 +23,8 @@ SOURCES += \
     discmap.cpp \
     discmapper.cpp \
     frame.cpp \
-    main.cpp
+    main.cpp \
+    sourceaudio.cpp
 
 HEADERS += \
     ../library/tbc/lddecodemetadata.h \
@@ -33,7 +34,8 @@ HEADERS += \
     ../library/tbc/dropouts.h \
     discmap.h \
     discmapper.h \
-    frame.h
+    frame.h \
+    sourceaudio.h
 
 # Add external includes to the include path
 INCLUDEPATH += ../library/tbc

--- a/tools/ld-discmap/main.cpp
+++ b/tools/ld-discmap/main.cpp
@@ -77,6 +77,11 @@ int main(int argc, char *argv[])
                                        QCoreApplication::translate("main", "Delete unmappable frames"));
     parser.addOption(setDeleteUnmappableOption);
 
+    // Option to not process analogue audio (-n / --no-audio)
+    QCommandLineOption setNoAudioOption(QStringList() << "n" << "no-audio",
+                                       QCoreApplication::translate("main", "Do not process analogue audio"));
+    parser.addOption(setNoAudioOption);
+
     // Positional argument to specify input TBC file
     parser.addPositionalArgument("input", QCoreApplication::translate("main", "Specify input TBC file"));
 
@@ -94,6 +99,7 @@ int main(int argc, char *argv[])
     bool mapOnly = parser.isSet(setMapOnlyOption);
     bool noStrict = parser.isSet(setNoStrictOption);
     bool deleteUnmappable = parser.isSet(setDeleteUnmappableOption);
+    bool noAudio = parser.isSet(setNoAudioOption);
 
     // Process the command line options
     QString inputFilename;
@@ -154,7 +160,8 @@ int main(int argc, char *argv[])
 
     // Perform disc mapping
     DiscMapper discMapper;
-    if (!discMapper.process(inputFileInfo, inputMetadataFileInfo, outputFileInfo, reverse, mapOnly, noStrict, deleteUnmappable)) return 1;
+    if (!discMapper.process(inputFileInfo, inputMetadataFileInfo, outputFileInfo, reverse,
+                            mapOnly, noStrict, deleteUnmappable, noAudio)) return 1;
 
     // Quit with success
     return 0;

--- a/tools/ld-discmap/sourceaudio.cpp
+++ b/tools/ld-discmap/sourceaudio.cpp
@@ -88,7 +88,7 @@ QVector<qint16> SourceAudio::getAudioForField(qint32 fieldNo)
         qFatal("Application requested an audio field number that exceeds the available number of fields");
         return audioData;
     }
-    qint64 maxPosition = (startPosition[fieldNo] + fieldLength[fieldNo]) * 2; // 16-bit word to byte
+    qint64 maxPosition = (startPosition[fieldNo] + fieldLength[fieldNo]) * 4; // 16-bit word * stereo - to byte
     if (maxPosition > inputAudioFile.bytesAvailable()) {
         qFatal("Application requested audio field number that exceeds the boundaries of the input PCM audio file");
         return audioData;
@@ -98,7 +98,7 @@ QVector<qint16> SourceAudio::getAudioForField(qint32 fieldNo)
     audioData.resize(fieldLength[fieldNo]);
 
     // Seek to the correct file position (if not already there)
-    if (!inputAudioFile.seek(startPosition[fieldNo] * 2)) {
+    if (!inputAudioFile.seek(startPosition[fieldNo] * 4)) {
         // Seek failed
         qFatal("Could not seek to field position in input audio file!");
         return audioData;
@@ -109,12 +109,12 @@ QVector<qint16> SourceAudio::getAudioForField(qint32 fieldNo)
     qint64 receivedBytes = 0;
     do {
         receivedBytes = inputAudioFile.read(reinterpret_cast<char *>(audioData.data()) + totalReceivedBytes,
-                                       ((fieldLength[fieldNo]) * 2) - totalReceivedBytes);
+                                       ((fieldLength[fieldNo]) * 4) - totalReceivedBytes);
         totalReceivedBytes += receivedBytes;
-    } while (receivedBytes > 0 && totalReceivedBytes < ((fieldLength[fieldNo]) * 2));
+    } while (receivedBytes > 0 && totalReceivedBytes < ((fieldLength[fieldNo]) * 4));
 
     // Verify read was ok
-    if (totalReceivedBytes != ((fieldLength[fieldNo]) * 2)) {
+    if (totalReceivedBytes != ((fieldLength[fieldNo]) * 4)) {
         qFatal("Could not get enough input bytes from input audio file");
         return audioData;
     }

--- a/tools/ld-discmap/sourceaudio.cpp
+++ b/tools/ld-discmap/sourceaudio.cpp
@@ -1,0 +1,123 @@
+/************************************************************************
+
+    sourceaudio.cpp
+
+    ld-discmap - TBC and VBI alignment and correction
+    Copyright (C) 2019-2020 Simon Inns
+
+    This file is part of ld-decode-tools.
+
+    ld-discmap is free software: you can redistribute it and/or
+    modify it under the terms of the GNU General Public License as
+    published by the Free Software Foundation, either version 3 of the
+    License, or (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+************************************************************************/
+
+#include "sourceaudio.h"
+
+SourceAudio::SourceAudio()
+{
+
+}
+
+// Open an audio source file
+bool SourceAudio::open(QFileInfo inputFileInfo)
+{
+    // Get the input audio fileinfo from the input TBC fileinfo:
+    QFileInfo inputAudioFileInfo(inputFileInfo.absolutePath() + inputFileInfo.baseName() + ".pcm");
+
+    // Open the metadata for the input TBC file
+    QFileInfo inputMetadataFileInfo(inputFileInfo.filePath() + ".json");
+    ldDecodeMetaData->read(inputMetadataFileInfo.filePath());
+
+    // Open the TBC metadata file
+    if (!ldDecodeMetaData->read(inputMetadataFileInfo.filePath())) {
+        // Open failed
+        qDebug() << "Cannot load JSON metadata from" << inputMetadataFileInfo.filePath();
+        return false;
+    }
+
+    // Open the audio source data file
+    if (!inputAudioFile.open(QIODevice::ReadOnly)) {
+        // Failed to open named input file
+        qWarning() << "Could not open " << inputAudioFileInfo.filePath() << "as source audio input file";
+        return false;
+    }
+
+    // Read the metadata and create an index to the field audio (position and length)
+    qint32 numberOfFields = ldDecodeMetaData->getVideoParameters().numberOfSequentialFields;
+    startPosition.resize(numberOfFields);
+    fieldLength.resize(numberOfFields);
+
+    for (qint32 fieldNo = 0; fieldNo < numberOfFields; fieldNo++) {
+        fieldLength[fieldNo] = static_cast<qint64>(ldDecodeMetaData->getField(fieldNo + 1).audioSamples);
+        if (fieldNo > 0) startPosition[fieldNo] = startPosition[fieldNo - 1] + fieldLength[fieldNo];
+        else startPosition[fieldNo] = 0;
+    }
+
+    return true;
+}
+
+// Close an audio source file
+void SourceAudio::close()
+{
+    // Clear the indexes
+    startPosition.clear();
+    fieldLength.clear();
+
+    // Close the audio source data file
+    inputAudioFile.close();
+}
+
+// Get audio data for a single field from the audio source file
+QVector<qint16> SourceAudio::getAudioForField(qint32 fieldNo)
+{
+    QVector<qint16> audioData;
+
+    // Check the requested field number is value
+    if (fieldNo > ldDecodeMetaData->getVideoParameters().numberOfSequentialFields) {
+        qFatal("Application requested an audio field number that exceeds the available number of fields");
+        return audioData;
+    }
+    qint64 maxPosition = (startPosition[fieldNo] + fieldLength[fieldNo]) * 2; // 16-bit word to byte
+    if (maxPosition > inputAudioFile.bytesAvailable()) {
+        qFatal("Application requested audio field number that exceeds the boundaries of the input PCM audio file");
+        return audioData;
+    }
+
+    // Resize the audio buffer
+    audioData.resize(fieldLength[fieldNo]);
+
+    // Seek to the correct file position (if not already there)
+    if (!inputAudioFile.seek(startPosition[fieldNo] * 2)) {
+        // Seek failed
+        qFatal("Could not seek to field position in input audio file!");
+        return audioData;
+    }
+
+    // Read the audio data from the audio input file
+    qint64 totalReceivedBytes = 0;
+    qint64 receivedBytes = 0;
+    do {
+        receivedBytes = inputAudioFile.read(reinterpret_cast<char *>(audioData.data()) + totalReceivedBytes,
+                                       ((fieldLength[fieldNo]) * 2) - totalReceivedBytes);
+        totalReceivedBytes += receivedBytes;
+    } while (receivedBytes > 0 && totalReceivedBytes < ((fieldLength[fieldNo]) * 2));
+
+    // Verify read was ok
+    if (totalReceivedBytes != ((fieldLength[fieldNo]) * 2)) {
+        qFatal("Could not get enough input bytes from input audio file");
+        return audioData;
+    }
+
+    return audioData;
+}

--- a/tools/ld-discmap/sourceaudio.cpp
+++ b/tools/ld-discmap/sourceaudio.cpp
@@ -142,6 +142,5 @@ QByteArray SourceAudio::getAudioForField(qint32 fieldNo)
         return audioData;
     }
 
-    qDebug() << "Got audio for field" << fieldNo << "with byte length" << fieldByteLength[fieldNo] << "(" << audioData.size() << ")";
     return audioData;
 }

--- a/tools/ld-discmap/sourceaudio.h
+++ b/tools/ld-discmap/sourceaudio.h
@@ -40,14 +40,15 @@ public:
 
     bool open(QFileInfo inputFileInfo);
     void close();
-    QVector<qint16> getAudioForField(qint32 fieldNo);
+    QByteArray getAudioForField(qint32 fieldNo);
 
 private:
     LdDecodeMetaData *ldDecodeMetaData;
     QFile inputAudioFile;
 
-    QVector<qint64> startPosition;
-    QVector<qint64> fieldLength;
+    QVector<qint64> startBytePosition;
+    QVector<qint64> fieldByteLength;
+    qint64 totalByteSize;
 };
 
 #endif // SOURCEAUDIO_H

--- a/tools/ld-discmap/sourceaudio.h
+++ b/tools/ld-discmap/sourceaudio.h
@@ -1,0 +1,53 @@
+/************************************************************************
+
+    sourceaudio.cpp
+
+    ld-discmap - TBC and VBI alignment and correction
+    Copyright (C) 2019-2020 Simon Inns
+
+    This file is part of ld-decode-tools.
+
+    ld-discmap is free software: you can redistribute it and/or
+    modify it under the terms of the GNU General Public License as
+    published by the Free Software Foundation, either version 3 of the
+    License, or (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+************************************************************************/
+
+#ifndef SOURCEAUDIO_H
+#define SOURCEAUDIO_H
+
+#include <QCoreApplication>
+#include <QDebug>
+#include <QFileInfo>
+#include <QFile>
+
+// TBC library includes
+#include "lddecodemetadata.h"
+
+class SourceAudio
+{
+public:
+    SourceAudio();
+
+    bool open(QFileInfo inputFileInfo);
+    void close();
+    QVector<qint16> getAudioForField(qint32 fieldNo);
+
+private:
+    LdDecodeMetaData *ldDecodeMetaData;
+    QFile inputAudioFile;
+
+    QVector<qint64> startPosition;
+    QVector<qint64> fieldLength;
+};
+
+#endif // SOURCEAUDIO_H


### PR DESCRIPTION
Fix for issue #546 - ld-discmap will now process analogue audio and output a .pcm file that matches the alignment and padding of the mapped TBC