### PR TITLE
Fix building on macOS

### DIFF
--- a/tools/ld-chroma-decoder/comb.cpp
+++ b/tools/ld-chroma-decoder/comb.cpp
@@ -66,7 +66,7 @@ static constexpr quint32 CANDIDATE_SHADES[] = {
 
 // Since we are at exactly 4fsc, calculating the value of a in-phase sine wave at a specific position
 // is very simple.
-static constexpr std::array<double, 4> sin4fsc_data = {1.0, 0.0, -1.0, 0.0};
+static constexpr double sin4fsc_data[] = {1.0, 0.0, -1.0, 0.0};
 
 // 4fsc sine wave
 constexpr double sin4fsc(const qint32 i) {


### PR DESCRIPTION
For whatever reason it doesn't like accessing std::array in a constexpr function, but
changing it to a plain array fixes it

Encountered by @Gamnn, fix suggested by @atsampson
According to gamnn on IRC it compiled fine after this fix.