### PR TITLE
Upstreaming tweaks from vhs-decode

### DIFF
--- a/tools/ld-analyse/chromadecoderconfigdialog.cpp
+++ b/tools/ld-analyse/chromadecoderconfigdialog.cpp
@@ -148,6 +148,8 @@ void ChromaDecoderConfigDialog::updateDialog()
 
     const bool isSourceNtsc = !isSourcePal;
 
+    ui->phaseCompCheckBox->setEnabled(isSourceNtsc);
+    ui->phaseCompCheckBox->setChecked(ntscConfiguration.phaseCompensation);
     ui->ntscFilter2DRadioButton->setEnabled(isSourceNtsc);
     ui->ntscFilter3DRadioButton->setEnabled(isSourceNtsc);
 
@@ -250,6 +252,12 @@ void ChromaDecoderConfigDialog::on_ntscFilterButtonGroup_buttonClicked(QAbstract
         ntscConfiguration.dimensions = 3;
     }
     updateDialog();
+    emit chromaDecoderConfigChanged();
+}
+
+void ChromaDecoderConfigDialog::on_phaseCompCheckBox_clicked()
+{
+    ntscConfiguration.phaseCompensation = ui->phaseCompCheckBox->isChecked();
     emit chromaDecoderConfigChanged();
 }
 

--- a/tools/ld-analyse/chromadecoderconfigdialog.h
+++ b/tools/ld-analyse/chromadecoderconfigdialog.h
@@ -60,6 +60,7 @@ private slots:
     void on_simplePALCheckBox_clicked();
 
     void on_ntscFilterButtonGroup_buttonClicked(QAbstractButton *button);
+    void on_phaseCompCheckBox_clicked();
     void on_adaptiveCheckBox_clicked();
     void on_showMapCheckBox_clicked();
     void on_whitePoint75CheckBox_clicked();

--- a/tools/ld-analyse/chromadecoderconfigdialog.ui
+++ b/tools/ld-analyse/chromadecoderconfigdialog.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>460</width>
-    <height>180</height>
+    <height>514</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -41,34 +41,34 @@
      </property>
     </widget>
    </item>
-       <item>
-        <widget class="QLabel" name="yNRLabel">
-         <property name="text">
-          <string>Luma noise reduction:</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QSlider" name="yNRHorizontalSlider">
-         <property name="orientation">
-          <enum>Qt::Horizontal</enum>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QLabel" name="yNRValueLabel">
-         <property name="text">
-          <string>0.00 IRE</string>
-         </property>
-         <property name="alignment">
-          <set>Qt::AlignCenter</set>
-         </property>
-        </widget>
-       </item>
+   <item>
+    <widget class="QLabel" name="yNRLabel">
+     <property name="text">
+      <string>Luma noise reduction:</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QSlider" name="yNRHorizontalSlider">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QLabel" name="yNRValueLabel">
+     <property name="text">
+      <string>0.00 IRE</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignCenter</set>
+     </property>
+    </widget>
+   </item>
    <item>
     <widget class="QTabWidget" name="standardTabs">
      <property name="currentIndex">
-      <number>0</number>
+      <number>1</number>
      </property>
      <widget class="QWidget" name="palTab">
       <attribute name="title">
@@ -283,6 +283,13 @@
         </spacer>
        </item>
        <item>
+        <widget class="QCheckBox" name="phaseCompCheckBox">
+         <property name="text">
+          <string>Phase compensating decoder</string>
+         </property>
+        </widget>
+       </item>
+       <item>
         <widget class="QCheckBox" name="adaptiveCheckBox">
          <property name="text">
           <string>Enable adaptive filter</string>
@@ -402,7 +409,7 @@
  <resources/>
  <connections/>
  <buttongroups>
-  <buttongroup name="ntscFilterButtonGroup"/>
   <buttongroup name="palFilterButtonGroup"/>
+  <buttongroup name="ntscFilterButtonGroup"/>
  </buttongroups>
 </ui>

