### PR TITLE
Support for building with Qt 6

### DIFF
--- a/tools/ld-analyse/blacksnranalysisdialog.cpp
+++ b/tools/ld-analyse/blacksnranalysisdialog.cpp
@@ -152,7 +152,7 @@ void BlackSnrAnalysisDialog::finishUpdate(qint32 _currentFrameNumber)
 
     // Update the plot panner
     panner->setAxisEnabled(QwtPlot::yRight, false);
-    panner->setMouseButton(Qt::MidButton);
+    panner->setMouseButton(Qt::MiddleButton);
 
     // Render the chart
     plot->maximumSize();

--- a/tools/ld-analyse/blacksnranalysisdialog.cpp
+++ b/tools/ld-analyse/blacksnranalysisdialog.cpp
@@ -25,6 +25,8 @@
 #include "blacksnranalysisdialog.h"
 #include "ui_blacksnranalysisdialog.h"
 
+#include <QPen>
+
 BlackSnrAnalysisDialog::BlackSnrAnalysisDialog(QWidget *parent) :
     QDialog(parent),
     ui(new Ui::BlackSnrAnalysisDialog)

--- a/tools/ld-analyse/dropoutanalysisdialog.cpp
+++ b/tools/ld-analyse/dropoutanalysisdialog.cpp
@@ -134,7 +134,7 @@ void DropoutAnalysisDialog::finishUpdate(qint32 _currentFrameNumber)
 
     // Update the plot panner
     panner->setAxisEnabled(QwtPlot::yRight, false);
-    panner->setMouseButton(Qt::MidButton);
+    panner->setMouseButton(Qt::MiddleButton);
 
     // Render the chart
     plot->maximumSize();

--- a/tools/ld-analyse/dropoutanalysisdialog.cpp
+++ b/tools/ld-analyse/dropoutanalysisdialog.cpp
@@ -25,6 +25,8 @@
 #include "dropoutanalysisdialog.h"
 #include "ui_dropoutanalysisdialog.h"
 
+#include <QPen>
+
 DropoutAnalysisDialog::DropoutAnalysisDialog(QWidget *parent) :
     QDialog(parent),
     ui(new Ui::DropoutAnalysisDialog)

--- a/tools/ld-analyse/ld-analyse.pro
+++ b/tools/ld-analyse/ld-analyse.pro
@@ -134,8 +134,15 @@ LIBS += -lfftw3
 # Include the QWT library (used for charting)
 unix:!macx {
 #INCLUDEPATH += $(QWT)/include
-INCLUDEPATH += /usr/include/qwt
-LIBS += -lqwt-qt5 #Distrubutions other than Ubuntu may be -lqwt
+    equals(QT_MAJOR_VERSION, 5) {
+        INCLUDEPATH += /usr/include/qwt
+        # Distributions other than Ubuntu may be -lqwt
+        LIBS += -lqwt-qt5
+    }
+    equals(QT_MAJOR_VERSION, 6) {
+        INCLUDEPATH += /usr/include/qwt6
+        LIBS += -lqwt-qt6
+    }
 }
 macx {
 INCLUDEPATH += "/usr/local/lib/qwt.framework/Versions/6/Headers"

--- a/tools/ld-analyse/mainwindow.cpp
+++ b/tools/ld-analyse/mainwindow.cpp
@@ -339,7 +339,7 @@ void MainWindow::updateFrameViewer()
         imagePainter.end();
     }
 
-    ui->frameViewerLabel->setPixmap(QPixmap::fromImage(frameImage));
+    QPixmap pixmap = QPixmap::fromImage(frameImage);
 
     // Get the pixmap width and height (and apply scaling and aspect ratio adjustment if required)
     qint32 adjustment = 0;
@@ -349,9 +349,9 @@ void MainWindow::updateFrameViewer()
     }
 
     // Scale and apply the pixmap
-    ui->frameViewerLabel->setPixmap(ui->frameViewerLabel->pixmap()->scaled((scaleFactor * (ui->frameViewerLabel->pixmap()->size().width() - adjustment)),
-                                                                           (scaleFactor * ui->frameViewerLabel->pixmap()->size().height()),
-                                                                           Qt::IgnoreAspectRatio, Qt::SmoothTransformation));
+    ui->frameViewerLabel->setPixmap(pixmap.scaled((scaleFactor * (pixmap.size().width() - adjustment)),
+                                                  (scaleFactor * pixmap.size().height()),
+                                                  Qt::IgnoreAspectRatio, Qt::SmoothTransformation));
 
     // Update the current frame markers on the graphs
     blackSnrAnalysisDialog->updateFrameMarker(currentFrameNumber);
