### PR TITLE
Add yuv4mpeg (Y4M) output

### DIFF
--- a/tools/ld-chroma-decoder/comb.cpp
+++ b/tools/ld-chroma-decoder/comb.cpp
@@ -736,13 +736,17 @@ OutputFrame Comb::FrameBuffer::yiqToYUVFrame()
     OutputFrame outputFrame;
 
     outputFrame.Y.resize(videoParameters.fieldWidth * frameHeight);
-    outputFrame.Cb.resize(videoParameters.fieldWidth * frameHeight);
-    outputFrame.Cr.resize(videoParameters.fieldWidth * frameHeight);
-
-    // Initialise the output frame
     outputFrame.Y.fill(16 * 256);
-    outputFrame.Cb.fill(128 * 256);
-    outputFrame.Cr.fill(128 * 256);
+
+    if (configuration.chromaGain > 0) {
+        outputFrame.Cb.resize(videoParameters.fieldWidth * frameHeight);
+        outputFrame.Cr.resize(videoParameters.fieldWidth * frameHeight);
+        outputFrame.Cb.fill(128 * 256);
+        outputFrame.Cr.fill(128 * 256);
+    } else {
+        outputFrame.Cb.clear();
+        outputFrame.Cr.clear();
+    }
 
     // Initialise YIQ to YCbCr converter
     YCbCr ycbcr(videoParameters.white16bIre, videoParameters.black16bIre, configuration.whitePoint75, configuration.chromaGain);

--- a/tools/ld-chroma-decoder/comb.h
+++ b/tools/ld-chroma-decoder/comb.h
@@ -57,6 +57,7 @@ public:
         bool showMap = false;
         Decoder::PixelFormat pixelFormat = Decoder::PixelFormat::RGB48;
         bool outputYCbCr = false;
+        bool outputY4m = false;
 
         double cNRLevel = 0.0;
         double yNRLevel = 1.0;

--- a/tools/ld-chroma-decoder/decoder.h
+++ b/tools/ld-chroma-decoder/decoder.h
@@ -35,6 +35,14 @@
 #include "outputframe.h"
 #include "sourcefield.h"
 
+static const QString Y4M_CS_YUV444P16 = QStringLiteral(" C444p16 XCOLORRANGE=LIMITED\n");
+static const QString Y4M_CS_GRAY16    = QStringLiteral(" Cmono16 XCOLORRANGE=LIMITED\n");
+static const QString Y4M_PAR_NTSC_43  = QStringLiteral("97:114");  // (4 / 3) * (485 / 760)
+static const QString Y4M_PAR_NTSC_169 = QStringLiteral("194:171"); // (16 / 9) * (485 / 760)
+static const QString Y4M_PAR_PAL_43   = QStringLiteral("384:461"); // (4 / 3) * (576 / 922)
+static const QString Y4M_PAR_PAL_169  = QStringLiteral("512:461"); // (16 / 9) * (576 / 922)
+static constexpr QChar y4mFieldOrder = 't';
+
 class DecoderPool;
 
 // Abstract base class for chroma decoders.
@@ -83,8 +91,14 @@ public:
         GRAY16
     };
 
-    // After configuration, return a readable output pixel format
+    // Return a readable output pixel format
     virtual const char *getPixelName() const = 0;
+
+    // Return true if the decoder will output Y4M
+    virtual bool isOutputY4m() = 0;
+
+    // Generate the Y4M headers
+    virtual QString getHeaders() const = 0;
 
     // Parameters used by the decoder and its threads.
     // This may be subclassed by decoders to add extra parameters.
@@ -95,6 +109,7 @@ public:
         qint32 bottomPadLines;
         Decoder::PixelFormat pixelFormat = RGB48;
         bool outputYCbCr = false;
+        bool outputY4m = false;
     };
 
     // Compute the output frame size in Configuration, adjusting the active

