### PR TITLE
Build cleanly with Qt 5.15 (and other minor fixes)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,7 +23,7 @@ jobs:
       run: |
         sudo apt-get update
         # This list is from: https://github.com/happycube/ld-decode/wiki/Installation
-        sudo apt-get install -y --no-install-recommends clang libopencv-dev libfann-dev python3-numpy python3-scipy python3-matplotlib git qt5-default libqwt-qt5-dev libfftw3-dev python3-tk python3-pandas python3-numba libavformat-dev libavcodec-dev libavutil-dev ffmpeg openssl pv
+        sudo apt-get install -y --no-install-recommends clang libfann-dev python3-numpy python3-scipy python3-matplotlib git qt5-default libqwt-qt5-dev libfftw3-dev python3-tk python3-pandas python3-numba libavformat-dev libavcodec-dev libavutil-dev ffmpeg openssl pv
 
     - name: Build
       timeout-minutes: 15

--- a/tools/ld-analyse/chromadecoderconfigdialog.ui
+++ b/tools/ld-analyse/chromadecoderconfigdialog.ui
@@ -212,19 +212,6 @@
          </property>
         </spacer>
        </item>
-       <item>
-        <spacer name="verticalSpacer_4">
-         <property name="orientation">
-          <enum>Qt::Vertical</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>20</width>
-           <height>40</height>
-          </size>
-         </property>
-        </spacer>
-       </item>
       </layout>
      </widget>
      <widget class="QWidget" name="ntscTab">
@@ -353,19 +340,6 @@
           <set>Qt::AlignCenter</set>
          </property>
         </widget>
-       </item>
-       <item>
-        <spacer name="verticalSpacer_6">
-         <property name="orientation">
-          <enum>Qt::Vertical</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>20</width>
-           <height>40</height>
-          </size>
-         </property>
-        </spacer>
        </item>
        <item>
         <spacer name="verticalSpacer">

--- a/tools/ld-analyse/chromadecoderconfigdialog.ui
+++ b/tools/ld-analyse/chromadecoderconfigdialog.ui
@@ -41,30 +41,30 @@
      </property>
     </widget>
    </item>
-       <item>
-        <widget class="QLabel" name="yNRLabel">
-         <property name="text">
-          <string>Luma noise reduction:</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QSlider" name="yNRHorizontalSlider">
-         <property name="orientation">
-          <enum>Qt::Horizontal</enum>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QLabel" name="yNRValueLabel">
-         <property name="text">
-          <string>0.00 IRE</string>
-         </property>
-         <property name="alignment">
-          <set>Qt::AlignCenter</set>
-         </property>
-        </widget>
-       </item>
+   <item>
+    <widget class="QLabel" name="yNRLabel">
+     <property name="text">
+      <string>Luma noise reduction:</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QSlider" name="yNRHorizontalSlider">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QLabel" name="yNRValueLabel">
+     <property name="text">
+      <string>0.00 IRE</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignCenter</set>
+     </property>
+    </widget>
+   </item>
    <item>
     <widget class="QTabWidget" name="standardTabs">
      <property name="currentIndex">

--- a/tools/ld-analyse/ld-analyse.pro
+++ b/tools/ld-analyse/ld-analyse.pro
@@ -130,7 +130,6 @@ INCLUDEPATH += "/usr/local/include"
 }
 
 # Normal open-source OS goodness
-INCLUDEPATH += "/usr/local/include/opencv"
 LIBS += -L"/usr/local/lib"
 LIBS += -lfftw3
 

--- a/tools/ld-chroma-decoder/comb.cpp
+++ b/tools/ld-chroma-decoder/comb.cpp
@@ -5,7 +5,8 @@
     ld-chroma-decoder - Colourisation filter for ld-decode
     Copyright (C) 2018 Chad Page
     Copyright (C) 2018-2019 Simon Inns
-    Copyright (C) 2020 Adam Sampson
+    Copyright (C) 2020-2021 Adam Sampson
+    Copyright (C) 2021 Phillip Blucas
 
     This file is part of ld-decode-tools.
 

