### PR TITLE
Fix off-by-one error when selecting replacement lines

### DIFF
--- a/tools/ld-dropout-correct/dropoutcorrect.cpp
+++ b/tools/ld-dropout-correct/dropoutcorrect.cpp
@@ -413,13 +413,15 @@ void DropOutCorrect::findPotentialReplacementLine(const QVector<QVector<DropOutL
     qint32 sourceLine = targetDropouts[0][targetIndex].fieldLine + sourceOffset;
 
     // Is the line within the active range?
-    if (sourceLine < videoParameters[sourceNo].firstActiveFieldLine || sourceLine >= videoParameters[sourceNo].lastActiveFieldLine) {
+    if ((sourceLine - 1) < videoParameters[sourceNo].firstActiveFieldLine
+        || (sourceLine - 1) >= videoParameters[sourceNo].lastActiveFieldLine) {
         qDebug() << "Line" << sourceLine << "is not in active range - ignoring";
         return;
     }
 
     // Hunt for a replacement
-    while (sourceLine >= videoParameters[sourceNo].firstActiveFieldLine && sourceLine < videoParameters[sourceNo].lastActiveFieldLine) {
+    while ((sourceLine - 1) >= videoParameters[sourceNo].firstActiveFieldLine
+           && (sourceLine - 1) < videoParameters[sourceNo].lastActiveFieldLine) {
         // Is there a dropout that overlaps the one we're trying to replace?
         bool hasOverlap = false;
         for (qint32 sourceIndex = 0; sourceIndex < sourceDropouts[sourceNo].size(); sourceIndex++) {


### PR DESCRIPTION
@Gamnn spotted that a dropout on the last line of the active region wasn't being corrected.

This is because the ld-dropout-correct code largely works in terms of 1-based line numbering, but the replacement search code was bounded by `first/lastActiveFieldLine` which use 0-based numbering.

This is the minimal fix - I think in the future it'd be better to rework ld-dropout-correct to use 0-based numbering internally. But the testcase in this bug is also a good example of why it'd be better to do a similarity comparison like ntsc3d does - it would be able to find an identical replacement for the line from a previous field...

Fixes #627.