@@ -828,22 +828,30 @@ void MainWindow::mouseMoveEvent(QMouseEvent *event)
 // Perform mouse based scan line selection
 void MainWindow::mouseScanLineSelect(qint32 oX, qint32 oY)
 {
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+    QPixmap frameViewerPixmap = ui->frameViewerLabel->pixmap();
+#elif QT_VERSION >= QT_VERSION_CHECK(5, 15, 0)
+    QPixmap frameViewerPixmap = ui->frameViewerLabel->pixmap(Qt::ReturnByValue);
+#else
+    QPixmap frameViewerPixmap = *(ui->frameViewerLabel->pixmap());
+#endif
+
     // X calc
     qreal offsetX = ((static_cast<qreal>(ui->frameViewerLabel->width()) -
-                     static_cast<qreal>(ui->frameViewerLabel->pixmap()->width())) / 2.0);
+                     static_cast<qreal>(frameViewerPixmap.width())) / 2.0);
 
     qreal unscaledXR = (static_cast<qreal>(tbcSource.getFrameWidth()) /
-                        static_cast<qreal>(ui->frameViewerLabel->pixmap()->width())) * static_cast<qreal>(oX - offsetX);
+                        static_cast<qreal>(frameViewerPixmap.width())) * static_cast<qreal>(oX - offsetX);
     qint32 unscaledX = static_cast<qint32>(unscaledXR);
     if (unscaledX > tbcSource.getFrameWidth() - 1) unscaledX = tbcSource.getFrameWidth() - 1;
     if (unscaledX < 0) unscaledX = 0;
 
     // Y Calc
     qreal offsetY = ((static_cast<qreal>(ui->frameViewerLabel->height()) -
-                     static_cast<qreal>(ui->frameViewerLabel->pixmap()->height())) / 2.0);
+                     static_cast<qreal>(frameViewerPixmap.height())) / 2.0);
 
     qreal unscaledYR = (static_cast<qreal>(tbcSource.getFrameHeight()) /
-                        static_cast<qreal>(ui->frameViewerLabel->pixmap()->height())) * static_cast<qreal>(oY - offsetY);
+                        static_cast<qreal>(frameViewerPixmap.height())) * static_cast<qreal>(oY - offsetY);
     qint32 unscaledY = static_cast<qint32>(unscaledYR);
     if (unscaledY > tbcSource.getFrameHeight()) unscaledY = tbcSource.getFrameHeight();
     if (unscaledY < 1) unscaledY = 1;

--- a/tools/ld-analyse/tbcsource.cpp
+++ b/tools/ld-analyse/tbcsource.cpp
@@ -65,7 +65,11 @@ void TbcSource::loadSource(QString sourceFilename)
     // Set up and fire-off background loading thread
     qDebug() << "TbcSource::loadSource(): Setting up background loader thread";
     connect(&watcher, SIGNAL(finished()), this, SLOT(finishBackgroundLoad()));
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
     future = QtConcurrent::run(this, &TbcSource::startBackgroundLoad, sourceFilename);
+#else
+    future = QtConcurrent::run(&TbcSource::startBackgroundLoad, this, sourceFilename);
+#endif
     watcher.setFuture(future);
 }
 

--- a/tools/ld-analyse/whitesnranalysisdialog.cpp
+++ b/tools/ld-analyse/whitesnranalysisdialog.cpp
@@ -25,6 +25,8 @@
 #include "whitesnranalysisdialog.h"
 #include "ui_whitesnranalysisdialog.h"
 
+#include <QPen>
+
 WhiteSnrAnalysisDialog::WhiteSnrAnalysisDialog(QWidget *parent) :
     QDialog(parent),
     ui(new Ui::WhiteSnrAnalysisDialog)

--- a/tools/ld-analyse/whitesnranalysisdialog.cpp
+++ b/tools/ld-analyse/whitesnranalysisdialog.cpp
@@ -152,7 +152,7 @@ void WhiteSnrAnalysisDialog::finishUpdate(qint32 _currentFrameNumber)
 
     // Update the plot panner
     panner->setAxisEnabled(QwtPlot::yRight, false);