--- a/tools/ld-chroma-decoder/comb.cpp
+++ b/tools/ld-chroma-decoder/comb.cpp
@@ -773,8 +773,8 @@ OutputFrame Comb::FrameBuffer::yiqToYUVFrame()
 
         // Fill the output line with YCbCr values
         ycbcr.convertLine(&yiqBuffer[lineNumber][videoParameters.activeVideoStart],
-                        &yiqBuffer[lineNumber][videoParameters.activeVideoEnd],
-                        &linePointerY[o], &linePointerCb[o], &linePointerCr[o]);
+                          &yiqBuffer[lineNumber][videoParameters.activeVideoEnd],
+                          &linePointerY[o], &linePointerCb[o], &linePointerCr[o]);
     }
 
     return outputFrame;

--- a/tools/ld-chroma-decoder/comb.h
+++ b/tools/ld-chroma-decoder/comb.h
@@ -6,6 +6,7 @@
     Copyright (C) 2018 Chad Page
     Copyright (C) 2018-2019 Simon Inns
     Copyright (C) 2020 Adam Sampson
+    Copyright (C) 2021 Phillip Blucas
 
     This file is part of ld-decode-tools.
 

--- a/tools/ld-chroma-decoder/decoder.h
+++ b/tools/ld-chroma-decoder/decoder.h
@@ -4,6 +4,7 @@
 
     ld-chroma-decoder - Colourisation filter for ld-decode
     Copyright (C) 2019 Adam Sampson
+    Copyright (C) 2021 Phillip Blucas
 
     This file is part of ld-decode-tools.
 

--- a/tools/ld-chroma-decoder/decoderpool.cpp
+++ b/tools/ld-chroma-decoder/decoderpool.cpp
@@ -4,6 +4,7 @@
 
     ld-chroma-decoder - Colourisation filter for ld-decode
     Copyright (C) 2018-2019 Simon Inns
+    Copyright (C) 2021 Phillip Blucas
 
     This file is part of ld-decode-tools.
 

--- a/tools/ld-chroma-decoder/main.cpp
+++ b/tools/ld-chroma-decoder/main.cpp
@@ -348,7 +348,7 @@ int main(int argc, char *argv[])
         monoConfig.outputYCbCr = true;
         monoConfig.pixelFormat = Decoder::PixelFormat::GRAY16;
     } else if (outputFormatName != "rgb") {
-        qCritical() << "Unknown output format " << outputFormatName;
+        qCritical() << "Unknown output format" << outputFormatName;
         return -1;
     }
 
@@ -390,7 +390,7 @@ int main(int argc, char *argv[])
             palConfig.transformMode = TransformPal::thresholdMode;
         } else {
             // Quit with error
-            qCritical() << "Unknown Transform mode " << name;
+            qCritical() << "Unknown Transform mode" << name;
             return -1;
         }
     }
@@ -495,7 +495,7 @@ int main(int argc, char *argv[])
     } else if (decoderName == "mono") {
         decoder.reset(new MonoDecoder(monoConfig));
     } else {
-        qCritical() << "Unknown decoder " << decoderName;
+        qCritical() << "Unknown decoder" << decoderName;
         return -1;
     }
 

--- a/tools/ld-chroma-decoder/main.cpp
+++ b/tools/ld-chroma-decoder/main.cpp
@@ -4,7 +4,9 @@
 
     ld-chroma-decoder - Colourisation filter for ld-decode
     Copyright (C) 2018-2020 Simon Inns
-    Copyright (C) 2019-2020 Adam Sampson
+    Copyright (C) 2019-2021 Adam Sampson
+    Copyright (C) 2021 Chad Page
+    Copyright (C) 2021 Phillip Blucas
 
     This file is part of ld-decode-tools.
 

--- a/tools/ld-chroma-decoder/main.cpp
+++ b/tools/ld-chroma-decoder/main.cpp
@@ -148,7 +148,7 @@ int main(int argc, char *argv[])
 
     // Option to specify chroma gain
     QCommandLineOption chromaGainOption(QStringList() << "chroma-gain",
-                                        QCoreApplication::translate("main", "Gain factor applied to chroma components (default 1.0 NTSC, 0.5 PAL)"),
+                                        QCoreApplication::translate("main", "Gain factor applied to chroma components (default 1.0)"),
                                         QCoreApplication::translate("main", "number"));
     parser.addOption(chromaGainOption);
 

