### PR TITLE
Fix ld-ldf-reader build with current ffmpeg

### DIFF
--- a/ld-ldf-reader.c
+++ b/ld-ldf-reader.c
@@ -32,6 +32,7 @@
 #include <unistd.h>
 #include <libavutil/samplefmt.h>
 #include <libavutil/timestamp.h>
+#include <libavcodec/avcodec.h>
 #include <libavformat/avformat.h>
 
 static AVFormatContext *fmt_ctx = NULL;

--- a/ld-ldf-reader.c
+++ b/ld-ldf-reader.c
@@ -97,7 +97,6 @@ static int open_codec_context(int *stream_idx,
     int ret, stream_index;
     AVStream *st;
     const AVCodec *dec = NULL;
-    AVDictionary *opts = NULL;
 
     ret = av_find_best_stream(fmt_ctx, type, -1, -1, NULL, 0);
 
@@ -133,7 +132,7 @@ static int open_codec_context(int *stream_idx,
         }
 
         /* Init the decoder */
-        if ((ret = avcodec_open2(*dec_ctx, dec, &opts)) < 0) {
+        if ((ret = avcodec_open2(*dec_ctx, dec, NULL)) < 0) {
             fprintf(stderr, "Failed to open %s codec\n",
                     av_get_media_type_string(type));
             return ret;


### PR DESCRIPTION
Two patches taken from the ffmpeg example that this code was based on. The #include fix is needed for current ffmpeg Git, but should be fine for older versions too.