### PR TITLE
Issue palphase

### DIFF
--- a/tools/ld-discmap/discmap.h
+++ b/tools/ld-discmap/discmap.h
@@ -64,6 +64,7 @@ public:
     bool isPadded(qint32 frameNumber) const;
     bool isClvOffset(qint32 frameNumber) const;
     bool isPhaseCorrect(qint32 frameNumber) const;
+    bool isPhaseRepeating(qint32 frameNumber) const;
 
     void setMarkedForDeletion(qint32 frameNumber);
     qint32 flush();

--- a/tools/ld-discmap/discmap.h
+++ b/tools/ld-discmap/discmap.h
@@ -63,6 +63,7 @@ public:
     qreal frameQuality(qint32 frameNumber) const;
     bool isPadded(qint32 frameNumber) const;
     bool isClvOffset(qint32 frameNumber) const;
+    bool isPhaseCorrect(qint32 frameNumber) const;
 
     void setMarkedForDeletion(qint32 frameNumber);
     qint32 flush();
@@ -74,6 +75,8 @@ public:
 
     qint32 getFirstFieldNumber(qint32 frameNumber) const;
     qint32 getSecondFieldNumber(qint32 frameNumber) const;
+    qint32 getFirstFieldPhase(qint32 frameNumber) const;
+    qint32 getSecondFieldPhase(qint32 frameNumber) const;
 
     bool saveTargetMetadata(QFileInfo outputFileInfo);
 

--- a/tools/ld-discmap/discmap.h
+++ b/tools/ld-discmap/discmap.h
@@ -69,7 +69,8 @@ public:
     void sort();
     void debugFrameDetails(qint32 frameNumber);
     void addPadding(qint32 startFrame, qint32 numberOfFrames);
-    qint32 getFieldLength();
+    qint32 getVideoFieldLength();
+    qint32 getAudioFieldLength();
 
     qint32 getFirstFieldNumber(qint32 frameNumber) const;
     qint32 getSecondFieldNumber(qint32 frameNumber) const;
@@ -86,7 +87,8 @@ private:
     bool m_isDiscPal;
     bool m_isDiscCav;
     qint32 m_numberOfPulldowns;
-    qint32 m_fieldLength;
+    qint32 m_videoFieldLength;
+    qint32 m_audioFieldLength;
 
     QVector<Frame> m_frames;
     LdDecodeMetaData *ldDecodeMetaData;

--- a/tools/ld-discmap/discmap.h
+++ b/tools/ld-discmap/discmap.h
@@ -88,7 +88,8 @@ private:
     bool m_isDiscCav;
     qint32 m_numberOfPulldowns;
     qint32 m_videoFieldLength;
-    qint32 m_audioFieldLength;
+    qint32 m_audioFieldByteLength;
+    qint32 m_audioFieldSampleLength;
 
     QVector<Frame> m_frames;
     LdDecodeMetaData *ldDecodeMetaData;

--- a/tools/ld-discmap/discmapper.cpp
+++ b/tools/ld-discmap/discmapper.cpp
@@ -553,7 +553,7 @@ bool DiscMapper::saveDiscMap(DiscMap &discMap)
 {
     // Open the input video file
     SourceVideo sourceVideo;
-    sourceVideo.open(inputFileInfo.filePath(), discMap.getFieldLength());
+    sourceVideo.open(inputFileInfo.filePath(), discMap.getVideoFieldLength());
 
     // Open the output video file
     QFile targetVideo(outputFileInfo.filePath());
@@ -591,25 +591,11 @@ bool DiscMapper::saveDiscMap(DiscMap &discMap)
 
     // Make a dummy video field to use when outputting padded frames
     SourceVideo::Data missingFieldData;
-    missingFieldData.fill(0, discMap.getFieldLength());
+    missingFieldData.fill(0, discMap.getVideoFieldLength());
 
     // Make a dummy audio field to use when outputting padded frames
     QByteArray missingFieldAudioData;
-    if (discMap.isDiscPal()) {
-        // Disc is PAL:
-        // 44,100 samples per second
-        // 50 fields per second
-        // 44,100 / 50 = 882 * 2 = 1764
-        // L/R channels = 1764 * 2 =
-        missingFieldAudioData.fill(0, 3528);
-    } else {
-        // Disc is NTSC:
-        // 44,100 samples per second
-        // 60000/1001 fields per second
-        // 44100 / (60000/1001) = 735.735 * 2 = 1472
-        // L/R channels = 1472 * 2 =
-        missingFieldAudioData.fill(0, 2944);
-    }
+    missingFieldAudioData.fill(0, discMap.getAudioFieldLength());
 
     // Create the output video file
     SourceVideo::Data sourceFirstField;

--- a/tools/ld-discmap/discmapper.h
+++ b/tools/ld-discmap/discmapper.h
@@ -57,6 +57,7 @@ private:
     bool noAudio;
 
     void removeLeadInOut(DiscMap &discMap);
+    void removeInvalidFramesByPhase(DiscMap &discMap);
     void correctVbiFrameNumbersUsingSequenceAnalysis(DiscMap &discMap);
     void removeDuplicateNumberedFrames(DiscMap &discMap);
     void numberPulldownFrames(DiscMap &discMap);

--- a/tools/ld-discmap/frame.cpp
+++ b/tools/ld-discmap/frame.cpp
@@ -27,11 +27,13 @@
 Frame::Frame(const qint32 &seqFrameNumber, const qint32 &vbiFrameNumber, const bool &isPictureStop,
              const bool &isPullDown, const bool &isLeadInOrOut, const bool &isMarkedForDeletion,
              const qreal &frameQuality, const bool &isPadded, const bool &isClvOffset,
-             const qint32 &firstField, const qint32 &secondField)
+             const qint32 &firstField, const qint32 &secondField,
+             const qint32 &firstFieldPhase, const qint32 &secondFieldPhase)
            : m_seqFrameNumber(seqFrameNumber),  m_vbiFrameNumber(vbiFrameNumber), m_isPictureStop(isPictureStop),
              m_isPullDown(isPullDown), m_isLeadInOrOut(isLeadInOrOut), m_isMarkedForDeletion(isMarkedForDeletion),
              m_frameQuality(frameQuality), m_isPadded(isPadded), m_isClvOffset(isClvOffset),