--- a/tools/ld-chroma-decoder/comb.cpp
+++ b/tools/ld-chroma-decoder/comb.cpp
@@ -589,8 +589,10 @@ void Comb::FrameBuffer::splitIQlocked()
             const auto tq = (lsin * info.bsin + lcos * info.bcos);
             // Invert Q get the correct I/Q vector.
             // Don't need to rotate 33 degrees as we already did that on the burst phase.
-            yiqBuffer[lineNumber][h].i = ti;
-            yiqBuffer[lineNumber][h].q = -tq;
+            // TODO: Needed to shift the chroma 1 sample to the right to get it to line up
+            // may not get the first pixel in each line correct because of this.
+            yiqBuffer[lineNumber][h + 1].i = ti;
+            yiqBuffer[lineNumber][h + 1].q = -tq;
             // Subtract the split chroma part from the luma signal.
             yiqBuffer[lineNumber][h].y = line[h] - val;
         }

--- a/tools/ld-chroma-decoder/comb.h
+++ b/tools/ld-chroma-decoder/comb.h
@@ -55,7 +55,8 @@ public:
         qint32 dimensions = 2;
         bool adaptive = true;
         bool showMap = false;
-        Decoder::PixelFormat pixelFormat = Decoder::PixelFormat::RGB48;
+        bool phaseCompensation = false;
+	Decoder::PixelFormat pixelFormat = Decoder::PixelFormat::RGB48;
         bool outputYCbCr = false;
         bool outputY4m = false;
 
@@ -98,7 +99,9 @@ private:
         void split3D(const FrameBuffer &previousFrame, const FrameBuffer &nextFrame);
 
         void splitIQ();
+        void splitIQlocked();
         void filterIQ();
+        void filterIQFull();
         void adjustY();
 
         void doCNR();
@@ -126,7 +129,7 @@ private:
         qint32 secondFieldPhaseID;
 
         // 1D, 2D and 3D-filtered chroma samples
-        struct {
+        struct Sample {
             double pixel[MAX_HEIGHT][MAX_WIDTH];
         } clpbuffer[3];
 

--- a/tools/ld-chroma-decoder/main.cpp
+++ b/tools/ld-chroma-decoder/main.cpp
@@ -229,6 +229,16 @@ int main(int argc, char *argv[])
                                       QCoreApplication::translate("main", "Transform: Overlay the input and output FFTs"));
     parser.addOption(showFFTsOption);
 
+    // Option to use phase compensating decoder
+    QCommandLineOption ntscPhaseComp(QStringList() << "ntsc-phase-comp",
+                                      QCoreApplication::translate("main", "Use NTSC QADM decoder taking burst phase into account (BETA)"));
+    parser.addOption(ntscPhaseComp);
+
+    // Option to use chroma post-filter
+    QCommandLineOption colorLPF(QStringList() << "color-lpf",
+                                      QCoreApplication::translate("main", "NTSC: Use Chroma post-filter"));
+    parser.addOption(colorLPF);
+
     // -- Positional arguments --
 
     // Positional argument to specify input video file
@@ -418,6 +428,14 @@ int main(int argc, char *argv[])
             qCritical("YUV output not available when showFFT is enabled");
             return -1;
         }
+    }
+
+    if (parser.isSet(ntscPhaseComp)) {
+        combConfig.phaseCompensation = true;
+    }
+
+    if (parser.isSet(colorLPF)) {
+        combConfig.colorlpf = true;
     }
 
     // Work out the metadata filename


### PR DESCRIPTION
Chroma decoder and convenience tweaks from vhs-decode fork - thought I'd upstream to keep somewhat in sync.

- Try loading a <file>.tbc.json if loading a <file>_chroma.tbc file and <file>_chroma.tbc.json doesn't exist
- Add ntsc-phase-comp decoder and options for it in ld-analyse and auto-enable on loading _chroma.tbc
  - Not sure why but had to rotate phase 10 degrees for it to look correct compared to normal decoder.
  - Chroma ends up 1 px off position relative to normal one but not sure which is actually correct, otherwise it's simple enough to compensate for
- chroma_lpf option in ld-chroma-decoder to enable the option, already present in ld-analyse (ended up not needing it but left it in)