### PR TITLE
Remove the "75% white point" option

### DIFF
--- a/tools/ld-analyse/chromadecoderconfigdialog.cpp
+++ b/tools/ld-analyse/chromadecoderconfigdialog.cpp
@@ -218,9 +218,6 @@ void ChromaDecoderConfigDialog::updateDialog()
     ui->showMapCheckBox->setEnabled(isSourceNtsc && ntscConfiguration.dimensions == 3);
     ui->showMapCheckBox->setChecked(ntscConfiguration.showMap);
 
-    ui->whitePoint75CheckBox->setEnabled(isSourceNtsc);
-    ui->whitePoint75CheckBox->setChecked(outputConfiguration.whitePoint75);
-
     ui->colorLpfCheckBox->setEnabled(isSourceNtsc);
     ui->colorLpfCheckBox->setChecked(ntscConfiguration.colorlpf);
 
@@ -319,12 +316,6 @@ void ChromaDecoderConfigDialog::on_adaptiveCheckBox_clicked()
 void ChromaDecoderConfigDialog::on_showMapCheckBox_clicked()
 {
     ntscConfiguration.showMap = ui->showMapCheckBox->isChecked();
-    emit chromaDecoderConfigChanged();
-}
-
-void ChromaDecoderConfigDialog::on_whitePoint75CheckBox_clicked()
-{
-    outputConfiguration.whitePoint75 = ui->whitePoint75CheckBox->isChecked();
     emit chromaDecoderConfigChanged();
 }
 

--- a/tools/ld-analyse/chromadecoderconfigdialog.h
+++ b/tools/ld-analyse/chromadecoderconfigdialog.h
@@ -67,7 +67,6 @@ private slots:
     void on_ntscFilterButtonGroup_buttonClicked(QAbstractButton *button);
     void on_adaptiveCheckBox_clicked();
     void on_showMapCheckBox_clicked();
-    void on_whitePoint75CheckBox_clicked();
     void on_colorLpfCheckBox_clicked();
     void on_colorLpfHqCheckBox_clicked();
     void on_cNRHorizontalSlider_valueChanged(int value);

--- a/tools/ld-analyse/chromadecoderconfigdialog.ui
+++ b/tools/ld-analyse/chromadecoderconfigdialog.ui
@@ -311,13 +311,6 @@
         </widget>
        </item>
        <item>
-        <widget class="QCheckBox" name="whitePoint75CheckBox">
-         <property name="text">
-          <string>Use 75 IRE white point</string>
-         </property>
-        </widget>
-       </item>
-       <item>
         <widget class="QCheckBox" name="colorLpfCheckBox">
          <property name="text">
           <string>Use chroma post-filter</string>

--- a/tools/ld-chroma-decoder/main.cpp
+++ b/tools/ld-chroma-decoder/main.cpp
@@ -193,11 +193,6 @@ int main(int argc, char *argv[])
                                      QCoreApplication::translate("main", "NTSC: Overlay the adaptive filter map (only used for testing)"));
     parser.addOption(showMapOption);
 
-    // Option to set the white point to 75% (rather than 100%)
-    QCommandLineOption whitePointOption(QStringList() << "w" << "white",
-                                        QCoreApplication::translate("main", "Use 75% white-point (default 100%)"));
-    parser.addOption(whitePointOption);
-
     // Option to set the chroma noise reduction level
     QCommandLineOption chromaNROption(QStringList() << "chroma-nr",
                                       QCoreApplication::translate("main", "NTSC: Chroma noise reduction level in dB (default 0.0)"),
@@ -340,10 +335,6 @@ int main(int argc, char *argv[])
     if (bwMode) {
         palConfig.chromaGain = 0.0;
         combConfig.chromaGain = 0.0;
-    }
-
-    if (parser.isSet(whitePointOption)) {
-        outputConfig.whitePoint75 = true;
     }
 
     if (parser.isSet(showMapOption)) {

--- a/tools/ld-chroma-decoder/outputwriter.cpp
+++ b/tools/ld-chroma-decoder/outputwriter.cpp
@@ -269,12 +269,6 @@ void OutputWriter::convertLine(qint32 lineNumber, const ComponentFrame &componen
     double yRange = videoParameters.white16bIre - videoParameters.black16bIre;
     const double uvRange = yRange;
 
-    if (config.whitePoint75) {
-        // Use 75% white point for luma only
-        // XXX This isn't correct - it should be 75/100, not 100/125
-        yRange *= 100.0 / 125.0;
-    }
-
     switch (config.pixelFormat) {
         case RGB48: {
             // Convert Y'UV to full-range R'G'B' [Poynton eq 28.6 p337]

--- a/tools/ld-chroma-decoder/outputwriter.h
+++ b/tools/ld-chroma-decoder/outputwriter.h
@@ -50,7 +50,6 @@ public:
 
     // Output settings
     struct Configuration {
-        bool whitePoint75 = false;
         bool usePadding = true;
         PixelFormat pixelFormat = RGB48;
         bool outputY4m = false;


### PR DESCRIPTION
This appears to be left over from early development; it's not very useful for real-world decoding.

Fixes #632.