--- a/tools/ld-chroma-decoder/monodecoder.cpp
+++ b/tools/ld-chroma-decoder/monodecoder.cpp
@@ -4,6 +4,7 @@
 
     ld-chroma-decoder - Colourisation filter for ld-decode
     Copyright (C) 2019 Adam Sampson
+    Copyright (C) 2021 Phillip Blucas
 
     This file is part of ld-decode-tools.
 

--- a/tools/ld-chroma-decoder/monodecoder.h
+++ b/tools/ld-chroma-decoder/monodecoder.h
@@ -4,6 +4,7 @@
 
     ld-chroma-decoder - Colourisation filter for ld-decode
     Copyright (C) 2019 Adam Sampson
+    Copyright (C) 2021 Phillip Blucas
 
     This file is part of ld-decode-tools.
 

--- a/tools/ld-chroma-decoder/ntscdecoder.cpp
+++ b/tools/ld-chroma-decoder/ntscdecoder.cpp
@@ -6,6 +6,7 @@
     Copyright (C) 2018 Chad Page
     Copyright (C) 2018-2019 Simon Inns
     Copyright (C) 2019-2020 Adam Sampson
+    Copyright (C) 2021 Phillip Blucas
 
     This file is part of ld-decode-tools.
 

--- a/tools/ld-chroma-decoder/ntscdecoder.h
+++ b/tools/ld-chroma-decoder/ntscdecoder.h
@@ -6,6 +6,7 @@
     Copyright (C) 2018 Chad Page
     Copyright (C) 2018-2019 Simon Inns
     Copyright (C) 2019-2020 Adam Sampson
+    Copyright (C) 2021 Phillip Blucas
 
     This file is part of ld-decode-tools.
 

--- a/tools/ld-chroma-decoder/palcolour.cpp
+++ b/tools/ld-chroma-decoder/palcolour.cpp
@@ -73,8 +73,8 @@
 constexpr qint32 PalColour::MAX_WIDTH;
 constexpr qint32 PalColour::FILTER_SIZE;
 
-PalColour::PalColour(QObject *parent)
-    : QObject(parent), configurationSet(false)
+PalColour::PalColour()
+    : configurationSet(false)
 {
 }
 

--- a/tools/ld-chroma-decoder/palcolour.cpp
+++ b/tools/ld-chroma-decoder/palcolour.cpp
@@ -8,6 +8,8 @@
     Copyright (C) 2018  William Andrew Steer
     Copyright (C) 2018-2019 Simon Inns
     Copyright (C) 2019 Adam Sampson
+    Copyright (C) 2021 Chad Page
+    Copyright (C) 2021 Phillip Blucas
 
     This file is part of ld-decode-tools.
 

--- a/tools/ld-chroma-decoder/palcolour.h
+++ b/tools/ld-chroma-decoder/palcolour.h
@@ -28,8 +28,8 @@
 #ifndef PALCOLOUR_H
 #define PALCOLOUR_H
 
+#include <QtGlobal>
 #include <QDebug>
-#include <QObject>
 #include <QScopedPointer>
 #include <QVector>
 #include <QtMath>
@@ -41,12 +41,10 @@
 #include "sourcefield.h"
 #include "transformpal.h"
 