-             m_firstField(firstField), m_secondField(secondField)
+             m_firstField(firstField), m_secondField(secondField),
+             m_firstFieldPhase(firstFieldPhase), m_secondFieldPhase(secondFieldPhase)
 {
 }
 
@@ -50,6 +52,8 @@ QDebug operator<<(QDebug dbg, const Frame &frame)
                                ", isClvOffset " << frame.isClvOffset() <<
                                ", firstField " << frame.firstField() <<
                                ", secondField" << frame.secondField() <<
+                               ", firstFieldPhase " << frame.firstFieldPhase() <<
+                               ", secondFieldPhase " << frame.secondFieldPhase() <<
                                ")";
 
     return dbg.maybeSpace();
@@ -111,6 +115,17 @@ qint32 Frame::secondField() const
     return m_secondField;
 }
 
+qint32 Frame::firstFieldPhase() const
+{
+    return m_firstFieldPhase;
+}
+
+qint32 Frame::secondFieldPhase() const
+{
+    return m_secondFieldPhase;
+}
+
+
 // Set methods
 void Frame::seqFrameNumber(qint32 value)
 {
@@ -165,6 +180,16 @@ void Frame::firstField(qint32 value)
 void Frame::secondField(qint32 value)
 {
     m_secondField = value;
+}
+
+void Frame::firstFieldPhase(qint32 value)
+{
+    m_firstFieldPhase = value;
+}
+
+void Frame::secondFieldPhase(qint32 value)
+{
+    m_secondFieldPhase = value;
 }
 
 // Overide less than operator for sorting

--- a/tools/ld-discmap/frame.h
+++ b/tools/ld-discmap/frame.h
@@ -34,7 +34,8 @@ public:
     Frame(const qint32 &seqFrameNumber = -1, const qint32 &vbiFrameNumber = -1, const bool &isPictureStop = false,
           const bool &isPullDown = false, const bool &isLeadInOrOut = false, const bool &isMarkedForDeletion = false,
           const qreal &frameQuality = 0, const bool &isPadded = false, const bool &isClvOffset = false,
-          const qint32 &firstField = -1, const qint32 &secondField = -1);
+          const qint32 &firstField = -1, const qint32 &secondField = -1,
+          const qint32 &firstFieldPhase = -1, const qint32 &secondFieldPhase = -1);
     ~Frame() = default;
     Frame(const Frame &) = default;
     Frame &operator=(const Frame &) = default;
@@ -51,6 +52,8 @@ public:
     bool isClvOffset() const;
     qint32 firstField() const;
     qint32 secondField() const;
+    qint32 firstFieldPhase() const;
+    qint32 secondFieldPhase() const;
 
     // Set
     void seqFrameNumber(qint32 value);
@@ -64,6 +67,8 @@ public:
     void isClvOffset(bool value);
     void firstField(qint32 value);
     void secondField(qint32 value);
+    void firstFieldPhase(qint32 value);
+    void secondFieldPhase(qint32 value);
 
     // Operators
     bool operator<(const Frame &) const;
@@ -80,6 +85,8 @@ private:
     bool m_isClvOffset;
     qint32 m_firstField;
     qint32 m_secondField;
+    qint32 m_firstFieldPhase;
+    qint32 m_secondFieldPhase;
 };
 
 // Custom streaming operator for debug

--- a/tools/ld-discmap/sourceaudio.cpp
+++ b/tools/ld-discmap/sourceaudio.cpp
@@ -144,3 +144,4 @@ QByteArray SourceAudio::getAudioForField(qint32 fieldNo)
 
     return audioData;
 }
+


### PR DESCRIPTION
Adds additional support to the disc mapper based on phases (since that's now available for both NTSC and PAL) - Note that the changes are applicable to both NTSC and PAL as the phase information is now used for both.  Issues #456 #451 and #539 will need to be re-tested.

Also includes code to help with #547 as the metadata will now include the length of the padded audio samples for the padded video field.