### PR TITLE
Disable ld-analyse's NTSC 1D filter radio button properly

### DIFF
--- a/tools/ld-analyse/chromadecoderconfigdialog.cpp
+++ b/tools/ld-analyse/chromadecoderconfigdialog.cpp
@@ -148,6 +148,7 @@ void ChromaDecoderConfigDialog::updateDialog()
 
     const bool isSourceNtsc = !isSourcePal;
 
+    ui->ntscFilter1DRadioButton->setEnabled(isSourceNtsc);
     ui->ntscFilter2DRadioButton->setEnabled(isSourceNtsc);
     ui->ntscFilter3DRadioButton->setEnabled(isSourceNtsc);
 


### PR DESCRIPTION
I missed this line when I added the 1D option in 036f5d8c0758714e233355467d750e3f3a9939dd, so currently it stays enabled in PAL mode. The fix is trivial.