### PR TITLE
Make some MacOS-specific process changes

### DIFF
--- a/lddecode/core.py
+++ b/lddecode/core.py
@@ -1,10 +1,13 @@
 import copy
 import itertools
+import platform
 import sys
 import threading
 import time
 
 from multiprocessing import Process, Queue, JoinableQueue, Pipe
+if platform.system() == 'Darwin':
+    from multiprocessing import set_start_method
 
 # standard numeric/scientific libraries
 import numpy as np
@@ -1074,6 +1077,9 @@ class DemodCache:
 
         self.lock = threading.Lock()
         self.blocks = {}
+
+        if platform.system() == 'Darwin':
+            set_start_method('fork')
 
         self.q_in = JoinableQueue()
         self.q_in_metadata = []


### PR DESCRIPTION
In order to make core.py usable on MacOS, have new processes fork instead of spawn.