### PR TITLE
Avoid get_git_info failing if commands fail and add two checks to avoid mean of empty slice warning

### DIFF
--- a/lddecode/core.py
+++ b/lddecode/core.py
@@ -1593,8 +1593,11 @@ class Field:
                 hlens.append(p.len)
 
         LT = {}
-
-        LT["hsync_median"] = np.median(hlens)
+        LT = {}
+        if len(hlens) > 0:
+            LT["hsync_median"] = np.median(hlens)
+        else:
+            LT["hsync_median"] = self.rf.SysParams["hsyncPulseUS"]
 
         hsync_min = LT["hsync_median"] + self.usectoinpx(-0.5)
         hsync_max = LT["hsync_median"] + self.usectoinpx(0.5)
@@ -1940,7 +1943,10 @@ class Field:
                     self.validpulses[i][1].start - self.validpulses[i - 1][1].start
                 )
 
-        return np.mean(linelens)
+        if len(linelens) > 0:
+            return np.mean(linelens)
+        else:
+            return self.inlinelen
 
     def skip_check(self):
         """ This routine checks to see if there's a (probable) VSYNC at the end.

--- a/lddecode/utils.py
+++ b/lddecode/utils.py
@@ -557,6 +557,9 @@ def get_version():
 def get_git_info():
     """ Return git branch and commit for current directory, if available. """
 
+    branch = "UNKNOWN"
+    commit = "UNKNOWN"
+
     version = get_version()
     if ':' in version:
         branch, commit = version.split(':')[0:2]


### PR DESCRIPTION
get_git_version can fail since branch/commit are not initialized in all branches.

the version file also doesn't have a ":" in it, so not sure what the intention was there.