### PR TITLE
Revert "Use setuptools rather than distutils."

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,7 +23,7 @@ jobs:
       run: |
         sudo apt-get update
         # This list is from: https://github.com/happycube/ld-decode/wiki/Installation
-        sudo apt-get install -y --no-install-recommends clang libfann-dev python3-setuptools python3-numpy python3-scipy python3-matplotlib git qt5-default libqwt-qt5-dev libfftw3-dev python3-tk python3-pandas python3-numba libavformat-dev libavcodec-dev libavutil-dev ffmpeg openssl pv
+        sudo apt-get install -y --no-install-recommends clang libfann-dev python3-numpy python3-scipy python3-matplotlib git qt5-default libqwt-qt5-dev libfftw3-dev python3-tk python3-pandas python3-numba libavformat-dev libavcodec-dev libavutil-dev ffmpeg openssl pv
 
     - name: Build
       timeout-minutes: 15

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python3
 
-from setuptools import setup
+from distutils.core import setup
 
 setup(
     name='ld-decode',


### PR DESCRIPTION
This reverts commit 80660adbad19b4ba739d3ff71e720f28766d1bf1 (#667).

Installation using setuptools doesn't work properly on Ubuntu 21.10 with Python 3.8, so we can't switch to this yet.

Fixes #671 (hopefully).