### PR TITLE
upstream stuff:

### DIFF
--- a/tools/ld-analyse/chromadecoderconfigdialog.cpp
+++ b/tools/ld-analyse/chromadecoderconfigdialog.cpp
@@ -196,6 +196,8 @@ void ChromaDecoderConfigDialog::updateDialog()
 
     const bool isSourceNtsc = !isSourcePal;
 
+    ui->phaseCompCheckBox->setEnabled(isSourceNtsc);
+    ui->phaseCompCheckBox->setChecked(ntscConfiguration.phaseCompensation);
     ui->ntscFilter1DRadioButton->setEnabled(isSourceNtsc);
     ui->ntscFilter2DRadioButton->setEnabled(isSourceNtsc);
     ui->ntscFilter3DRadioButton->setEnabled(isSourceNtsc);
@@ -304,6 +306,12 @@ void ChromaDecoderConfigDialog::on_ntscFilterButtonGroup_buttonClicked(QAbstract
         ntscConfiguration.dimensions = 3;
     }
     updateDialog();
+    emit chromaDecoderConfigChanged();
+}
+
+void ChromaDecoderConfigDialog::on_phaseCompCheckBox_clicked()
+{
+    ntscConfiguration.phaseCompensation = ui->phaseCompCheckBox->isChecked();
     emit chromaDecoderConfigChanged();
 }
 

--- a/tools/ld-analyse/chromadecoderconfigdialog.h
+++ b/tools/ld-analyse/chromadecoderconfigdialog.h
@@ -65,6 +65,7 @@ private slots:
     void on_simplePALCheckBox_clicked();
 
     void on_ntscFilterButtonGroup_buttonClicked(QAbstractButton *button);
+    void on_phaseCompCheckBox_clicked();
     void on_adaptiveCheckBox_clicked();
     void on_showMapCheckBox_clicked();
     void on_colorLpfCheckBox_clicked();

--- a/tools/ld-analyse/chromadecoderconfigdialog.ui
+++ b/tools/ld-analyse/chromadecoderconfigdialog.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>460</width>
-    <height>180</height>
+    <height>514</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -95,7 +95,7 @@
    <item>
     <widget class="QTabWidget" name="standardTabs">
      <property name="currentIndex">
-      <number>0</number>
+      <number>1</number>
      </property>
      <widget class="QWidget" name="palTab">
       <attribute name="title">
@@ -297,6 +297,13 @@
         </spacer>
        </item>
        <item>
+        <widget class="QCheckBox" name="phaseCompCheckBox">
+         <property name="text">
+          <string>Phase compensating decoder</string>
+         </property>
+        </widget>
+       </item>
+       <item>
         <widget class="QCheckBox" name="adaptiveCheckBox">
          <property name="text">
           <string>Enable adaptive filter</string>
@@ -396,7 +403,7 @@
  <resources/>
  <connections/>
  <buttongroups>
-  <buttongroup name="ntscFilterButtonGroup"/>
   <buttongroup name="palFilterButtonGroup"/>
+  <buttongroup name="ntscFilterButtonGroup"/>
  </buttongroups>
 </ui>

--- a/tools/ld-analyse/mainwindow.cpp
+++ b/tools/ld-analyse/mainwindow.cpp
@@ -25,6 +25,21 @@
 #include "mainwindow.h"
 #include "ui_mainwindow.h"
 
+namespace {
+namespace Aspect {
+    constexpr quint8 SAR_11 = 0;
+    constexpr char const* SAR_11_S = "SAR 1:1";
+    constexpr quint8 DAR_43 = 1;
+    constexpr char const* DAR_43_S ="DAR 4:3";
+    constexpr int DAR_43_ADJ_525 = -150; // NTSC
+    constexpr int DAR_43_ADJ_625 = -196; // PAL
+    constexpr quint8 DAR_169 = 2;
+    constexpr char const* DAR_169_S ="DAR 16:9";
+    constexpr int DAR_169_ADJ_525 = 122;
+    constexpr int DAR_169_ADJ_625 = 103;
+}
+}
+
 MainWindow::MainWindow(QString inputFilenameParam, QWidget *parent) :
     QMainWindow(parent),
     ui(new Ui::MainWindow)
@@ -52,7 +67,8 @@ MainWindow::MainWindow(QString inputFilenameParam, QWidget *parent) :
     currentFrameNumber = 1;
 
     // Set the initial aspect