-    panner->setMouseButton(Qt::MidButton);
+    panner->setMouseButton(Qt::MiddleButton);
 
     // Render the chart
     plot->maximumSize();

--- a/tools/ld-export-metadata/csv.cpp
+++ b/tools/ld-export-metadata/csv.cpp
@@ -51,7 +51,9 @@ bool writeVitsCsv(LdDecodeMetaData &metaData, const QString &fileName)
 
     // Create a text stream for the CSV output
     QTextStream outStream(&csvFile);
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
     outStream.setCodec("UTF-8");
+#endif
 
     // Write the field and VITS data
     outStream << "seqNo,isFirstField,syncConf,";
@@ -93,7 +95,9 @@ bool writeVbiCsv(LdDecodeMetaData &metaData, const QString &fileName)
 
     // Create a text stream for the CSV output
     QTextStream outStream(&csvFile);
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
     outStream.setCodec("UTF-8");
+#endif
 
     // Write the field and VBI data
     outStream << "frameNo,";

--- a/tools/ld-export-metadata/ffmetadata.cpp
+++ b/tools/ld-export-metadata/ffmetadata.cpp
@@ -114,7 +114,9 @@ bool writeFfmetadata(LdDecodeMetaData &metaData, const QString &fileName)
         return false;
     }
     QTextStream stream(&file);
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
     stream.setCodec("UTF-8");
+#endif
 
     // Write the header
     stream << ";FFMETADATA1\n";

--- a/tools/library/JsonWax/JsonWax.h
+++ b/tools/library/JsonWax/JsonWax.h
@@ -190,7 +190,9 @@ public:
             return false;
 
         QTextStream in (&qfile);
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
         in.setCodec("UTF-8");
+#endif
         /*
             TODO: Determine correct codec. UTF-8 setting invalidates some ansi characters like "æ,ø,å".
             So make sure the read file is UTF-8 encoded, then everything will work perfectly.

--- a/tools/library/JsonWax/JsonWaxSerializer.h
+++ b/tools/library/JsonWax/JsonWaxSerializer.h
@@ -363,7 +363,7 @@ inline SpecialTextStream& operator << (SpecialTextStream &stream, const QObject 
     SERIALIZE_TO_EDITOR = true;
 
     for (int i = 0; i < obj.metaObject()->propertyCount(); ++i)
-        if (obj.metaObject()->property(i).isStored( &obj))
+        if (obj.metaObject()->property(i).isStored())
         {
             QString name = QString( obj.metaObject()->property(i).name());
             QString value = obj.metaObject()->property(i).read( &obj).toString();
@@ -386,7 +386,7 @@ inline SpecialTextStream& operator >> (SpecialTextStream &stream, QObject &obj)
         if (index == -1)
             return stream;
 
-        if (obj.metaObject()->property( index).isStored( &obj))
+        if (obj.metaObject()->property( index).isStored())
         {
             QVariant value = DESERIALIZE_EDITOR->value( DESERIALIZE_KEYS + QVariantList{key}, QVariant());
             obj.metaObject()->property( index).write( &obj, value);
@@ -670,7 +670,7 @@ inline SpecialTextStream& operator >> (SpecialTextStream &stream, QMap<QString, 
 inline QDataStream& operator << (QDataStream &stream, const QObject &obj)
 {
     for (int i = 1; i < obj.metaObject()->propertyCount(); ++i)
-        if (obj.metaObject()->property(i).isStored( &obj))
+        if (obj.metaObject()->property(i).isStored())
             stream << obj.metaObject()->property(i).read( &obj);
     return stream;
 }
@@ -679,7 +679,7 @@ inline QDataStream& operator >> (QDataStream &stream, QObject &obj)
 {
     QVariant value;
     for (int i = 1; i < obj.metaObject()->propertyCount(); ++i)
-        if (obj.metaObject()->property(i).isStored( &obj))
+        if (obj.metaObject()->property(i).isStored())
         {
             stream >> value;
             obj.metaObject()->property(i).write( &obj, value);


### PR DESCRIPTION
This is the minimal set of changes to get ld-decode to build with Qt 6 (in addition to the usual Qt 5). I've not used it extensively, but the test suite passes and ld-analyse seems to work. There are still lots of deprecation warnings from the JsonWax code.

Note that this requires a Qt 6 version of qwt, which currently means building qwt 6.2 from Git.