-class PalColour : public QObject
+class PalColour
 {
-    Q_OBJECT
-
 public:
-    explicit PalColour(QObject *parent = nullptr);
+    PalColour();
 
     // Specify which filter to use to separate luma and chroma information.
     enum ChromaFilterMode {

--- a/tools/ld-chroma-decoder/palcolour.h
+++ b/tools/ld-chroma-decoder/palcolour.h
@@ -5,6 +5,8 @@
     ld-chroma-decoder - Colourisation filter for ld-decode
     Copyright (C) 2018-2019 Simon Inns
     Copyright (C) 2019 Adam Sampson
+    Copyright (C) 2021 Chad Page
+    Copyright (C) 2021 Phillip Blucas
 
     This file is part of ld-decode-tools.
 

--- a/tools/ld-chroma-decoder/paldecoder.cpp
+++ b/tools/ld-chroma-decoder/paldecoder.cpp
@@ -5,6 +5,7 @@
     ld-chroma-decoder - Colourisation filter for ld-decode
     Copyright (C) 2018-2019 Simon Inns
     Copyright (C) 2019 Adam Sampson
+    Copyright (C) 2021 Phillip Blucas
 
     This file is part of ld-decode-tools.
 

--- a/tools/ld-chroma-decoder/paldecoder.h
+++ b/tools/ld-chroma-decoder/paldecoder.h
@@ -5,6 +5,7 @@
     ld-chroma-decoder - Colourisation filter for ld-decode
     Copyright (C) 2018-2019 Simon Inns
     Copyright (C) 2019 Adam Sampson
+    Copyright (C) 2021 Phillip Blucas
 
     This file is part of ld-decode-tools.
 

--- a/tools/ld-lds-converter/dataconverter.cpp
+++ b/tools/ld-lds-converter/dataconverter.cpp
@@ -80,7 +80,7 @@ bool DataConverter::openInputFile(void)
         inputFileHandle = new QFile(inputFileName);
         if (!inputFileHandle->open(QIODevice::ReadOnly)) {
             // Failed to open source sample file
-            qDebug() << "Could not open " << inputFileName << "as input file";
+            qDebug() << "Could not open" << inputFileName << "as input file";
             return false;
         }
         qDebug() << "DataConverter::openInputFile(): Input file is" << inputFileName << "and is" << inputFileHandle->size() << "bytes in length";
@@ -122,7 +122,7 @@ bool DataConverter::openOutputFile(void)
         outputFileHandle = new QFile(outputFileName);
         if (!outputFileHandle->open(QIODevice::WriteOnly)) {
             // Failed to open output file
-            qDebug() << "DataConverter::openOutputFile(): Could not open " << outputFileName << "as output file";
+            qDebug() << "DataConverter::openOutputFile(): Could not open" << outputFileName << "as output file";
             return false;
         }
         qDebug() << "DataConverter::openOutputFile(): Output file is" << outputFileName;

--- a/tools/library/tbc/dropouts.cpp
+++ b/tools/library/tbc/dropouts.cpp
@@ -137,11 +137,11 @@ void DropOuts::concatenate()
 // Custom debug streaming operator
 QDebug operator<<(QDebug dbg, DropOuts &dropOuts)
 {
-    dbg.nospace() << "Dropout object contains " << dropOuts.size() << " entries:" << endl;
+    dbg.nospace() << "Dropout object contains " << dropOuts.size() << " entries:\n";
 
     for (qint32 i = 0; i < dropOuts.size(); i++) {
         dbg.nospace() << "  [" << i << "] startx = " << dropOuts.startx(i) <<
-                         " - endx = " << dropOuts.endx(i) << " - line = " << dropOuts.fieldLine(i) << endl;
+                         " - endx = " << dropOuts.endx(i) << " - line = " << dropOuts.fieldLine(i) << "\n";
     }
 
     return dbg.maybeSpace();

--- a/tools/library/tbc/logging.cpp
+++ b/tools/library/tbc/logging.cpp
@@ -100,7 +100,7 @@ void openDebugFile(QString filename)
     debugFile = new QFile(filename);
     if (!debugFile->open(QIODevice::WriteOnly)) {
         // Failed to open source sample file
-        qDebug() << "Could not open " << filename << "as debug output file";
+        qDebug() << "Could not open" << filename << "as debug output file";
     } else saveDebug = true;
 }
 

--- a/tools/library/tbc/logging.cpp
+++ b/tools/library/tbc/logging.cpp
@@ -4,6 +4,7 @@
 
     ld-decode-tools TBC library
     Copyright (C) 2018-2020 Simon Inns
+    Copyright (C) 2021 Adam Sampson
 
     This file is part of ld-decode-tools.
 
@@ -45,31 +46,30 @@ void debugOutputHandler(QtMsgType type, const QMessageLogContext &context, const
     // context.line - to show the line number
     // context.function - to show the function name
 
-    QByteArray localMsg = msg.toLocal8Bit();
     QString outputMessage;
-
     switch (type) {
     case QtDebugMsg: // These are debug messages meant for developers
-        // If the code was compiled as 'release' the context.file will be NULL
-        if (context.file != nullptr) outputMessage.sprintf("Debug: [%s:%d] %s\n", context.file, context.line, localMsg.constData());
-        else outputMessage.sprintf("Debug: %s\n", localMsg.constData());
+        outputMessage = "Debug";
         break;
     case QtInfoMsg: // These are information messages meant for end-users
-        if (context.file != nullptr) outputMessage.sprintf("Info: [%s:%d] %s\n", context.file, context.line, localMsg.constData());
-        else outputMessage.sprintf("Info: %s\n", localMsg.constData());
+        outputMessage = "Info";
         break;
     case QtWarningMsg:
-        if (context.file != nullptr) outputMessage.sprintf("Warning: [%s:%d] %s\n", context.file, context.line, localMsg.constData());
-        else outputMessage.sprintf("Warning: %s\n", localMsg.constData());
+        outputMessage = "Warning";
         break;
     case QtCriticalMsg:
-        if (context.file != nullptr) outputMessage.sprintf("Critical: [%s:%d] %s\n", context.file, context.line, localMsg.constData());
-        else outputMessage.sprintf("Critical: %s\n", localMsg.constData());
+        outputMessage = "Critical";
         break;
     case QtFatalMsg:
-        if (context.file != nullptr) outputMessage.sprintf("Fatal: [%s:%d] %s\n", context.file, context.line, localMsg.constData());
-        else outputMessage.sprintf("Fatal: %s\n", localMsg.constData());
+        outputMessage = "Fatal";
         break;
+    }
+
+    // If the code was compiled as 'release' the context.file will be NULL
+    if (context.file != nullptr) {
+        outputMessage += QString(": [%1:%2] %3\n").arg(context.file).arg(context.line).arg(msg);
+    } else {
+        outputMessage += QString(": %1\n").arg(msg);
     }
 
     // If quiet mode is set, suppress all output

--- a/tools/library/tbc/sourceaudio.cpp
+++ b/tools/library/tbc/sourceaudio.cpp
@@ -44,7 +44,7 @@ bool SourceAudio::open(QFileInfo inputFileInfo)
     inputAudioFile.setFileName(inputAudioFileInfo.filePath());
     if (!inputAudioFile.open(QIODevice::ReadOnly)) {
         // Failed to open named input file
-        qDebug() << "Could not open " << inputAudioFileInfo.filePath() << "as source audio input file";
+        qDebug() << "Could not open" << inputAudioFileInfo.filePath() << "as source audio input file";
         qFatal("Could not open PCM audio file!");
         return false;
     }
@@ -52,7 +52,7 @@ bool SourceAudio::open(QFileInfo inputFileInfo)
     // Get the length of the PCM audio file
     audioFileByteLength = inputAudioFileInfo.size();
     if (audioFileByteLength == 0) {
-        qDebug() << "Could get file size of " << inputAudioFileInfo.filePath() << "(or file was 0 bytes length)";
+        qDebug() << "Could get file size of" << inputAudioFileInfo.filePath() << "(or file was 0 bytes length)";
         qFatal("Could not get PCM audio file length!");
         return false;
     }

--- a/tools/library/tbc/sourcevideo.cpp
+++ b/tools/library/tbc/sourcevideo.cpp
@@ -79,7 +79,7 @@ bool SourceVideo::open(QString filename, qint32 _fieldLength, qint32 _fieldLineL
     } else {
         if (!inputFile.open(QIODevice::ReadOnly)) {
             // Failed to open named input file
-            qWarning() << "Could not open " << filename << "as source video input file";
+            qWarning() << "Could not open" << filename << "as source video input file";
             return false;
         }
 


### PR DESCRIPTION
See the commit messages for more details. The general aim here was to get rid of the warnings when building ld-decode against Qt 5.15, but I found a few other trivial things in the process.

One warning remains, about `QLabel::pixmap()` being deprecated, but I can't fix that without adding a version conditional for older Qt and I don't think it's worth it.