-    aspect43On = false;
+    aspectRatio = Aspect::SAR_11;
+    if (tbcSource.getIsWidescreen()) aspectRatio = Aspect::DAR_169;
 
     // Connect to the scan line changed signal from the oscilloscope dialogue
     connect(oscilloscopeDialog, &OscilloscopeDialog::scanLineChanged, this, &MainWindow::scanLineChangedSignalHandler);
@@ -167,7 +183,7 @@ void MainWindow::updateGuiLoaded()
     // Set option button states
     ui->videoPushButton->setText(tr("Source"));
     ui->dropoutsPushButton->setText(tr("Dropouts Off"));
-    ui->aspectPushButton->setText(tr("1:1"));
+    ui->aspectPushButton->setText(tr(Aspect::SAR_11_S));
     ui->fieldOrderPushButton->setText(tr("Normal Field-order"));
 
     // Set zoom button states
@@ -192,7 +208,11 @@ void MainWindow::updateGuiLoaded()
     sourceVideoStatus.setText(statusText);
 
     // Reset the aspect setting
-    aspect43On = false;
+    aspectRatio = Aspect::SAR_11;
+    if (tbcSource.getIsWidescreen()) {
+        aspectRatio = Aspect::DAR_169;
+        ui->aspectPushButton->setText(tr(Aspect::DAR_169_S));
+    }
 
     // Update the chroma decoder configuration dialogue
     chromaDecoderConfigDialog->setConfiguration(tbcSource.getIsSourcePal(), tbcSource.getPalConfiguration(),
@@ -252,7 +272,8 @@ void MainWindow::updateGuiUnloaded()
     // Set option button states
     ui->videoPushButton->setText(tr("Source"));
     ui->dropoutsPushButton->setText(tr("Dropouts Off"));
-    ui->aspectPushButton->setText(tr("1:1"));
+    aspectRatio = Aspect::SAR_11;
+    ui->aspectPushButton->setText(tr(Aspect::SAR_11_S));;
     ui->fieldOrderPushButton->setText(tr("Normal Field-order"));
 
     // Set zoom button states
@@ -346,13 +367,18 @@ void MainWindow::updateFrameViewer()
 
     // Get the pixmap width and height (and apply scaling and aspect ratio adjustment if required)
     qint32 adjustment = 0;
-    if (aspect43On) {
-        if (tbcSource.getIsSourcePal()) adjustment = 196; // PAL
-        else adjustment = 150; // NTSC
+    if (aspectRatio == Aspect::DAR_43) {
+        if (tbcSource.getIsSourcePal()) adjustment = Aspect::DAR_43_ADJ_625; // PAL 4:3
+        else adjustment = Aspect::DAR_43_ADJ_525; // NTSC 4:3
+    }
+    
+    if (aspectRatio == Aspect::DAR_169) {
+        if (tbcSource.getIsSourcePal()) adjustment = Aspect::DAR_169_ADJ_625; // PAL 16:9
+        else adjustment = Aspect::DAR_169_ADJ_525; // NTSC 16:9
     }
 
     // Scale and apply the pixmap
-    ui->frameViewerLabel->setPixmap(pixmap.scaled((scaleFactor * (pixmap.size().width() - adjustment)),
+    ui->frameViewerLabel->setPixmap(pixmap.scaled((scaleFactor * (pixmap.size().width() + adjustment)),
                                                   (scaleFactor * pixmap.size().height()),
                                                   Qt::IgnoreAspectRatio, Qt::SmoothTransformation));
 
@@ -493,7 +519,8 @@ void MainWindow::on_actionSave_frame_as_PNG_triggered()
     if (!tbcSource.getChromaDecoder()) filenameSuggestion += tr("source_");
     else filenameSuggestion += tr("chroma_");
 
-    if (aspect43On) filenameSuggestion += tr("ar43_");
+    if (aspectRatio == Aspect::DAR_43) filenameSuggestion += tr("ar43_");
+    if (aspectRatio == Aspect::DAR_169) filenameSuggestion += tr("ar169_");
 
     filenameSuggestion += QString::number(currentFrameNumber) + tr(".png");
 
@@ -511,13 +538,25 @@ void MainWindow::on_actionSave_frame_as_PNG_triggered()
         QImage imageToSave = tbcSource.getFrameImage();
 
         // Change to 4:3 aspect ratio?
-        if (aspect43On) {
+        if (aspectRatio == Aspect::DAR_43) {
             // Scale to 4:3 aspect
             qint32 adjustment = 0;
-            if (tbcSource.getIsSourcePal()) adjustment = 196; // PAL
-            else adjustment = 150; // NTSC
+            if (tbcSource.getIsSourcePal()) adjustment = Aspect::DAR_43_ADJ_625; // PAL 4:3
+            else adjustment = Aspect::DAR_43_ADJ_525; // NTSC 4:3
 
-            imageToSave = imageToSave.scaled((imageToSave.size().width() - adjustment),
+            imageToSave = imageToSave.scaled((imageToSave.size().width() + adjustment),
+                                             (imageToSave.size().height()),
+                                             Qt::IgnoreAspectRatio, Qt::SmoothTransformation);
+        }
+        
+        // Change to 16:9 aspect ratio?
+        if (aspectRatio == Aspect::DAR_169) {
+            // Scale to 16:9 aspect
+            qint32 adjustment = 0;
+            if (tbcSource.getIsSourcePal()) adjustment = Aspect::DAR_169_ADJ_625; // PAL 16:9
+            else adjustment = Aspect::DAR_169_ADJ_525; // NTSC 16:9
+
+            imageToSave = imageToSave.scaled((imageToSave.size().width() + adjustment),
                                              (imageToSave.size().height()),
                                              Qt::IgnoreAspectRatio, Qt::SmoothTransformation);
         }
@@ -753,13 +792,15 @@ void MainWindow::on_mouseModePushButton_clicked()
 // Aspect ratio button clicked
 void MainWindow::on_aspectPushButton_clicked()
 {
-    if (aspect43On) {
-        aspect43On = false;
-        ui->aspectPushButton->setText(tr("1:1"));
-    } else {
-        aspect43On = true;
-        ui->aspectPushButton->setText(tr("4:3"));
-    }
+    aspectRatio += 1;
+    
+    if (aspectRatio > 2) aspectRatio = 0;
+    
+    if (aspectRatio == Aspect::SAR_11) ui->aspectPushButton->setText(tr(Aspect::SAR_11_S));
+    else if (aspectRatio == Aspect::DAR_43) ui->aspectPushButton->setText(tr(Aspect::DAR_43_S));
+    else if (aspectRatio == Aspect::DAR_169) ui->aspectPushButton->setText(tr(Aspect::DAR_169_S));
+
+    qDebug() << "Aspect ratio: " << aspectRatio << " text " << ui->aspectPushButton->text();
 
     // Show the current frame (why isn't this option passed?)
     showFrame();

--- a/tools/ld-analyse/mainwindow.h
+++ b/tools/ld-analyse/mainwindow.h
@@ -124,13 +124,13 @@ private:
     QLabel sourceVideoStatus;
     QLabel fieldNumberStatus;
     TbcSource tbcSource;
+    quint8 aspectRatio;
     qint32 lastScopeLine;
     qint32 lastScopeDot;
     qint32 currentFrameNumber;
     qreal scaleFactor;
     QPalette buttonPalette;
     QString lastFilename;
-    bool aspect43On;
 
     // Update GUI methods
     void updateGuiLoaded();

--- a/tools/ld-analyse/mainwindow.ui
+++ b/tools/ld-analyse/mainwindow.ui
@@ -53,7 +53,7 @@
            <x>0</x>
            <y>0</y>
            <width>969</width>
-           <height>576</height>
+           <height>559</height>
           </rect>
          </property>
          <layout class="QVBoxLayout" name="verticalLayout_2">
@@ -383,7 +383,7 @@
            <item>
             <widget class="QPushButton" name="aspectPushButton">
              <property name="text">
-              <string>1:1</string>
+              <string>DAR 1:1</string>
              </property>
             </widget>
            </item>
@@ -434,7 +434,7 @@
      <x>0</x>
      <y>0</y>
      <width>991</width>
-     <height>22</height>
+     <height>29</height>
     </rect>
    </property>
    <widget class="QMenu" name="menuFile">

--- a/tools/ld-analyse/tbcsource.cpp
+++ b/tools/ld-analyse/tbcsource.cpp
@@ -217,6 +217,13 @@ qint32 TbcSource::getNumberOfFields()
     return ldDecodeMetaData.getNumberOfFields();
 }
 
+// Method returns true if the TBC source is anamorphic (false for 4:3)
+bool TbcSource::getIsWidescreen()
+{
+    if (!sourceReady) return false;
+    return ldDecodeMetaData.getVideoParameters().isWidescreen;
+}
+
 // Method returns true if the TBC source is PAL (false for NTSC)
 bool TbcSource::getIsSourcePal()
 {
@@ -738,7 +745,19 @@ void TbcSource::startBackgroundLoad(QString sourceFilename)
     // Open the TBC metadata file
     qDebug() << "TbcSource::startBackgroundLoad(): Processing JSON metadata...";
     emit busyLoading("Processing JSON metadata...");
-    if (!ldDecodeMetaData.read(sourceFilename + ".json")) {
+
+    QString jsonFileName = sourceFilename + ".json";
+
+    const bool chroma_tbc = sourceFilename.endsWith("_chroma.tbc");
+
+    // If we are trying to open a _chroma tbc from vhs-decode.
+    // Try to look for the json for the luma part if the chroma doesn't have it's own.
+    if (!QFileInfo::exists(jsonFileName) && chroma_tbc) {
+        jsonFileName.chop(16);
+        jsonFileName += ".tbc.json";
+    }
+
+    if (!ldDecodeMetaData.read(jsonFileName)) {
         // Open failed
         qWarning() << "Open TBC JSON metadata failed for filename" << sourceFilename;
         currentSourceFilename.clear();
@@ -773,6 +792,10 @@ void TbcSource::startBackgroundLoad(QString sourceFilename)
     if (getIsSourcePal()) {
         palColour.updateConfiguration(videoParameters, palConfiguration);
     } else {
+        // Enable this option by default if we are loading a vhs-decode chroma only tbc file.
+        if(chroma_tbc) {
+            ntscConfiguration.phaseCompensation = true;
+        }
         ntscColour.updateConfiguration(videoParameters, ntscConfiguration);
     }
 

--- a/tools/ld-analyse/tbcsource.h
+++ b/tools/ld-analyse/tbcsource.h
@@ -81,6 +81,7 @@ public:
     QImage getFrameImage();
     qint32 getNumberOfFrames();
     qint32 getNumberOfFields();
+    bool getIsWidescreen();
     bool getIsSourcePal();
     qint32 getFrameHeight();
     qint32 getFrameWidth();

--- a/tools/ld-chroma-decoder/comb.h
+++ b/tools/ld-chroma-decoder/comb.h
@@ -50,9 +50,11 @@ public:
         double chromaPhase = 0.0;
         bool colorlpf = false;
         bool colorlpf_hq = true;
+        bool whitePoint75 = false;
         qint32 dimensions = 2;
         bool adaptive = true;
         bool showMap = false;
+        bool phaseCompensation = false;
 
         double cNRLevel = 0.0;
         double yNRLevel = 1.0;
@@ -97,7 +99,9 @@ private:
         }
 
         void splitIQ();
+        void splitIQlocked();
         void filterIQ();
+        void filterIQFull();
         void adjustY();
         void doCNR();
         void doYNR();
@@ -123,7 +127,7 @@ private:
         qint32 secondFieldPhaseID;
 
         // 1D, 2D and 3D-filtered chroma samples
-        struct {
+        struct Sample {
             double pixel[MAX_HEIGHT][MAX_WIDTH];
         } clpbuffer[3];
 

--- a/tools/ld-chroma-decoder/componentframe.cpp
+++ b/tools/ld-chroma-decoder/componentframe.cpp
@@ -29,7 +29,7 @@ ComponentFrame::ComponentFrame()
 {
 }
 
-void ComponentFrame::init(const LdDecodeMetaData::VideoParameters &videoParameters)
+void ComponentFrame::init(const LdDecodeMetaData::VideoParameters &videoParameters, bool mono)
 {
     width = videoParameters.fieldWidth;
     height = (videoParameters.fieldHeight * 2) - 1;
@@ -39,9 +39,18 @@ void ComponentFrame::init(const LdDecodeMetaData::VideoParameters &videoParamete
     yData.resize(size);
     yData.fill(0.0);
 
-    uData.resize(size);
-    uData.fill(0.0);
+    if(!mono) {
+        uData.resize(size);
+        uData.fill(0.0);
 
-    vData.resize(size);
-    vData.fill(0.0);
+        vData.resize(size);
+        vData.fill(0.0);
+    } else {
+        // Clear and deallocate U/V if they're not used.
+        uData.clear();
+        uData.squeeze();
+
+        vData.clear();
+        vData.squeeze();
+    }
 }

--- a/tools/ld-chroma-decoder/componentframe.h
+++ b/tools/ld-chroma-decoder/componentframe.h
@@ -42,7 +42,8 @@ public:
     ComponentFrame();
 
     // Set the frame's size and clear it to black
-    void init(const LdDecodeMetaData::VideoParameters &videoParameters);
+    // If mono is true, only Y set to black, while U and V are cleared.
+    void init(const LdDecodeMetaData::VideoParameters &videoParameters, bool mono=false);
 
     // Get a pointer to a line of samples. Line numbers are 0-based within the frame.
     // Lines are stored in a contiguous array, so it's safe to get a pointer to
@@ -51,19 +52,19 @@ public:
         return yData.data() + getLineOffset(line);
     }
     double *u(qint32 line) {
-        return uData.data() + getLineOffset(line);
+        return uData.data() + getLineOffsetUV(line);
     }
     double *v(qint32 line) {
-        return vData.data() + getLineOffset(line);
+        return vData.data() + getLineOffsetUV(line);
     }
     const double *y(qint32 line) const {
         return yData.data() + getLineOffset(line);
     }
     const double *u(qint32 line) const {
-        return uData.data() + getLineOffset(line);
+        return uData.data() + getLineOffsetUV(line);
     }
     const double *v(qint32 line) const {
-        return vData.data() + getLineOffset(line);
+        return vData.data() + getLineOffsetUV(line);
     }
 
     qint32 getWidth() const {
@@ -76,7 +77,13 @@ public:
 private:
     qint32 getLineOffset(qint32 line) const {
         assert(line >= 0);
-        assert(line < height);
+        assert(line < yData.size());
+        return line * width;
+    }
+
+    qint32 getLineOffsetUV(qint32 line) const {
+        assert(line >= 0);
+        assert(line < uData.size());
         return line * width;
     }
 

--- a/tools/ld-chroma-decoder/main.cpp
+++ b/tools/ld-chroma-decoder/main.cpp
@@ -235,6 +235,11 @@ int main(int argc, char *argv[])
                                       QCoreApplication::translate("main", "Transform: Overlay the input and output FFTs"));
     parser.addOption(showFFTsOption);
 
+    // Option to use phase compensating decoder
+    QCommandLineOption ntscPhaseComp(QStringList() << "ntsc-phase-comp",
+                                      QCoreApplication::translate("main", "Use NTSC QADM decoder taking burst phase into account (BETA)"));
+    parser.addOption(ntscPhaseComp);
+
     // -- Positional arguments --
 
     // Positional argument to specify input video file
@@ -388,6 +393,11 @@ int main(int argc, char *argv[])
             qCritical("Transform threshold must be between 0 and 1");
             return -1;
         }
+    }
+
+
+    if (parser.isSet(ntscPhaseComp)) {
+        combConfig.phaseCompensation = true;
     }
 
     // Work out the metadata filename

--- a/tools/ld-chroma-decoder/monodecoder.cpp
+++ b/tools/ld-chroma-decoder/monodecoder.cpp
@@ -58,8 +58,12 @@ void MonoThread::decodeFrame(const SourceField &firstField, const SourceField &s
 {
     const LdDecodeMetaData::VideoParameters &videoParameters = config.videoParameters;
 
+    bool ignoreUV = decoderPool.getOutputWriter().getPixelFormat() == OutputWriter::PixelFormat::GRAY16;
+
     // Initialise and clear the component frame
-    componentFrame.init(videoParameters);
+    // Ignore UV if we're doing Grayscale output.
+    // TODO: Fix so we don't need U/V vectors for RGB and YUV output either.
+    componentFrame.init(videoParameters, ignoreUV);
 
     // Interlace the active lines of the two input fields to produce a component frame
     for (qint32 y = videoParameters.firstActiveFrameLine; y < videoParameters.lastActiveFrameLine; y++) {

--- a/tools/ld-chroma-decoder/outputwriter.cpp
+++ b/tools/ld-chroma-decoder/outputwriter.cpp
@@ -260,8 +260,11 @@ void OutputWriter::convertLine(qint32 lineNumber, const ComponentFrame &componen
     // Get pointers to the component data for the active region
     const qint32 inputLine = videoParameters.firstActiveFrameLine + lineNumber;
     const double *inY = componentFrame.y(inputLine) + videoParameters.activeVideoStart;
-    const double *inU = componentFrame.u(inputLine) + videoParameters.activeVideoStart;
-    const double *inV = componentFrame.v(inputLine) + videoParameters.activeVideoStart;
+    // Not used if output is GRAY16
+    const double *inU = (config.pixelFormat != GRAY16) ?
+                            componentFrame.u(inputLine) + videoParameters.activeVideoStart : nullptr;
+    const double *inV = (config.pixelFormat != GRAY16) ?
+                            componentFrame.v(inputLine) + videoParameters.activeVideoStart : nullptr;
 
     const qint32 outputLine = topPadLines + lineNumber;
 

--- a/tools/ld-chroma-decoder/outputwriter.h
+++ b/tools/ld-chroma-decoder/outputwriter.h
@@ -71,6 +71,10 @@ public:
     // For worker threads: convert a component frame to the configured output format
     void convert(const ComponentFrame &componentFrame, OutputFrame &outputFrame) const;
 
+    PixelFormat getPixelFormat() const {
+        return config.pixelFormat;
+    }
+
 private:
     // Configuration parameters
     Configuration config;

--- a/tools/ld-chroma-decoder/palcolour.cpp
+++ b/tools/ld-chroma-decoder/palcolour.cpp
@@ -145,10 +145,22 @@ void PalColour::buildLookUpTables()
     //   the chroma information centred on 0 Hz
     // - working out what the phase of the subcarrier is on each line,
     //   so we can rotate the chroma samples to put U/V on the right axes
-    for (qint32 i = 0; i < videoParameters.fieldWidth; i++) {
-        const double rad = 2 * M_PI * i * videoParameters.fsc / videoParameters.sampleRate;
-        sine[i] = sin(rad);
-        cosine[i] = cos(rad);
+    if(videoParameters.fieldHeight != 263) {
+        for (qint32 i = 0; i < videoParameters.fieldWidth; i++) {
+            const double rad = 2 * M_PI * i * videoParameters.fsc / videoParameters.sampleRate;
+            sine[i] = sin(rad);
+            cosine[i] = cos(rad);
+        }
+    }
+    else {
+        // HACK - For whatever reason Pal-M ends up with the vectors swapped and out of phase
+        // swapping the cos and sin references seem to work around that.
+        // TODO: Find a proper solution to this.
+        for (qint32 i = 0; i < videoParameters.fieldWidth; i++) {
+            const double rad = 2 * M_PI * i * videoParameters.fsc / videoParameters.sampleRate;
+            sine[i] = cos(rad);
+            cosine[i] = sin(rad);
+        }
     }
 
     // Create filter profiles for colour filtering.

--- a/tools/library/tbc/dropouts.cpp
+++ b/tools/library/tbc/dropouts.cpp
@@ -29,6 +29,12 @@ DropOuts::DropOuts(const QVector<qint32> &startx, const QVector<qint32> &endx, c
 {
 }
 
+DropOuts::DropOuts(int reserve_size)
+    : m_startx(), m_endx(), m_fieldLine()
+{
+    reserve(reserve_size);
+}
+
 // Assignment '=' operator
 DropOuts& DropOuts::operator=(const DropOuts &inDropouts)
 {
@@ -55,6 +61,13 @@ void DropOuts::append(const qint32 startx, const qint32 endx, const qint32 field
 qint32 DropOuts::size() const
 {
     return m_startx.size();
+}
+
+void DropOuts::reserve(int size)
+{
+    m_startx.reserve(size);
+    m_endx.reserve(size);
+    m_fieldLine.reserve(size);
 }
 
 // Resize the size of the DropOuts record

--- a/tools/library/tbc/dropouts.h
+++ b/tools/library/tbc/dropouts.h
@@ -33,6 +33,7 @@ class DropOuts
 {
 public:
     DropOuts() = default;
+    DropOuts(int reserve);
     ~DropOuts() = default;
     DropOuts(const DropOuts &) = default;
 
@@ -41,6 +42,7 @@ public:
 
     void append(const qint32 startx, const qint32 endx, const qint32 fieldLine);
     qint32 size() const;
+    void reserve(int size);
     void resize(qint32 size);
     void clear();
     void concatenate();


### PR DESCRIPTION
Aspect ratio setting in ld-analyse
ld-analyse looks for file.tbc.json for file_chroma.tbc if file_chroma.tbc.json does not exist
minor performance tweak to getfielddropouts
large performance improve in monodecoder if output is GRAY16
add ntsc-phase-comp, ntsc variant that doesn't assume color burst lines up correctly (used for vhs, needs some tweaking still), add option in ld-analyse
support PAL-M in PAL decoder