--- a/tools/ld-chroma-decoder/decoderpool.cpp
+++ b/tools/ld-chroma-decoder/decoderpool.cpp
@@ -97,6 +97,13 @@ bool DecoderPool::process()
         }
     }
 
+    if (decoder.isOutputY4m()) {
+        if (targetVideo.write(decoder.getHeaders().toUtf8()) == -1) {
+            qCritical() << "Could not write Y4M header";
+            return false;
+        }
+    }
+
     qInfo() << "Using" << maxThreads << "threads";
     qInfo() << "Processing from start frame #" << startFrame << "with a length of" << length << "frames";
 
@@ -210,6 +217,12 @@ bool DecoderPool::putOutputFrame(qint32 frameNumber, const OutputFrame &outputFr
 
         // Save the frame data to the output file
         if (outputData.Y.size()) {
+            if (decoder.isOutputY4m()) {
+                if (targetVideo.write("FRAME\n") == -1) {
+                    qCritical() << "Writing to the output video file failed";
+                    return false;
+                }
+            }
             if (targetVideo.write(reinterpret_cast<const char *>(outputData.Y.data()), outputData.Y.size() * 2) == -1 ||
                 targetVideo.write(reinterpret_cast<const char *>(outputData.Cb.data()), outputData.Cb.size() * 2) == -1 ||
                 targetVideo.write(reinterpret_cast<const char *>(outputData.Cr.data()), outputData.Cr.size() * 2) == -1) {

--- a/tools/ld-chroma-decoder/main.cpp
+++ b/tools/ld-chroma-decoder/main.cpp
@@ -338,9 +338,11 @@ int main(int argc, char *argv[])
             monoConfig.outputY4m = true;
         }
         palConfig.outputYCbCr = true;
-        palConfig.pixelFormat = Decoder::PixelFormat::YUV444P16;
+        palConfig.pixelFormat = palConfig.chromaGain > 0 ? Decoder::PixelFormat::YUV444P16 :
+                                                           Decoder::PixelFormat::GRAY16;
         combConfig.outputYCbCr = true;
-        combConfig.pixelFormat = Decoder::PixelFormat::YUV444P16;
+        combConfig.pixelFormat = combConfig.chromaGain > 0 ? Decoder::PixelFormat::YUV444P16 :
+                                                             Decoder::PixelFormat::GRAY16;
         monoConfig.outputYCbCr = true;
         monoConfig.pixelFormat = Decoder::PixelFormat::GRAY16;
     } else if (outputFormatName != "rgb") {

--- a/tools/ld-chroma-decoder/main.cpp
+++ b/tools/ld-chroma-decoder/main.cpp
@@ -154,7 +154,7 @@ int main(int argc, char *argv[])
 
     // Option to select the output format (-p)
     QCommandLineOption outputFormatOption(QStringList() << "p" << "output-format",
-                                       QCoreApplication::translate("main", "Output format (rgb, yuv; default rgb); RGB48, YUV444P16, GRAY16 pixel formats are supported"),
+                                       QCoreApplication::translate("main", "Output format (rgb, yuv, y4m; default rgb); RGB48, YUV444P16, GRAY16 pixel formats are supported"),
                                        QCoreApplication::translate("main", "output-format"));
     parser.addOption(outputFormatOption);
 
@@ -331,7 +331,12 @@ int main(int argc, char *argv[])
     } else {
         outputFormatName = "rgb";
     }
-    if (outputFormatName == "yuv") {
+    if (outputFormatName == "yuv" || outputFormatName == "y4m") {
+        if (outputFormatName == "y4m") {
+            palConfig.outputY4m = true;
+            combConfig.outputY4m = true;
+            monoConfig.outputY4m = true;
+        }
         palConfig.outputYCbCr = true;
         palConfig.pixelFormat = Decoder::PixelFormat::YUV444P16;
         combConfig.outputYCbCr = true;
@@ -402,7 +407,11 @@ int main(int argc, char *argv[])
 
     if (parser.isSet(showFFTsOption)) {
         palConfig.showFFTs = true;
-        if (palConfig.outputYCbCr) {
+        if (palConfig.outputY4m) {
+            // Quit with error
+            qCritical("Y4M output not available when showFFT is enabled");
+            return -1;
+        } else if (palConfig.outputYCbCr) {
             // Quit with error
             qCritical("YUV output not available when showFFT is enabled");
             return -1;

--- a/tools/ld-chroma-decoder/monodecoder.cpp
+++ b/tools/ld-chroma-decoder/monodecoder.cpp
@@ -47,6 +47,31 @@ const char *MonoDecoder::getPixelName() const
     return config.outputYCbCr ? "GRAY16" : "RGB48";
 }
 
+bool MonoDecoder::isOutputY4m()
+{
+    return config.outputY4m;
+}
+
+QString MonoDecoder::getHeaders() const
+{
+    QString y4mHeader;
+    qint32 rateN = 30000;
+    qint32 rateD = 1001;
+    qint32 width = config.videoParameters.activeVideoEnd - config.videoParameters.activeVideoStart;
+    qint32 height = config.topPadLines + config.bottomPadLines +
+                    config.videoParameters.lastActiveFrameLine - config.videoParameters.firstActiveFrameLine;
+    QString y4mPixelAspect = (config.videoParameters.isWidescreen ? Y4M_PAR_NTSC_169 : Y4M_PAR_NTSC_43);
+    if (config.videoParameters.isSourcePal) {
+        rateN = 25;
+        rateD = 1;
+        y4mPixelAspect = (config.videoParameters.isWidescreen ? Y4M_PAR_PAL_169 : Y4M_PAR_PAL_43);
+    }
+    QTextStream(&y4mHeader) << "YUV4MPEG2 W" << width << " H" << height << " F" << rateN << ":" << rateD
+                            << " I" << y4mFieldOrder << " A" << y4mPixelAspect
+                            << (config.pixelFormat == YUV444P16 ? Y4M_CS_YUV444P16 : Y4M_CS_GRAY16);
+    return y4mHeader;
+}
+
 QThread *MonoDecoder::makeThread(QAtomicInt& abort, DecoderPool& decoderPool) {
     return new MonoThread(abort, decoderPool, config);
 }

--- a/tools/ld-chroma-decoder/monodecoder.h
+++ b/tools/ld-chroma-decoder/monodecoder.h
@@ -45,6 +45,8 @@ public:
     MonoDecoder(const MonoDecoder::Configuration &monoConfig);
     bool configure(const LdDecodeMetaData::VideoParameters &videoParameters) override;
     const char *getPixelName() const override;
+    bool isOutputY4m() override;
+    QString getHeaders() const override;
     QThread *makeThread(QAtomicInt& abort, DecoderPool& decoderPool) override;
 
 private:

--- a/tools/ld-chroma-decoder/ntscdecoder.cpp
+++ b/tools/ld-chroma-decoder/ntscdecoder.cpp
@@ -32,6 +32,7 @@ NtscDecoder::NtscDecoder(const Comb::Configuration &combConfig)
 {
     config.combConfig = combConfig;
     config.outputYCbCr = combConfig.outputYCbCr;
+    config.outputY4m = combConfig.outputY4m;
     config.pixelFormat = combConfig.pixelFormat;
 }
 
@@ -48,6 +49,30 @@ bool NtscDecoder::configure(const LdDecodeMetaData::VideoParameters &videoParame
     return true;
 }
 
+const char *NtscDecoder::getPixelName() const
+{
+    return config.combConfig.outputYCbCr ? "YUV444P16" : "RGB48";
+}
+
+bool NtscDecoder::isOutputY4m()
+{
+    return config.outputY4m;
+}
+
+QString NtscDecoder::getHeaders() const
+{
+    QString y4mHeader;
+    qint32 rateN = 30000;
+    qint32 rateD = 1001;
+    qint32 width = config.videoParameters.activeVideoEnd - config.videoParameters.activeVideoStart;
+    qint32 height = config.topPadLines + config.bottomPadLines +
+                    config.videoParameters.lastActiveFrameLine - config.videoParameters.firstActiveFrameLine;
+    QTextStream(&y4mHeader) << "YUV4MPEG2 W" << width << " H" << height << " F" << rateN << ":" << rateD
+                            << " I" << y4mFieldOrder << " A" << (config.videoParameters.isWidescreen ? Y4M_PAR_NTSC_169 : Y4M_PAR_NTSC_43)
+                            << (config.pixelFormat == YUV444P16 ? Y4M_CS_YUV444P16 : Y4M_CS_GRAY16);
+    return y4mHeader;
+}
+
 qint32 NtscDecoder::getLookBehind() const
 {
     return config.combConfig.getLookBehind();
@@ -56,11 +81,6 @@ qint32 NtscDecoder::getLookBehind() const
 qint32 NtscDecoder::getLookAhead() const
 {
     return config.combConfig.getLookAhead();
-}
-
-const char *NtscDecoder::getPixelName() const
-{
-    return config.combConfig.outputYCbCr ? "YUV444P16" : "RGB48";
 }
 
 QThread *NtscDecoder::makeThread(QAtomicInt& abort, DecoderPool& decoderPool)

--- a/tools/ld-chroma-decoder/ntscdecoder.cpp
+++ b/tools/ld-chroma-decoder/ntscdecoder.cpp
@@ -51,7 +51,8 @@ bool NtscDecoder::configure(const LdDecodeMetaData::VideoParameters &videoParame
 
 const char *NtscDecoder::getPixelName() const
 {
-    return config.combConfig.outputYCbCr ? "YUV444P16" : "RGB48";
+    return config.outputYCbCr ?
+           config.combConfig.chromaGain > 0 ? "YUV444P16" : "GRAY16" : "RGB48";
 }
 
 bool NtscDecoder::isOutputY4m()

--- a/tools/ld-chroma-decoder/ntscdecoder.h
+++ b/tools/ld-chroma-decoder/ntscdecoder.h
@@ -47,6 +47,8 @@ public:
     NtscDecoder(const Comb::Configuration &combConfig);
     bool configure(const LdDecodeMetaData::VideoParameters &videoParameters) override;
     const char *getPixelName() const override;
+    bool isOutputY4m() override;
+    QString getHeaders() const override;
     qint32 getLookBehind() const override;
     qint32 getLookAhead() const override;
     QThread *makeThread(QAtomicInt& abort, DecoderPool& decoderPool) override;

--- a/tools/ld-chroma-decoder/palcolour.cpp
+++ b/tools/ld-chroma-decoder/palcolour.cpp
@@ -263,10 +263,19 @@ void PalColour::decodeFrames(const QVector<SourceField> &inputFields, qint32 sta
         for (qint32 i = 0; i < outputFrames.size(); i++) {
             outputFrames[i].Y.resize(videoParameters.fieldWidth * frameHeight);
             outputFrames[i].Y.fill(16 * 256);
-            outputFrames[i].Cb.resize(videoParameters.fieldWidth * frameHeight);
-            outputFrames[i].Cb.fill(128 * 256);
-            outputFrames[i].Cr.resize(videoParameters.fieldWidth * frameHeight);
-            outputFrames[i].Cr.fill(128 * 256);
+        }
+        if (configuration.chromaGain > 0) {
+            for (qint32 i = 0; i < outputFrames.size(); i++) {
+                outputFrames[i].Cb.resize(videoParameters.fieldWidth * frameHeight);
+                outputFrames[i].Cb.fill(128 * 256);
+                outputFrames[i].Cr.resize(videoParameters.fieldWidth * frameHeight);
+                outputFrames[i].Cr.fill(128 * 256);
+            }
+        } else {
+            for (qint32 i = 0; i < outputFrames.size(); i++) {
+                outputFrames[i].Cb.clear();
+                outputFrames[i].Cr.clear();
+            }
         }
     } else {
         for (qint32 i = 0; i < outputFrames.size(); i++) {
@@ -611,8 +620,10 @@ void PalColour::decodeLine(const SourceField &inputField, const ChromaSample *ch
 
             // Place the 16-bit YCbCr values in the output arrays
             ptrY[i] = static_cast<quint16>(rY);
-            ptrCb[i] = static_cast<quint16>(u);
-            ptrCr[i] = static_cast<quint16>(v);
+            if (configuration.chromaGain > 0) {
+                ptrCb[i] = static_cast<quint16>(u);
+                ptrCr[i] = static_cast<quint16>(v);
+            }
         }
     } else {
         // Define scan line pointer to RGB output buffer using 16 bit unsigned words

--- a/tools/ld-chroma-decoder/palcolour.h
+++ b/tools/ld-chroma-decoder/palcolour.h
@@ -66,6 +66,7 @@ public:
         QVector<double> transformThresholds;
         Decoder::PixelFormat pixelFormat = Decoder::PixelFormat::RGB48;
         bool outputYCbCr = false;
+        bool outputY4m = false;
         bool showFFTs = false;
         qint32 showPositionX = 200;
         qint32 showPositionY = 200;

--- a/tools/ld-chroma-decoder/paldecoder.cpp
+++ b/tools/ld-chroma-decoder/paldecoder.cpp
@@ -31,6 +31,7 @@ PalDecoder::PalDecoder(const PalColour::Configuration &palConfig)
 {
     config.pal = palConfig;
     config.outputYCbCr = palConfig.outputYCbCr;
+    config.outputY4m = palConfig.outputY4m;
     config.pixelFormat = palConfig.pixelFormat;
 }
 
@@ -50,6 +51,25 @@ bool PalDecoder::configure(const LdDecodeMetaData::VideoParameters &videoParamet
 const char *PalDecoder::getPixelName() const
 {
     return config.pal.outputYCbCr ? "YUV444P16" : "RGB48";
+}
+
+bool PalDecoder::isOutputY4m()
+{
+    return config.outputY4m;
+}
+
+QString PalDecoder::getHeaders() const
+{
+    QString y4mHeader;
+    qint32 rateN = 25;
+    qint32 rateD = 1;
+    qint32 width = config.videoParameters.activeVideoEnd - config.videoParameters.activeVideoStart;
+    qint32 height = config.topPadLines + config.bottomPadLines +
+                    config.videoParameters.lastActiveFrameLine - config.videoParameters.firstActiveFrameLine;
+    QTextStream(&y4mHeader) << "YUV4MPEG2 W" << width << " H" << height << " F" << rateN << ":" << rateD
+                            << " I" << y4mFieldOrder << " A" << (config.videoParameters.isWidescreen ? Y4M_PAR_PAL_169 : Y4M_PAR_PAL_43)
+                            << (config.pixelFormat == YUV444P16 ? Y4M_CS_YUV444P16 : Y4M_CS_GRAY16);
+    return y4mHeader;
 }
 
 qint32 PalDecoder::getLookBehind() const

--- a/tools/ld-chroma-decoder/paldecoder.cpp
+++ b/tools/ld-chroma-decoder/paldecoder.cpp
@@ -50,7 +50,8 @@ bool PalDecoder::configure(const LdDecodeMetaData::VideoParameters &videoParamet
 
 const char *PalDecoder::getPixelName() const
 {
-    return config.pal.outputYCbCr ? "YUV444P16" : "RGB48";
+    return config.outputYCbCr ?
+           config.pal.chromaGain > 0 ? "YUV444P16" : "GRAY16" : "RGB48";
 }
 
 bool PalDecoder::isOutputY4m()

--- a/tools/ld-chroma-decoder/paldecoder.h
+++ b/tools/ld-chroma-decoder/paldecoder.h
@@ -46,6 +46,8 @@ public:
     PalDecoder(const PalColour::Configuration &palConfig);
     bool configure(const LdDecodeMetaData::VideoParameters &videoParameters) override;
     const char *getPixelName() const override;
+    bool isOutputY4m() override;
+    QString getHeaders() const override;
     qint32 getLookBehind() const override;
     qint32 getLookAhead() const override;
     QThread *makeThread(QAtomicInt& abort, DecoderPool& decoderPool) override;

--- a/tools/ld-chroma-decoder/ycbcr.cpp
+++ b/tools/ld-chroma-decoder/ycbcr.cpp
@@ -78,7 +78,9 @@ void YCbCr::convertLine(const YIQ *begin, const YIQ *end, quint16 *outY, quint16
 
         // Place the 16-bit YCbCr values in the output arrays
         *outY++ = static_cast<quint16>(y);
-        *outCb++ = static_cast<quint16>(Cb);
-        *outCr++ = static_cast<quint16>(Cr);
+        if (chromaGain > 0) {
+            *outCb++ = static_cast<quint16>(Cb);
+            *outCr++ = static_cast<quint16>(Cr);
+        }
     }
 }

--- a/tools/library/tbc/lddecodemetadata.cpp
+++ b/tools/library/tbc/lddecodemetadata.cpp
@@ -75,6 +75,7 @@ LdDecodeMetaData::VideoParameters LdDecodeMetaData::getVideoParameters()
         videoParameters.numberOfSequentialFields = json.value({"videoParameters", "numberOfSequentialFields"}).toInt();
         videoParameters.isSourcePal = json.value({"videoParameters", "isSourcePal"}).toBool();
         videoParameters.isSubcarrierLocked = json.value({"videoParameters", "isSubcarrierLocked"}).toBool();
+        videoParameters.isWidescreen = json.value({"videoParameters", "isWidescreen"}).toBool();
 
         videoParameters.colourBurstStart = json.value({"videoParameters", "colourBurstStart"}).toInt();
         videoParameters.colourBurstEnd = json.value({"videoParameters", "colourBurstEnd"}).toInt();
@@ -126,6 +127,7 @@ void LdDecodeMetaData::setVideoParameters (LdDecodeMetaData::VideoParameters _vi
     json.setValue({"videoParameters", "numberOfSequentialFields"}, getNumberOfFields());
     json.setValue({"videoParameters", "isSourcePal"}, _videoParameters.isSourcePal);
     json.setValue({"videoParameters", "isSubcarrierLocked"}, _videoParameters.isSubcarrierLocked);
+    json.setValue({"videoParameters", "isWidescreen"}, _videoParameters.isWidescreen);
 
     json.setValue({"videoParameters", "colourBurstStart"}, _videoParameters.colourBurstStart);
     json.setValue({"videoParameters", "colourBurstEnd"}, _videoParameters.colourBurstEnd);

--- a/tools/library/tbc/lddecodemetadata.h
+++ b/tools/library/tbc/lddecodemetadata.h
@@ -52,6 +52,7 @@ public:
 
         bool isSourcePal;
         bool isSubcarrierLocked;
+        bool isWidescreen;
 
         qint32 colourBurstStart;
         qint32 colourBurstEnd;


### PR DESCRIPTION
ld-chroma-decoder: add 'y4m' to the available --output-format options.

'y4m' output is identical to 'yuv' except with the addition of headers. This
avoids having to specify the dimensions, frame rate, field order, aspect ratio,
and pixel format to downstream consumers such as ffmpeg.

For example:
ld-chroma-decoder -p y4m input - | ffmpeg -f yuv4mpegpipe -i - output.mkv