### PR TITLE
Clear Comb::FrameBuffer::clpbuffer before each frame

### DIFF
--- a/tools/ld-chroma-decoder/comb.cpp
+++ b/tools/ld-chroma-decoder/comb.cpp
@@ -243,6 +243,15 @@ void Comb::FrameBuffer::loadFields(const SourceField &firstField, const SourceFi
     // Set the phase IDs for the frame
     firstFieldPhaseID = firstField.field.fieldPhaseID;
     secondFieldPhaseID = secondField.field.fieldPhaseID;
+
+    // Clear clpbuffer
+    for (qint32 buf = 0; buf < 3; buf++) {
+        for (qint32 y = 0; y < MAX_HEIGHT; y++) {
+            for (qint32 x = 0; x < MAX_WIDTH; x++) {
+                clpbuffer[buf].pixel[y][x] = 0.0;
+            }
+        }
+    }
 }
 
 // Extract chroma into clpbuffer[0] using a 1D bandpass filter.


### PR DESCRIPTION
@Gamnn reported that ntsc2d was producing differences in output for identical input after 200+ frames. Bisection narrowed this down to ff5f9914dd257e7c2b065adbca4a4f06cb5956c9.

The problem was that the `Comb` code didn't explicitly initialise `clpbuffer`. The code fills in values for the active region, but it
assumes anything outside the active region will read as 0 when filtering -- this was probably the case by accident before when
`clpbuffer` was allocated each time by Qt.

Zeroing the buffer explicitly fixes it.

Fixes #623. @Gamnn, please can you check this works for your file now?