### PR TITLE
Make ld-decode run on windows native

### DIFF
--- a/lddecode/core.py
+++ b/lddecode/core.py
@@ -8,6 +8,8 @@ import time
 from multiprocessing import Process, Queue, JoinableQueue, Pipe
 if platform.system() == 'Darwin':
     from multiprocessing import set_start_method
+if platform.system() != 'Windows':
+    from multiprocessing import Process
 
 # standard numeric/scientific libraries
 import numpy as np
@@ -1081,6 +1083,13 @@ class DemodCache:
         if platform.system() == 'Darwin':
             set_start_method('fork')
 
+        # Workaround to make it work on windows.
+        # Using Process gives a "io.BufferedReader can't be pickled error".
+        # Using Thread may be a bit slower due to how python threads work,
+        # so ideally we would want to
+        # find a better way to do this later.
+        thread_type = Process if platform.system() != 'Windows' else threading.Thread
+
         self.q_in = JoinableQueue()
         self.q_in_metadata = []
 
@@ -1093,7 +1102,7 @@ class DemodCache:
 
         for i in range(num_worker_threads):
             self.threadpipes.append(Pipe())
-            t = Process(
+            t = thread_type(
                 target=self.worker, daemon=True, args=(self.threadpipes[-1][1],)
             )
             t.start()

--- a/lddecode/utils.py
+++ b/lddecode/utils.py
@@ -962,7 +962,7 @@ def write_json(ldd, jsondict, outname):
     fp.write("\n")
     fp.close()
 
-    os.rename(outname + ".tbc.json.tmp", outname + ".tbc.json")
+    os.replace(outname + ".tbc.json.tmp", outname + ".tbc.json")
 
 
 def jsondump_thread(ldd, outname):
@@ -977,7 +977,6 @@ def jsondump_thread(ldd, outname):
     def consume(q):
         while True:
             jsondict = q.get()
-
             if jsondict is None:
                 q.task_done()
                 return


### PR DESCRIPTION
Use Thread instead of process for decoding threads,
Use replace instead of rename to work cross-platform

Next up - c++ bits