### PR TITLE
Show the current chroma decoder's output on the ld-analyse scope

### DIFF
--- a/tools/ld-analyse/mainwindow.cpp
+++ b/tools/ld-analyse/mainwindow.cpp
@@ -873,8 +873,13 @@ void MainWindow::chromaDecoderConfigChangedSignalHandler()
                                      chromaDecoderConfigDialog->getNtscConfiguration(),
                                      chromaDecoderConfigDialog->getOutputConfiguration());
 
-    // Update the frame viewer;
+    // Update the frame viewer
     updateFrameViewer();
+
+    // If the scope window is open, update it too
+    if (oscilloscopeDialog->isVisible()) {
+        updateOscilloscopeDialogue(lastScopeLine, lastScopeDot);
+    }
 }
 
 // TbcSource class signal handlers ------------------------------------------------------------------------------------

--- a/tools/ld-analyse/mainwindow.cpp
+++ b/tools/ld-analyse/mainwindow.cpp
@@ -274,15 +274,18 @@ void MainWindow::updateGuiUnloaded()
 
 // Frame display methods ----------------------------------------------------------------------------------------------
 
-// Method to display a sequential frame
+// Update the UI and displays when currentFrameNumber has changed
 void MainWindow::showFrame()
 {
+    // Load the frame
+    tbcSource.loadFrame(currentFrameNumber);
+
     // Show the field numbers
-    fieldNumberStatus.setText(" -  Fields: " + QString::number(tbcSource.getFirstFieldNumber(currentFrameNumber)) + "/" +
-                              QString::number(tbcSource.getSecondFieldNumber(currentFrameNumber)));
+    fieldNumberStatus.setText(" -  Fields: " + QString::number(tbcSource.getFirstFieldNumber()) + "/" +
+                              QString::number(tbcSource.getSecondFieldNumber()));
 
     // If there are dropouts in the frame, highlight the show dropouts button
-    if (tbcSource.getIsDropoutPresent(currentFrameNumber)) {
+    if (tbcSource.getIsDropoutPresent()) {
         QPalette tempPalette = buttonPalette;
         tempPalette.setColor(QPalette::Button, QColor(Qt::lightGray));
         ui->dropoutsPushButton->setAutoFillBackground(true);
@@ -295,8 +298,8 @@ void MainWindow::showFrame()
     }
 
     // Update the VBI dialogue
-    if (vbiDialog->isVisible()) vbiDialog->updateVbi(tbcSource.getFrameVbi(currentFrameNumber),
-                                                     tbcSource.getIsFrameVbiValid(currentFrameNumber)); 
+    if (vbiDialog->isVisible()) vbiDialog->updateVbi(tbcSource.getFrameVbi(),
+                                                     tbcSource.getIsFrameVbiValid());
 
     // Add the QImage to the QLabel in the dialogue
     ui->frameViewerLabel->clear();
@@ -312,7 +315,7 @@ void MainWindow::showFrame()
 
     // Update the closed caption dialog
     if (!tbcSource.getIsSourcePal()) {
-        closedCaptionDialog->addData(currentFrameNumber, tbcSource.getCcData0(currentFrameNumber), tbcSource.getCcData1(currentFrameNumber));
+        closedCaptionDialog->addData(currentFrameNumber, tbcSource.getCcData0(), tbcSource.getCcData1());
     }
     // QT Bug workaround for some macOS versions
     #if defined(Q_OS_MACOS)
@@ -323,7 +326,7 @@ void MainWindow::showFrame()
 // Redraw the frame viewer (for example, when scaleFactor has been changed)
 void MainWindow::updateFrameViewer()
 {
-    QImage frameImage = tbcSource.getFrameImage(currentFrameNumber);
+    QImage frameImage = tbcSource.getFrameImage();
 
     if (ui->mouseModePushButton->isChecked()) {
         // Create a painter object
@@ -391,7 +394,7 @@ void MainWindow::loadTbcFile(QString inputFileName)
 void MainWindow::updateOscilloscopeDialogue(qint32 scanLine, qint32 pictureDot)
 {
     // Update the oscilloscope dialogue
-    oscilloscopeDialog->showTraceImage(tbcSource.getScanLineData(currentFrameNumber, scanLine),
+    oscilloscopeDialog->showTraceImage(tbcSource.getScanLineData(scanLine),
                                        scanLine, pictureDot, tbcSource.getFrameHeight());
 }
 
@@ -451,7 +454,7 @@ void MainWindow::on_actionAbout_ld_analyse_triggered()
 void MainWindow::on_actionVBI_triggered()
 {
     // Show the VBI dialogue
-    vbiDialog->updateVbi(tbcSource.getFrameVbi(currentFrameNumber), tbcSource.getIsFrameVbiValid(currentFrameNumber));
+    vbiDialog->updateVbi(tbcSource.getFrameVbi(), tbcSource.getIsFrameVbiValid());
     vbiDialog->show();
 }
 
@@ -505,7 +508,7 @@ void MainWindow::on_actionSave_frame_as_PNG_triggered()
         qDebug() << "MainWindow::on_actionSave_frame_as_PNG_triggered(): Saving current frame as" << pngFilename;
 
         // Generate QImage for the current frame
-        QImage imageToSave = tbcSource.getFrameImage(currentFrameNumber);
+        QImage imageToSave = tbcSource.getFrameImage();
 
         // Change to 4:3 aspect ratio?
         if (aspect43On) {

--- a/tools/ld-analyse/oscilloscopedialog.cpp
+++ b/tools/ld-analyse/oscilloscopedialog.cpp
@@ -25,6 +25,8 @@
 #include "oscilloscopedialog.h"
 #include "ui_oscilloscopedialog.h"
 
+#include <cassert>
+
 OscilloscopeDialog::OscilloscopeDialog(QWidget *parent) :
     QDialog(parent),
     ui(new Ui::OscilloscopeDialog)
@@ -107,10 +109,12 @@ QImage OscilloscopeDialog::getFieldLineTraceImage(TbcSource::ScanLineData scanLi
     QPainter scopePainter;
 
     // Ensure we have valid data
-    if (scanLineData.data.empty()) {
+    if (scanLineData.composite.empty()) {
         qWarning() << "Did not get valid data for the requested field!";
         return scopeImage;
     }
+    assert(scanLineData.composite.size() == scanLineData.fieldWidth);
+    assert(scanLineData.luma.size() == scanLineData.fieldWidth);
 
     // Set the background to black
     scopeImage.fill(Qt::black);
@@ -146,51 +150,19 @@ QImage OscilloscopeDialog::getFieldLineTraceImage(TbcSource::ScanLineData scanLi
     scopePainter.drawLine(scanLineData.activeVideoEnd, 0, scanLineData.activeVideoEnd, scopeHeight);
 
     // Get the signal data
-    QVector<qint32> signalDataYC; // Luminance (Y) and Chrominance (C) combined
-    QVector<bool> dropOutYC; // Drop out locations within YC data
-    QVector<qint32> signalDataY; // Luminance (Y) only
-    QVector<qint32> signalDataC; // Chrominance (C) only
-    signalDataYC.resize(scanLineData.fieldWidth);
-    dropOutYC.resize(scanLineData.fieldWidth);
-    signalDataY.resize(scanLineData.fieldWidth);
-    signalDataC.resize(scanLineData.fieldWidth);
-
-    // To extract Y from PAL, a LPF of 3.8MHz is required
-    // To extract Y from NTSC, a LPF of 3.0MHz is required
-    // To extract C from PAL, a HPF of 3.8MHz is required
-    // To extract C from NTSC, a HPF of 3.0MHz is required
-
-    // Get the YC data
-    for (qint32 xPosition = 0; xPosition < scanLineData.fieldWidth; xPosition++) {
-        // Get the data for the current pixel
-        signalDataYC[xPosition] = scanLineData.data[xPosition];
-        dropOutYC[xPosition] = scanLineData.isDropout[xPosition];
-    }
-
-    if (showY || showC) {
-        // Filter out the Y data (using the filters library)
-        Filters filters;
-
-        if (scanLineData.isSourcePal) {
-            signalDataY = signalDataYC;
-            filters.palLumaFirFilter(signalDataY);
-        } else {
-            signalDataY = signalDataYC;
-            filters.ntscLumaFirFilter(signalDataY);
-        }
-    }
+    const QVector<qint32> &signalDataYC = scanLineData.composite; // Composite - luma (Y) and chroma (C) combined
+    const QVector<bool> &dropOutYC = scanLineData.isDropout; // Drop out locations within YC data
+    const QVector<qint32> &signalDataY = scanLineData.luma; // Luma (Y) only
+    QVector<qint32> signalDataC(scanLineData.fieldWidth); // Chroma (C) only
 
     if (showC) {
-        for (qint32 i = 0; i < signalDataYC.size(); i++) {
+        for (qint32 i = 0; i < scanLineData.fieldWidth; i++) {
             signalDataC[i] = signalDataYC[i] - signalDataY[i];
         }
     }
 
     // Draw the scope image
-    scopePainter.setPen(Qt::yellow);
     qint32 lastSignalLevelYC = 0;
-    qint32 lastSignalLevelY = 0;
-    qint32 lastSignalLevelC = 0;
     for (qint32 xPosition = 0; xPosition < scanLineData.fieldWidth; xPosition++) {
         if (showYC) {
             // Scale (to 0-512) and invert
@@ -211,35 +183,36 @@ QImage OscilloscopeDialog::getFieldLineTraceImage(TbcSource::ScanLineData scanLi
             // Remember the current signal's level
             lastSignalLevelYC = signalLevelYC;
         }
+    }
 
-        if (showC) {
+    // Draw the Y/C traces, for the active region only
+    qint32 lastSignalLevelY = 0;
+    qint32 lastSignalLevelC = 0;
+    for (qint32 xPosition = scanLineData.activeVideoStart; xPosition < scanLineData.activeVideoEnd; xPosition++) {
+        if (showC && scanLineData.isActiveLine) {
             // Scale (to 0-512) and invert
             qint32 signalLevelC = (scopeHeight - (signalDataC[xPosition] / scopeScale)) - (scopeHeight - midPointIre);
 
-            if (xPosition != 0) {
+            if (xPosition != scanLineData.activeVideoStart) {
                 // Draw a line from the last Y signal to the current one (signal green, out of range in yellow)
-                if (xPosition > scanLineData.colourBurstEnd && xPosition < scanLineData.activeVideoEnd) {
-                    if (signalLevelC > blackIre || signalLevelC < whiteIre) scopePainter.setPen(Qt::yellow);
-                    else scopePainter.setPen(Qt::green);
-                    scopePainter.drawLine(xPosition - 1, lastSignalLevelC, xPosition, signalLevelC);
-                }
+                if (signalLevelC > blackIre || signalLevelC < whiteIre) scopePainter.setPen(Qt::yellow);
+                else scopePainter.setPen(Qt::green);
+                scopePainter.drawLine(xPosition - 1, lastSignalLevelC, xPosition, signalLevelC);
             }
 
             // Remember the current signal's level
             lastSignalLevelC = signalLevelC;
         }
 
-        if (showY) {
+        if (showY && scanLineData.isActiveLine) {
             // Scale (to 0-512) and invert
             qint32 signalLevelY = scopeHeight - (signalDataY[xPosition] / scopeScale);
 
-            if (xPosition != 0) {
+            if (xPosition != scanLineData.activeVideoStart) {
                 // Draw a line from the last Y signal to the current one (signal white, out of range in red)
-                if (xPosition > scanLineData.colourBurstEnd && xPosition < scanLineData.activeVideoEnd) {
-                    if (signalLevelY > blackIre || signalLevelY < whiteIre) scopePainter.setPen(Qt::red);
-                    else scopePainter.setPen(Qt::white);
-                    scopePainter.drawLine(xPosition - 1, lastSignalLevelY, xPosition, signalLevelY);
-                }
+                if (signalLevelY > blackIre || signalLevelY < whiteIre) scopePainter.setPen(Qt::red);
+                else scopePainter.setPen(Qt::white);
+                scopePainter.drawLine(xPosition - 1, lastSignalLevelY, xPosition, signalLevelY);
             }
 
             // Remember the current signal's level

--- a/tools/ld-analyse/oscilloscopedialog.cpp
+++ b/tools/ld-analyse/oscilloscopedialog.cpp
@@ -98,16 +98,16 @@ QImage OscilloscopeDialog::getFieldLineTraceImage(TbcSource::ScanLineData scanLi
 
     // These are fixed, but may be changed to options later
     qint32 scopeHeight = 2048;
-    scopeWidth = scanLineData.data.size();
+    scopeWidth = scanLineData.fieldWidth;
 
     qint32 scopeScale = 65536 / scopeHeight;
 
     // Define image with width, height and format
-    QImage scopeImage(scanLineData.data.size(), scopeHeight, QImage::Format_RGB888);
+    QImage scopeImage(scopeWidth, scopeHeight, QImage::Format_RGB888);
     QPainter scopePainter;
 
     // Ensure we have valid data
-    if (scanLineData.data.isEmpty()) {
+    if (scanLineData.data.empty()) {
         qWarning() << "Did not get valid data for the requested field!";
         return scopeImage;
     }
@@ -128,13 +128,13 @@ QImage OscilloscopeDialog::getFieldLineTraceImage(TbcSource::ScanLineData scanLi
     midPointIre = scopeHeight - (midPointIre / scopeScale);
 
     scopePainter.setPen(Qt::white);
-    scopePainter.drawLine(0, blackIre, scanLineData.data.size(), blackIre);
-    scopePainter.drawLine(0, whiteIre, scanLineData.data.size(), whiteIre);
+    scopePainter.drawLine(0, blackIre, scanLineData.fieldWidth, blackIre);
+    scopePainter.drawLine(0, whiteIre, scanLineData.fieldWidth, whiteIre);
 
     // If showing C - draw the IRE mid-point
     if (showC) {
         scopePainter.setPen(Qt::gray);
-        scopePainter.drawLine(0, midPointIre, scanLineData.data.size(), midPointIre);
+        scopePainter.drawLine(0, midPointIre, scanLineData.fieldWidth, midPointIre);
     }
 
     // Draw the indicator lines
@@ -150,10 +150,10 @@ QImage OscilloscopeDialog::getFieldLineTraceImage(TbcSource::ScanLineData scanLi
     QVector<bool> dropOutYC; // Drop out locations within YC data
     QVector<qint32> signalDataY; // Luminance (Y) only
     QVector<qint32> signalDataC; // Chrominance (C) only
-    signalDataYC.resize(scanLineData.data.size());
-    dropOutYC.resize(scanLineData.data.size());
-    signalDataY.resize(scanLineData.data.size());
-    signalDataC.resize(scanLineData.data.size());
+    signalDataYC.resize(scanLineData.fieldWidth);
+    dropOutYC.resize(scanLineData.fieldWidth);
+    signalDataY.resize(scanLineData.fieldWidth);
+    signalDataC.resize(scanLineData.fieldWidth);
 
     // To extract Y from PAL, a LPF of 3.8MHz is required
     // To extract Y from NTSC, a LPF of 3.0MHz is required
@@ -161,7 +161,7 @@ QImage OscilloscopeDialog::getFieldLineTraceImage(TbcSource::ScanLineData scanLi
     // To extract C from NTSC, a HPF of 3.0MHz is required
 
     // Get the YC data
-    for (qint32 xPosition = 0; xPosition < scanLineData.data.size(); xPosition++) {
+    for (qint32 xPosition = 0; xPosition < scanLineData.fieldWidth; xPosition++) {
         // Get the data for the current pixel
         signalDataYC[xPosition] = scanLineData.data[xPosition];
         dropOutYC[xPosition] = scanLineData.isDropout[xPosition];
@@ -191,7 +191,7 @@ QImage OscilloscopeDialog::getFieldLineTraceImage(TbcSource::ScanLineData scanLi
     qint32 lastSignalLevelYC = 0;
     qint32 lastSignalLevelY = 0;
     qint32 lastSignalLevelC = 0;
-    for (qint32 xPosition = 0; xPosition < scanLineData.data.size(); xPosition++) {
+    for (qint32 xPosition = 0; xPosition < scanLineData.fieldWidth; xPosition++) {
         if (showYC) {
             // Scale (to 0-512) and invert
             qint32 signalLevelYC = scopeHeight - (signalDataYC[xPosition] / scopeScale);

--- a/tools/ld-analyse/oscilloscopedialog.h
+++ b/tools/ld-analyse/oscilloscopedialog.h
@@ -34,7 +34,6 @@
 #include "sourcevideo.h"
 #include "lddecodemetadata.h"
 #include "tbcsource.h"
-#include "filters.h"
 
 namespace Ui {
 class OscilloscopeDialog;

--- a/tools/ld-analyse/tbcsource.cpp
+++ b/tools/ld-analyse/tbcsource.cpp
@@ -310,20 +310,31 @@ TbcSource::ScanLineData TbcSource::getScanLineData(qint32 scanLine)
     scanLineData.activeVideoEnd = videoParameters.activeVideoEnd;
     scanLineData.isSourcePal = videoParameters.isSourcePal;
 
-    // Load SourceFields for the current frame
+    // Is this line part of the active region?
+    scanLineData.isActiveLine = (scanLine - 1) >= videoParameters.firstActiveFrameLine
+                                && (scanLine -1) < videoParameters.lastActiveFrameLine;
+
+    // Load and decode SourceFields for the current frame
     loadInputFields();
+    decodeFrame();
 
     // Get the field video and dropout data
     const SourceVideo::Data &fieldData = isFieldTop ? inputFields[inputStartIndex].data
                                                     : inputFields[inputStartIndex + 1].data;
+    const ComponentFrame &componentFrame = componentFrames[0];
     DropOuts &dropouts = isFieldTop ? firstField.dropOuts
                                     : secondField.dropOuts;
 
-    scanLineData.data.resize(videoParameters.fieldWidth);
+    scanLineData.composite.resize(videoParameters.fieldWidth);
+    scanLineData.luma.resize(videoParameters.fieldWidth);
     scanLineData.isDropout.resize(videoParameters.fieldWidth);
+
     for (qint32 xPosition = 0; xPosition < videoParameters.fieldWidth; xPosition++) {
-        // Get the 16-bit YC value for the current pixel (frame data is numbered 0-624 or 0-524)
-        scanLineData.data[xPosition] = fieldData[((fieldLine - 1) * videoParameters.fieldWidth) + xPosition];
+        // Get the 16-bit composite value for the current pixel (frame data is numbered 0-624 or 0-524)
+        scanLineData.composite[xPosition] = fieldData[((fieldLine - 1) * videoParameters.fieldWidth) + xPosition];
+
+        // Get the decoded luma value for the current pixel (only computed in the active region)
+        scanLineData.luma[xPosition] = static_cast<qint32>(componentFrame.y(scanLine - 1)[xPosition]);
 
         scanLineData.isDropout[xPosition] = false;
         for (qint32 doCount = 0; doCount < dropouts.size(); doCount++) {

--- a/tools/ld-analyse/tbcsource.cpp
+++ b/tools/ld-analyse/tbcsource.cpp
@@ -616,8 +616,8 @@ QImage TbcSource::generateQImage(qint32 frameNumber)
     return frameImage;
 }
 
-// Generate the data points for the Drop-out and SNR analysis graphs
-// We do these both at the same time to reduce calls to the metadata
+// Generate the data points for the Drop-out and SNR analysis graphs, and the chapter map.
+// We do these all at the same time to reduce calls to the metadata.
 void TbcSource::generateData()
 {
     dropoutGraphData.clear();
@@ -628,7 +628,13 @@ void TbcSource::generateData()
     blackSnrGraphData.resize(ldDecodeMetaData.getNumberOfFrames());
     whiteSnrGraphData.resize(ldDecodeMetaData.getNumberOfFrames());
 
-    for (qint32 frameNumber = 0; frameNumber < ldDecodeMetaData.getNumberOfFrames(); frameNumber++) {
+    bool ignoreChapters = false;
+    qint32 lastChapter = -1;
+    qint32 giveUpCounter = 0;
+    chapterMap.clear();
+
+    const qint32 numFrames = ldDecodeMetaData.getNumberOfFrames();
+    for (qint32 frameNumber = 0; frameNumber < numFrames; frameNumber++) {
         qreal doLength = 0;
         qreal blackSnrTotal = 0;
         qreal whiteSnrTotal = 0;
@@ -685,6 +691,27 @@ void TbcSource::generateData()
         dropoutGraphData[frameNumber] = doLength;
         blackSnrGraphData[frameNumber] = blackSnrTotal / blackSnrPoints; // Calc average for frame
         whiteSnrGraphData[frameNumber] = whiteSnrTotal / whiteSnrPoints; // Calc average for frame
+
+        if (ignoreChapters) continue;
+
+        // Decode the VBI
+        VbiDecoder::Vbi vbi = vbiDecoder.decodeFrame(
+            firstField.vbi.vbiData[0], firstField.vbi.vbiData[1], firstField.vbi.vbiData[2],
+            secondField.vbi.vbiData[0], secondField.vbi.vbiData[1], secondField.vbi.vbiData[2]);
+
+        // Get the chapter number
+        qint32 currentChapter = vbi.chNo;
+        if (currentChapter != -1) {
+            if (currentChapter != lastChapter) {
+                lastChapter = currentChapter;
+                chapterMap.append(frameNumber);
+            } else giveUpCounter++;
+        }
+
+        if (frameNumber == 100 && giveUpCounter < 50) {
+            qDebug() << "Not seeing valid chapter numbers, giving up chapter mapping";
+            ignoreChapters = true;
+        }
     }
 }
 
@@ -731,30 +758,9 @@ void TbcSource::startBackgroundLoad(QString sourceFilename)
         ntscColour.updateConfiguration(videoParameters, ntscConfiguration);
     }
 
-    // Generate the graph data for the source
-    emit busyLoading("Generating graph data...");
+    // Analyse the metadata
+    emit busyLoading("Generating graph data and chapter map...");
     generateData();
-
-    // Generate a chapter map (used by the chapter skip
-    // forwards and backwards buttons)
-    emit busyLoading("Generating VBI chapter map...");
-    qint32 lastChapter = -1;
-    qint32 giveUpCounter = 0;
-    chapterMap.clear();
-    for (qint32 i = 1; i <= getNumberOfFrames(); i++) {
-        qint32 currentChapter = getFrameVbi(i).chNo;
-        if (currentChapter != -1) {
-            if (currentChapter != lastChapter) {
-                lastChapter = currentChapter;
-                chapterMap.append(i);
-            } else giveUpCounter++;
-        }
-
-        if (i == 100 && giveUpCounter < 50) {
-            qDebug() << "Not seeing valid chapter numbers, giving up chapter mapping";
-            break;
-        }
-    }
 }
 
 void TbcSource::finishBackgroundLoad()

--- a/tools/ld-analyse/tbcsource.cpp
+++ b/tools/ld-analyse/tbcsource.cpp
@@ -29,13 +29,7 @@
 
 TbcSource::TbcSource(QObject *parent) : QObject(parent)
 {
-    // Default frame image options
-    chromaOn = false;
-    dropoutsOn = false;
-    reverseFoOn = false;
-    sourceReady = false;
-    loadedFrameNumber = -1;
-    frameCacheValid = false;
+    resetState();
 
     // Configure the chroma decoder
     palConfiguration = palColour.getConfiguration();
@@ -50,13 +44,7 @@ TbcSource::TbcSource(QObject *parent) : QObject(parent)
 // Method to load a TBC source file
 void TbcSource::loadSource(QString sourceFilename)
 {
-    // Default frame options
-    chromaOn = false;
-    dropoutsOn = false;
-    reverseFoOn = false;
-    sourceReady = false;
-    loadedFrameNumber = -1;
-    frameCacheValid = false;
+    resetState();
 
     // Set the current file name
     QFileInfo inFileInfo(sourceFilename);
@@ -74,7 +62,7 @@ void TbcSource::loadSource(QString sourceFilename)
 void TbcSource::unloadSource()
 {
     sourceVideo.close();
-    sourceReady = false;
+    resetState();
 }
 
 // Method returns true is a TBC source is loaded
@@ -482,6 +470,20 @@ qint32 TbcSource::startOfChapter(qint32 currentFrameNumber)
 
 
 // Private methods ----------------------------------------------------------------------------------------------------
+
+// Re-initialise state for a new source video
+void TbcSource::resetState()
+{
+    // Default frame image options
+    chromaOn = false;
+    dropoutsOn = false;
+    reverseFoOn = false;
+    sourceReady = false;
+
+    // Cache state
+    loadedFrameNumber = -1;
+    frameCacheValid = false;
+}
 
 // Mark the cached frame as invalid
 void TbcSource::invalidateFrameCache()

--- a/tools/ld-analyse/tbcsource.cpp
+++ b/tools/ld-analyse/tbcsource.cpp
@@ -303,6 +303,7 @@ TbcSource::ScanLineData TbcSource::getScanLineData(qint32 scanLine)
     // Set the video parameters
     scanLineData.blackIre = videoParameters.black16bIre;
     scanLineData.whiteIre = videoParameters.white16bIre;
+    scanLineData.fieldWidth = videoParameters.fieldWidth;
     scanLineData.colourBurstStart = videoParameters.colourBurstStart;
     scanLineData.colourBurstEnd = videoParameters.colourBurstEnd;
     scanLineData.activeVideoStart = videoParameters.activeVideoStart;

--- a/tools/ld-analyse/tbcsource.cpp
+++ b/tools/ld-analyse/tbcsource.cpp
@@ -29,13 +29,13 @@
 
 TbcSource::TbcSource(QObject *parent) : QObject(parent)
 {
-    invalidateFrameCache();
-
     // Default frame image options
     chromaOn = false;
     dropoutsOn = false;
     reverseFoOn = false;
     sourceReady = false;
+    loadedFrameNumber = -1;
+    frameCacheValid = false;
 
     // Configure the chroma decoder
     palConfiguration = palColour.getConfiguration();
@@ -55,7 +55,8 @@ void TbcSource::loadSource(QString sourceFilename)
     dropoutsOn = false;
     reverseFoOn = false;
     sourceReady = false;
-    frameCacheFrameNumber = -1;
+    loadedFrameNumber = -1;
+    frameCacheValid = false;
 
     // Set the current file name
     QFileInfo inFileInfo(sourceFilename);
@@ -132,18 +133,17 @@ bool TbcSource::getFieldOrder()
     return reverseFoOn;
 }
 
-// Method to get a QImage from a frame number
-QImage TbcSource::getFrameImage(qint32 frameNumber)
+// Load the metadata for a frame
+void TbcSource::loadFrame(qint32 frameNumber)
 {
-    if (!sourceReady) return QImage();
-
-    // Check cached QImage
-    if (frameCacheFrameNumber == frameNumber) return frameCache;
-    frameCacheFrameNumber = frameNumber;
+    // If there's no source, or we've already loaded that frame, nothing to do
+    if (!sourceReady || loadedFrameNumber == frameNumber) return;
+    loadedFrameNumber = frameNumber;
+    invalidateFrameCache();
 
     // Get the required field numbers
-    qint32 firstFieldNumber = ldDecodeMetaData.getFirstFieldNumber(frameNumber);
-    qint32 secondFieldNumber = ldDecodeMetaData.getSecondFieldNumber(frameNumber);
+    firstFieldNumber = ldDecodeMetaData.getFirstFieldNumber(frameNumber);
+    secondFieldNumber = ldDecodeMetaData.getSecondFieldNumber(frameNumber);
 
     // Make sure we have a valid response from the frame determination
     if (firstFieldNumber == -1 || secondFieldNumber == -1) {
@@ -156,15 +156,24 @@ QImage TbcSource::getFrameImage(qint32 frameNumber)
             firstFieldNumber = ldDecodeMetaData.getFirstFieldNumber(frameNumber);
             secondFieldNumber = ldDecodeMetaData.getSecondFieldNumber(frameNumber);
         }
-        qDebug() << "TbcSource::getFrameImage(): Jumping back one frame due to error";
+        qDebug() << "TbcSource::loadFrame(): Jumping back one frame due to error";
     }
 
-    // Get a QImage for the frame
-    QImage frameImage = generateQImage(frameNumber);
-
     // Get the field metadata
-    LdDecodeMetaData::Field firstField = ldDecodeMetaData.getField(firstFieldNumber);
-    LdDecodeMetaData::Field secondField = ldDecodeMetaData.getField(secondFieldNumber);
+    firstField = ldDecodeMetaData.getField(firstFieldNumber);
+    secondField = ldDecodeMetaData.getField(secondFieldNumber);
+}
+
+// Method to get a QImage from a frame number
+QImage TbcSource::getFrameImage()
+{
+    if (loadedFrameNumber == -1) return QImage();
+
+    // Check cached QImage
+    if (frameCacheValid) return frameCache;
+
+    // Get a QImage for the frame
+    QImage frameImage = generateQImage();
 
     // Highlight dropouts
     if (dropoutsOn) {
@@ -197,6 +206,7 @@ QImage TbcSource::getFrameImage(qint32 frameNumber)
     }
 
     frameCache = frameImage;
+    frameCacheValid = true;
     return frameImage;
 }
 
@@ -271,30 +281,19 @@ qint32 TbcSource::getGraphDataSize()
 }
 
 // Method returns true if frame contains dropouts
-bool TbcSource::getIsDropoutPresent(qint32 frameNumber)
+bool TbcSource::getIsDropoutPresent()
 {
-    if (!sourceReady) return false;
+    if (loadedFrameNumber == -1) return false;
 
-    bool dropOutsPresent = false;
-
-    // Determine the first and second fields for the frame number
-    qint32 firstFieldNumber = ldDecodeMetaData.getFirstFieldNumber(frameNumber);
-    qint32 secondFieldNumber = ldDecodeMetaData.getSecondFieldNumber(frameNumber);
-
-    if (ldDecodeMetaData.getFieldDropOuts(firstFieldNumber).size() > 0) dropOutsPresent = true;
-    if (ldDecodeMetaData.getFieldDropOuts(secondFieldNumber).size() > 0) dropOutsPresent = true;
-
-    return dropOutsPresent;
+    if (firstField.dropOuts.size() > 0) return true;
+    if (secondField.dropOuts.size() > 0) return true;
+    return false;
 }
 
-// Get scan line data from a frame
-TbcSource::ScanLineData TbcSource::getScanLineData(qint32 frameNumber, qint32 scanLine)
+// Get scan line data from the frame
+TbcSource::ScanLineData TbcSource::getScanLineData(qint32 scanLine)
 {
-    if (!sourceReady) return ScanLineData();
-
-    // Determine the first and second fields for the frame number
-    qint32 firstFieldNumber = ldDecodeMetaData.getFirstFieldNumber(frameNumber);
-    qint32 secondFieldNumber = ldDecodeMetaData.getSecondFieldNumber(frameNumber);
+    if (loadedFrameNumber == -1) return ScanLineData();
 
     ScanLineData scanLineData;
     LdDecodeMetaData::VideoParameters videoParameters = ldDecodeMetaData.getVideoParameters();
@@ -326,10 +325,10 @@ TbcSource::ScanLineData TbcSource::getScanLineData(qint32 frameNumber, qint32 sc
     DropOuts dropouts;
     if (isFieldTop) {
         fieldData = sourceVideo.getVideoField(firstFieldNumber);
-        dropouts = ldDecodeMetaData.getFieldDropOuts(firstFieldNumber);
+        dropouts = firstField.dropOuts;
     } else {
         fieldData = sourceVideo.getVideoField(secondFieldNumber);
-        dropouts = ldDecodeMetaData.getFieldDropOuts(secondFieldNumber);
+        dropouts = secondField.dropOuts;
     }
 
     scanLineData.data.resize(videoParameters.fieldWidth);
@@ -349,69 +348,51 @@ TbcSource::ScanLineData TbcSource::getScanLineData(qint32 frameNumber, qint32 sc
     return scanLineData;
 }
 
-// Method to return the decoded VBI data for a frame
-VbiDecoder::Vbi TbcSource::getFrameVbi(qint32 frameNumber)
+// Method to return the decoded VBI data for the frame
+VbiDecoder::Vbi TbcSource::getFrameVbi()
 {
-    if (!sourceReady) return VbiDecoder::Vbi();
+    if (loadedFrameNumber == -1) return VbiDecoder::Vbi();
 
-    // Get the field VBI data
-    LdDecodeMetaData::Vbi firstField = ldDecodeMetaData.getFieldVbi(ldDecodeMetaData.getFirstFieldNumber(frameNumber));
-    LdDecodeMetaData::Vbi secondField = ldDecodeMetaData.getFieldVbi(ldDecodeMetaData.getSecondFieldNumber(frameNumber));
-
-    return vbiDecoder.decodeFrame(firstField.vbiData[0], firstField.vbiData[1], firstField.vbiData[2],
-            secondField.vbiData[0], secondField.vbiData[1], secondField.vbiData[2]);
+    return vbiDecoder.decodeFrame(firstField.vbi.vbiData[0], firstField.vbi.vbiData[1], firstField.vbi.vbiData[2],
+                                  secondField.vbi.vbiData[0], secondField.vbi.vbiData[1], secondField.vbi.vbiData[2]);
 }
 
-// Method returns true if the VBI is valid for the specified frame number
-bool TbcSource::getIsFrameVbiValid(qint32 frameNumber)
+// Method returns true if the VBI is valid for the frame
+bool TbcSource::getIsFrameVbiValid()
 {
-    if (!sourceReady) return false;
+    if (loadedFrameNumber == -1) return false;
 
-    // Get the field VBI data
-    LdDecodeMetaData::Vbi firstField = ldDecodeMetaData.getFieldVbi(ldDecodeMetaData.getFirstFieldNumber(frameNumber));
-    LdDecodeMetaData::Vbi secondField = ldDecodeMetaData.getFieldVbi(ldDecodeMetaData.getSecondFieldNumber(frameNumber));
-
-    if (firstField.vbiData[0] == -1 || firstField.vbiData[1] == -1 || firstField.vbiData[2] == -1) return false;
-    if (secondField.vbiData[0] == -1 || secondField.vbiData[1] == -1 || secondField.vbiData[2] == -1) return false;
+    if (firstField.vbi.vbiData[0] == -1 || firstField.vbi.vbiData[1] == -1 || firstField.vbi.vbiData[2] == -1) return false;
+    if (secondField.vbi.vbiData[0] == -1 || secondField.vbi.vbiData[1] == -1 || secondField.vbi.vbiData[2] == -1) return false;
 
     return true;
 }
 
-// Method to get the field number of the first field of the specified frame
-qint32 TbcSource::getFirstFieldNumber(qint32 frameNumber)
+// Method to get the field number of the first field of the frame
+qint32 TbcSource::getFirstFieldNumber()
 {
-    if (!sourceReady) return 0;
-
-    return ldDecodeMetaData.getFirstFieldNumber(frameNumber);
+    if (loadedFrameNumber == -1) return 0;
+    return firstFieldNumber;
 }
 
-// Method to get the field number of the second field of the specified frame
-qint32 TbcSource::getSecondFieldNumber(qint32 frameNumber)
+// Method to get the field number of the second field of the frame
+qint32 TbcSource::getSecondFieldNumber()
 {
-    if (!sourceReady) return 0;
-
-    return ldDecodeMetaData.getSecondFieldNumber(frameNumber);
+    if (loadedFrameNumber == -1) return 0;
+    return secondFieldNumber;
 }
 
-qint32 TbcSource::getCcData0(qint32 frameNumber)
+qint32 TbcSource::getCcData0()
 {
-    if (!sourceReady) return false;
-
-    // Get the field metadata
-    LdDecodeMetaData::Field firstField = ldDecodeMetaData.getField(ldDecodeMetaData.getFirstFieldNumber(frameNumber));
-    LdDecodeMetaData::Field secondField = ldDecodeMetaData.getField(ldDecodeMetaData.getSecondFieldNumber(frameNumber));
+    if (loadedFrameNumber == -1) return 0;
 
     if (firstField.ntsc.ccData0 != -1) return firstField.ntsc.ccData0;
     return secondField.ntsc.ccData0;
 }
 
-qint32 TbcSource::getCcData1(qint32 frameNumber)
+qint32 TbcSource::getCcData1()
 {
-    if (!sourceReady) return false;
-
-    // Get the field metadata
-    LdDecodeMetaData::Field firstField = ldDecodeMetaData.getField(ldDecodeMetaData.getFirstFieldNumber(frameNumber));
-    LdDecodeMetaData::Field secondField = ldDecodeMetaData.getField(ldDecodeMetaData.getSecondFieldNumber(frameNumber));
+    if (loadedFrameNumber == -1) return 0;
 
     if (firstField.ntsc.ccData1 != -1) return firstField.ntsc.ccData1;
     return secondField.ntsc.ccData1;
@@ -505,11 +486,11 @@ qint32 TbcSource::startOfChapter(qint32 currentFrameNumber)
 // Mark the cached frame as invalid
 void TbcSource::invalidateFrameCache()
 {
-    frameCacheFrameNumber = -1;
+    frameCacheValid = false;
 }
 
 // Method to create a QImage for a source video frame
-QImage TbcSource::generateQImage(qint32 frameNumber)
+QImage TbcSource::generateQImage()
 {
     // Get the metadata for the video parameters
     LdDecodeMetaData::VideoParameters videoParameters = ldDecodeMetaData.getVideoParameters();
@@ -519,10 +500,10 @@ QImage TbcSource::generateQImage(qint32 frameNumber)
 
     // Show debug information
     if (chromaOn) {
-        qDebug().nospace() << "TbcSource::generateQImage(): Generating a chroma image from frame " << frameNumber <<
+        qDebug().nospace() << "TbcSource::generateQImage(): Generating a chroma image from frame " << loadedFrameNumber <<
                     " (" << videoParameters.fieldWidth << "x" << frameHeight << ")";
     } else {
-        qDebug().nospace() << "TbcSource::generateQImage(): Generating a source image from frame " << frameNumber <<
+        qDebug().nospace() << "TbcSource::generateQImage(): Generating a source image from frame " << loadedFrameNumber <<
                     " (" << videoParameters.fieldWidth << "x" << frameHeight << ")";
     }
 
@@ -547,7 +528,7 @@ QImage TbcSource::generateQImage(qint32 frameNumber)
     QVector<SourceField> inputFields;
     qint32 startIndex, endIndex;
     SourceField::loadFields(sourceVideo, ldDecodeMetaData,
-                            frameNumber, 1, lookBehind, lookAhead,
+                            loadedFrameNumber, 1, lookBehind, lookAhead,
                             inputFields, startIndex, endIndex);
 
     if (chromaOn) {

--- a/tools/ld-analyse/tbcsource.h
+++ b/tools/ld-analyse/tbcsource.h
@@ -54,6 +54,7 @@ public:
         QVector<bool> isDropout;
         qint32 blackIre;
         qint32 whiteIre;
+        qint32 fieldWidth;
         qint32 colourBurstStart;
         qint32 colourBurstEnd;
         qint32 activeVideoStart;

--- a/tools/ld-analyse/tbcsource.h
+++ b/tools/ld-analyse/tbcsource.h
@@ -151,11 +151,11 @@ private:
     PalColour::Configuration palConfiguration;
     Comb::Configuration ntscConfiguration;
     OutputWriter::Configuration outputConfiguration;
-    bool decoderConfigurationChanged;
 
     // Chapter map
     QVector<qint32> chapterMap;
 
+    void invalidateFrameCache();
     QImage generateQImage(qint32 frameNumber);
     void generateData();
     void startBackgroundLoad(QString sourceFilename);

--- a/tools/ld-analyse/tbcsource.h
+++ b/tools/ld-analyse/tbcsource.h
@@ -163,6 +163,7 @@ private:
     // Chapter map
     QVector<qint32> chapterMap;
 
+    void resetState();
     void invalidateFrameCache();
     QImage generateQImage();
     void generateData();

--- a/tools/ld-analyse/tbcsource.h
+++ b/tools/ld-analyse/tbcsource.h
@@ -151,7 +151,16 @@ private:
     LdDecodeMetaData::Field firstField, secondField;
     qint32 loadedFrameNumber;
 
-    // Image data for the loaded frame
+    // Source fields needed to decode the loaded frame
+    QVector<SourceField> inputFields;
+    qint32 inputStartIndex, inputEndIndex;
+    bool inputFieldsValid;
+
+    // Chroma decoder output for the loaded frame
+    QVector<ComponentFrame> componentFrames;
+    bool decodedFrameValid;
+
+    // RGB image data for the loaded frame
     QImage frameCache;
     bool frameCacheValid;
 
@@ -165,6 +174,8 @@ private:
 
     void resetState();
     void invalidateFrameCache();
+    void loadInputFields();
+    void decodeFrame();
     QImage generateQImage();
     void generateData();
     void startBackgroundLoad(QString sourceFilename);

--- a/tools/ld-analyse/tbcsource.h
+++ b/tools/ld-analyse/tbcsource.h
@@ -4,6 +4,7 @@
 
     ld-analyse - TBC output analysis
     Copyright (C) 2018-2021 Simon Inns
+    Copyright (C) 2021 Adam Sampson
 
     This file is part of ld-decode-tools.
 
@@ -72,29 +73,31 @@ public:
     bool getChromaDecoder();
     bool getFieldOrder();
 
-    QImage getFrameImage(qint32 frameNumber);
+    void loadFrame(qint32 frameNumber);
+
+    QImage getFrameImage();
     qint32 getNumberOfFrames();
     qint32 getNumberOfFields();
     bool getIsSourcePal();
     qint32 getFrameHeight();
     qint32 getFrameWidth();
 
-    VbiDecoder::Vbi getFrameVbi(qint32 frameNumber);
-    bool getIsFrameVbiValid(qint32 frameNumber);
+    VbiDecoder::Vbi getFrameVbi();
+    bool getIsFrameVbiValid();
 
     QVector<qreal> getBlackSnrGraphData();
     QVector<qreal> getWhiteSnrGraphData();
     QVector<qreal> getDropOutGraphData();
     qint32 getGraphDataSize();
 
-    bool getIsDropoutPresent(qint32 frameNumber);
-    ScanLineData getScanLineData(qint32 frameNumber, qint32 scanLine);
+    bool getIsDropoutPresent();
+    ScanLineData getScanLineData(qint32 scanLine);
 
-    qint32 getFirstFieldNumber(qint32 frameNumber);
-    qint32 getSecondFieldNumber(qint32 frameNumber);
+    qint32 getFirstFieldNumber();
+    qint32 getSecondFieldNumber();
 
-    qint32 getCcData0(qint32 frameNumber);
-    qint32 getCcData1(qint32 frameNumber);
+    qint32 getCcData0();
+    qint32 getCcData1();
 
     void setChromaConfiguration(const PalColour::Configuration &palConfiguration, const Comb::Configuration &ntscConfiguration,
                                 const OutputWriter::Configuration &outputConfiguration);
@@ -143,9 +146,14 @@ private:
     QFutureWatcher<void> watcher;
     QFuture <void> future;
 
-    // Cache of current frame QImage
+    // Metadata for the loaded frame
+    qint32 firstFieldNumber, secondFieldNumber;
+    LdDecodeMetaData::Field firstField, secondField;
+    qint32 loadedFrameNumber;
+
+    // Image data for the loaded frame
     QImage frameCache;
-    qint32 frameCacheFrameNumber;
+    bool frameCacheValid;
 
     // Chroma decoder configuration
     PalColour::Configuration palConfiguration;
@@ -156,7 +164,7 @@ private:
     QVector<qint32> chapterMap;
 
     void invalidateFrameCache();
-    QImage generateQImage(qint32 frameNumber);
+    QImage generateQImage();
     void generateData();
     void startBackgroundLoad(QString sourceFilename);
 };

--- a/tools/ld-analyse/tbcsource.h
+++ b/tools/ld-analyse/tbcsource.h
@@ -50,7 +50,8 @@ public:
     explicit TbcSource(QObject *parent = nullptr);
 
     struct ScanLineData {
-        QVector<qint32> data;
+        QVector<qint32> composite;
+        QVector<qint32> luma;
         QVector<bool> isDropout;
         qint32 blackIre;
         qint32 whiteIre;
@@ -59,6 +60,7 @@ public:
         qint32 colourBurstEnd;
         qint32 activeVideoStart;
         qint32 activeVideoEnd;
+        bool isActiveLine;
         bool isSourcePal;
     };
 


### PR DESCRIPTION
This replaces ld-analyse's old 1D filters, and it means that you can see the effect of chroma decoder configuration changes - including noise reduction - interactively on the scope.

I've refactored `TbcSource` as part of this - it now acts more like a player that you can seek to a particular frame, so the decoder and the different analysis views all use the same cached data. The same infrastructure should make it fairly straightforward to add a vectorscope or other kinds of displays.

Fixes #305.

![yuvscope](https://user-images.githubusercontent.com/436317/118382765-826ea580-b5f0-11eb-8ced-1caab2c34a9a.png)
