### PR TITLE
Use package-relative imports

### DIFF
--- a/lddecode/audio.py
+++ b/lddecode/audio.py
@@ -21,26 +21,10 @@ except ImportError:
 
 # internal libraries
 
-# XXX: figure out how to handle these module imports better for vscode imports
-try:
-    import efm_pll
-except ImportError:
-    from lddecode import efm_pll
-
-try:
-    import core
-except ImportError:
-    from lddecode import core
-
-try:
-    import utils
-except ImportError:
-    from lddecode import utils
-
-try:
-    import utils_logging
-except ImportError:
-    from lddecode import utils_logging
+from . import efm_pll
+from . import core
+from . import utils
+from . import utils_logging
 
 try:
     # If Anaconda's numpy is installed, mkl will use all threads for fft etc

--- a/lddecode/core.py
+++ b/lddecode/core.py
@@ -28,16 +28,8 @@ except ImportError:
 
 # internal libraries
 
-# XXX: figure out how to handle these module imports better for vscode imports
-try:
-    import efm_pll
-except ImportError:
-    from lddecode import efm_pll
-
-try:
-    from utils import *
-except ImportError:
-    from lddecode.utils import *
+from . import efm_pll
+from .utils import *
 
 try:
     # If Anaconda's numpy is installed, mkl will use all threads for fft etc


### PR DESCRIPTION
Use [package-relative imports](https://docs.python.org/3/reference/import.html#package-relative-imports) when one of the files in the lddecode package needs to import one of the others.

This should work regardless of whether the code has been installed.