### PR TITLE
Use setuptools rather than distutils

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,7 +23,7 @@ jobs:
       run: |
         sudo apt-get update
         # This list is from: https://github.com/happycube/ld-decode/wiki/Installation
-        sudo apt-get install -y --no-install-recommends clang libfann-dev python3-numpy python3-scipy python3-matplotlib git qt5-default libqwt-qt5-dev libfftw3-dev python3-tk python3-pandas python3-numba libavformat-dev libavcodec-dev libavutil-dev ffmpeg openssl pv
+        sudo apt-get install -y --no-install-recommends clang libfann-dev python3-setuptools python3-numpy python3-scipy python3-matplotlib git qt5-default libqwt-qt5-dev libfftw3-dev python3-tk python3-pandas python3-numba libavformat-dev libavcodec-dev libavutil-dev ffmpeg openssl pv
 
     - name: Build
       timeout-minutes: 15

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python3
 
-from distutils.core import setup
+from setuptools import setup
 
 setup(
     name='ld-decode',


### PR DESCRIPTION
distutils is [deprecated as of Python 3.10](https://www.python.org/dev/peps/pep-0632/). (It's not actually possible to use ld-decode with Python 3.10 yet, because numba hasn't been ported to it yet.)

Unfortunately this means adding another external dependency - so this commit adds `python3-setuptools` to the CI configuration, and it will also need adding to [Installation](https://github.com/happycube/ld-decode/wiki/Installation) when this is merged.