### PR TITLE
ld-chroma-decoder: First/last field/frame line + padding options

### DIFF
--- a/tools/ld-analyse/tbcsource.cpp
+++ b/tools/ld-analyse/tbcsource.cpp
@@ -36,7 +36,7 @@ TbcSource::TbcSource(QObject *parent) : QObject(parent)
     palConfiguration.chromaFilter = PalColour::transform2DFilter;
     ntscConfiguration = ntscColour.getConfiguration();
     outputConfiguration.pixelFormat = OutputWriter::PixelFormat::RGB48;
-    outputConfiguration.usePadding = false;
+    outputConfiguration.paddingAmount = 1;
 }
 
 // Public methods -----------------------------------------------------------------------------------------------------

--- a/tools/ld-chroma-decoder/main.cpp
+++ b/tools/ld-chroma-decoder/main.cpp
@@ -277,7 +277,7 @@ int main(int argc, char *argv[])
 
     // Positional argument to specify output video file
     parser.addPositionalArgument("output", QCoreApplication::translate("main", "Specify output file (omit or - for piped output)"));
-    
+
     // Process the command line options and arguments given by the user
     parser.process(a);
 
@@ -347,7 +347,7 @@ int main(int argc, char *argv[])
             return -1;
         }
     }
-    
+
     if (parser.isSet(chromaGainOption)) {
         const double value = parser.value(chromaGainOption).toDouble();
         palConfig.chromaGain = value;
@@ -488,7 +488,7 @@ int main(int argc, char *argv[])
         qCritical() << "Can only show FFTs with the transform2d/transform3d decoders";
         return -1;
     }
-    
+
     // Select the decoder
     QScopedPointer<Decoder> decoder;
     if (decoderName == "pal2d") {

--- a/tools/ld-chroma-decoder/main.cpp
+++ b/tools/ld-chroma-decoder/main.cpp
@@ -174,6 +174,12 @@ int main(int argc, char *argv[])
                                        QCoreApplication::translate("main", "Output in black and white"));
     parser.addOption(setBwModeOption);
 
+    // Option to select output padding (-pad)
+    QCommandLineOption outputPaddingOption(QStringList() << "pad" << "output-padding",
+                                       QCoreApplication::translate("main", "Pad the output frame to a multiple of this many pixels on both axes (1 means no padding, maximum is 32)"),
+                                       QCoreApplication::translate("main", "number"));
+    parser.addOption(outputPaddingOption);
+
     // Option to select which decoder to use (-f)
     QCommandLineOption decoderOption(QStringList() << "f" << "decoder",
                                      QCoreApplication::translate("main", "Decoder to use (pal2d, transform2d, transform3d, ntsc1d, ntsc2d, ntsc3d, ntsc3dnoadapt, mono; default automatic)"),
@@ -182,9 +188,33 @@ int main(int argc, char *argv[])
 
     // Option to select the number of threads (-t)
     QCommandLineOption threadsOption(QStringList() << "t" << "threads",
-                                        QCoreApplication::translate("main", "Specify the number of concurrent threads (default number of logical CPUs)"),
-                                        QCoreApplication::translate("main", "number"));
+                                     QCoreApplication::translate("main", "Specify the number of concurrent threads (default number of logical CPUs)"),
+                                     QCoreApplication::translate("main", "number"));
     parser.addOption(threadsOption);
+
+    // Option to override calculated firstActiveFieldLine in our video parameters (-ffll)
+    QCommandLineOption firstFieldLineOption(QStringList() << "ffll" << "first_active_field_line",
+                                            QCoreApplication::translate("main", "The first visible line of a field. Range 1-259 for NTSC (default: 20), 2-308 for PAL (default: 22)"),
+                                            QCoreApplication::translate("main", "number"));
+    parser.addOption(firstFieldLineOption);
+
+    // Option to override calculated lastActiveFieldLine in our video parameters (-lfll)
+    QCommandLineOption lastFieldLineOption(QStringList() << "lfll" << "last_active_field_line",
+                                           QCoreApplication::translate("main", "The last visible line of a field. Range 1-259 for NTSC (default: 259), 2-308 for PAL (default: 308)"),
+                                           QCoreApplication::translate("main", "number"));
+    parser.addOption(lastFieldLineOption);
+
+    // Option to override calculated firstActiveFrameLine in our video parameters (-ffrl)
+    QCommandLineOption firstFrameLineOption(QStringList() << "ffrl" << "first_active_frame_line",
+                                            QCoreApplication::translate("main", "The first visible line of a frame. Range 1-525 for NTSC (default: 40), 1-620 for PAL (default: 44)"),
+                                            QCoreApplication::translate("main", "number"));
+    parser.addOption(firstFrameLineOption);
+
+    // Option to override calculated lastActiveFieldLine in our video parameters (-lfll)
+    QCommandLineOption lastFrameLineOption(QStringList() << "lfrl" << "last_active_frame_line",
+                                           QCoreApplication::translate("main", "The last visible line of a frame. Range 1-525 for NTSC (default: 525), 1-620 for PAL (default: 620)"),
+                                           QCoreApplication::translate("main", "number"));
+    parser.addOption(lastFrameLineOption);
 
     // -- NTSC decoder options --
 
@@ -247,7 +277,7 @@ int main(int argc, char *argv[])
 
     // Positional argument to specify output video file
     parser.addPositionalArgument("output", QCoreApplication::translate("main", "Specify output file (omit or - for piped output)"));
-
+    
     // Process the command line options and arguments given by the user
     parser.process(a);
 
@@ -317,7 +347,7 @@ int main(int argc, char *argv[])
             return -1;
         }
     }
-
+    
     if (parser.isSet(chromaGainOption)) {
         const double value = parser.value(chromaGainOption).toDouble();
         palConfig.chromaGain = value;
@@ -395,9 +425,25 @@ int main(int argc, char *argv[])
         }
     }
 
-
     if (parser.isSet(ntscPhaseComp)) {
         combConfig.phaseCompensation = true;
+    }
+    
+    LdDecodeMetaData::LineParameters lineParameters;
+    if (parser.isSet(firstFieldLineOption)) {
+        lineParameters.firstActiveFieldLine = parser.value(firstFieldLineOption).toInt();
+    }
+    
+    if (parser.isSet(lastFieldLineOption)) {
+        lineParameters.lastActiveFieldLine = parser.value(lastFieldLineOption).toInt();
+    }
+    
+    if (parser.isSet(firstFrameLineOption)) {
+        lineParameters.firstActiveFrameLine = parser.value(firstFrameLineOption).toInt();
+    }
+    
+    if (parser.isSet(lastFrameLineOption)) {
+        lineParameters.lastActiveFrameLine = parser.value(lastFrameLineOption).toInt();
     }
 
     // Work out the metadata filename
@@ -412,7 +458,9 @@ int main(int argc, char *argv[])
         qInfo() << "Unable to open ld-decode metadata file";
         return -1;
     }
-
+    
+    metaData.processLineParameters(lineParameters);
+    
     // Reverse field order if required
     if (parser.isSet(setReverseOption)) {
         qInfo() << "Expected field order is reversed to second field/first field";
@@ -440,7 +488,7 @@ int main(int argc, char *argv[])
         qCritical() << "Can only show FFTs with the transform2d/transform3d decoders";
         return -1;
     }
-
+    
     // Select the decoder
     QScopedPointer<Decoder> decoder;
     if (decoderName == "pal2d") {
@@ -500,6 +548,14 @@ int main(int argc, char *argv[])
         return -1;
     }
 
+    if (parser.isSet(outputPaddingOption)) {
+        outputConfig.paddingAmount = parser.value(outputPaddingOption).toInt();
+        if (outputConfig.paddingAmount < 1 || outputConfig.paddingAmount > 32) {
+            qInfo() << "Invalid value" << outputConfig.paddingAmount << "specified for padding amount, defaulting to 8.";
+            outputConfig.paddingAmount = 8;
+        }
+    }
+    
     // Perform the processing
     DecoderPool decoderPool(*decoder, inputFileName, metaData, outputConfig, outputFileName, startFrame, length, maxThreads);
     if (!decoderPool.process()) {

--- a/tools/ld-chroma-decoder/outputwriter.cpp
+++ b/tools/ld-chroma-decoder/outputwriter.cpp
@@ -62,12 +62,14 @@ void OutputWriter::updateConfiguration(LdDecodeMetaData::VideoParameters &_video
     activeHeight = videoParameters.lastActiveFrameLine - videoParameters.firstActiveFrameLine;
     outputHeight = activeHeight;
 
-    if (config.usePadding) {
-        // Both width and height should be divisible by 8, as video codecs expect this.
-        // Expand horizontal active region so the width is divisible by 8.
+    if (config.paddingAmount > 1) {
+        // Some video codecs require the width and height of a video to be divisible by
+        // a given number of samples on each axis.
+        
+        // Expand horizontal active region so the width is divisible by the specified padding factor.
         while (true) {
             activeWidth = videoParameters.activeVideoEnd - videoParameters.activeVideoStart;
-            if ((activeWidth % 8) == 0) {
+            if ((activeWidth % config.paddingAmount) == 0) {
                 break;
             }
 
@@ -79,10 +81,10 @@ void OutputWriter::updateConfiguration(LdDecodeMetaData::VideoParameters &_video
             }
         }
 
-        // Insert empty padding lines so the height is divisible by 8
+        // Insert empty padding lines so the height is divisible by by the specified padding factor.
         while (true) {
             outputHeight = topPadLines + activeHeight + bottomPadLines;
-            if ((outputHeight % 8) == 0) {
+            if ((outputHeight % config.paddingAmount) == 0) {
                 break;
             }
 

--- a/tools/ld-chroma-decoder/outputwriter.h
+++ b/tools/ld-chroma-decoder/outputwriter.h
@@ -50,7 +50,7 @@ public:
 
     // Output settings
     struct Configuration {
-        bool usePadding = true;
+        qint32 paddingAmount = 8;
         PixelFormat pixelFormat = RGB48;
         bool outputY4m = false;
     };

--- a/tools/library/tbc/lddecodemetadata.cpp
+++ b/tools/library/tbc/lddecodemetadata.cpp
@@ -24,6 +24,25 @@
 
 #include "lddecodemetadata.h"
 
+// Default line parameters for PAL decoding
+const qint32 LdDecodeMetaData::LineParameters::sMinPALFirstActiveFrameLine = 2;
+const qint32 LdDecodeMetaData::LineParameters::sDefaultPALFirstActiveFieldLine = 22;
+const qint32 LdDecodeMetaData::LineParameters::sDefaultPALLastActiveFieldLine = 308;
+const qint32 LdDecodeMetaData::LineParameters::sDefaultPALFirstActiveFrameLine = 44;
+const qint32 LdDecodeMetaData::LineParameters::sDefaultPALLastActiveFrameLine = 620;
+const qint32 LdDecodeMetaData::LineParameters::sDefaultPALFieldHeightCheck = 313;
+
+// Default line parameters for NTSC decoding
+const qint32 LdDecodeMetaData::LineParameters::sMinNTSCFirstActiveFrameLine = 1;
+const qint32 LdDecodeMetaData::LineParameters::sDefaultNTSCFirstActiveFieldLine = 20;
+const qint32 LdDecodeMetaData::LineParameters::sDefaultNTSCLastActiveFieldLine = 259;
+const qint32 LdDecodeMetaData::LineParameters::sDefaultNTSCFirstActiveFrameLine = 40;
+const qint32 LdDecodeMetaData::LineParameters::sDefaultNTSCLastActiveFrameLine = 525;
+const qint32 LdDecodeMetaData::LineParameters::sDefaultNTSCFieldHeightCheck = 263;
+
+// Default line parameters for Auto/Unknown decoding
+const qint32 LdDecodeMetaData::LineParameters::sDefaultAutoFirstActiveFieldLine = 20;
+
 LdDecodeMetaData::LdDecodeMetaData()
 {
     // Set defaults
@@ -68,10 +87,11 @@ bool LdDecodeMetaData::write(QString fileName)
 // This method returns the videoParameters metadata
 LdDecodeMetaData::VideoParameters LdDecodeMetaData::getVideoParameters()
 {
-    VideoParameters videoParameters;
-
-    // Read the video paramters
-    if (json.size({"videoParameters"}) > 0) {
+    if (videoParameters.isValid) {
+        // Return our existing video parameters
+        return videoParameters;
+    } else if (json.size({"videoParameters"}) > 0) {
+        // Read the video paramters
         videoParameters.numberOfSequentialFields = json.value({"videoParameters", "numberOfSequentialFields"}).toInt();
         videoParameters.isSourcePal = json.value({"videoParameters", "isSourcePal"}).toBool();
         videoParameters.isSubcarrierLocked = json.value({"videoParameters", "isSubcarrierLocked"}).toBool();
@@ -94,47 +114,21 @@ LdDecodeMetaData::VideoParameters LdDecodeMetaData::getVideoParameters()
 
         videoParameters.gitBranch = json.value({"videoParameters", "gitBranch"}).toString();
         videoParameters.gitCommit = json.value({"videoParameters", "gitCommit"}).toString();
+        
+        videoParameters.isValid = true;
     } else {
         qCritical("JSON file invalid: videoParameters object is not defined");
         return videoParameters;
-    }
-
-    // Add in the active field line range psuedo-metadata
-    if (videoParameters.fieldHeight == 313) {
-        // PAL
-        videoParameters.firstActiveFieldLine = 22;
-        videoParameters.lastActiveFieldLine = 308;
-
-        // Interlaced line 44 is PAL line 23 (the first active half-line)
-        videoParameters.firstActiveFrameLine = 44;
-        // Interlaced line 619 is PAL line 623 (the last active half-line)
-        videoParameters.lastActiveFrameLine = 620;
-    } else if (videoParameters.fieldHeight == 263) {
-        // NTSC
-        videoParameters.firstActiveFieldLine = 20;
-        videoParameters.lastActiveFieldLine = 259;
-
-        // Interlaced line 40 is NTSC line 21 (the closed-caption line before the first active half-line)
-        videoParameters.firstActiveFrameLine = 40;
-        // Interlaced line 524 is NTSC line 263 (the last active half-line).
-        videoParameters.lastActiveFrameLine = 525;
-    } else {
-        // Unknown video system, guessing some stuff for now instead of risking going out of bounds.
-        qCritical("Unknown video system! Output may not be correct!");
-
-        videoParameters.firstActiveFieldLine = 20;
-        videoParameters.lastActiveFieldLine = videoParameters.fieldHeight - 5;
-
-        videoParameters.firstActiveFrameLine = videoParameters.firstActiveFieldLine * 2;
-        videoParameters.lastActiveFrameLine = videoParameters.lastActiveFieldLine * 2;
     }
 
     return videoParameters;
 }
 
 // This method sets the videoParameters metadata
-void LdDecodeMetaData::setVideoParameters (LdDecodeMetaData::VideoParameters _videoParameters)
+void LdDecodeMetaData::setVideoParameters(LdDecodeMetaData::VideoParameters _videoParameters)
 {
+    videoParameters = _videoParameters;
+    
     // Write the video parameters
     json.setValue({"videoParameters", "numberOfSequentialFields"}, getNumberOfFields());
     json.setValue({"videoParameters", "isSourcePal"}, _videoParameters.isSourcePal);
@@ -158,19 +152,23 @@ void LdDecodeMetaData::setVideoParameters (LdDecodeMetaData::VideoParameters _vi
 
     json.setValue({"videoParameters", "gitBranch"}, _videoParameters.gitBranch);
     json.setValue({"videoParameters", "gitCommit"}, _videoParameters.gitCommit);
+    
+    videoParameters.isValid = true;
 }
 
 // This method returns the pcmAudioParameters metadata
 LdDecodeMetaData::PcmAudioParameters LdDecodeMetaData::getPcmAudioParameters()
 {
-    PcmAudioParameters pcmAudioParameters;
-
-    if (json.size({"pcmAudioParameters"}) > 0) {
+    if (pcmAudioParameters.isValid) {
+        return pcmAudioParameters;
+    } else if (json.size({"pcmAudioParameters"}) > 0) {
         // Read the PCM audio data
         pcmAudioParameters.sampleRate = json.value({"pcmAudioParameters", "sampleRate"}).toInt();
         pcmAudioParameters.isLittleEndian = json.value({"pcmAudioParameters", "isLittleEndian"}).toBool();
         pcmAudioParameters.isSigned = json.value({"pcmAudioParameters", "isSigned"}).toBool();
         pcmAudioParameters.bits = json.value({"pcmAudioParameters", "bits"}).toInt();
+        
+        pcmAudioParameters.isValid = true;
     } else {
         qCritical("JSON file invalid: pcmAudioParameters is not defined");
         return pcmAudioParameters;
@@ -182,10 +180,106 @@ LdDecodeMetaData::PcmAudioParameters LdDecodeMetaData::getPcmAudioParameters()
 // This method sets the pcmAudioParameters metadata
 void LdDecodeMetaData::setPcmAudioParameters(LdDecodeMetaData::PcmAudioParameters _pcmAudioParam)
 {
+    pcmAudioParameters = _pcmAudioParam;
+    
     json.setValue({"pcmAudioParameters", "sampleRate"}, _pcmAudioParam.sampleRate);
     json.setValue({"pcmAudioParameters", "isLittleEndian"}, _pcmAudioParam.isLittleEndian);
     json.setValue({"pcmAudioParameters", "isSigned"}, _pcmAudioParam.isSigned);
     json.setValue({"pcmAudioParameters", "bits"}, _pcmAudioParam.bits);
+    
+    pcmAudioParameters.isValid = true;
+}
+
+// Validate any user-specified line parameters and set them to reasonable defaults + warn if invalid.
+void LdDecodeMetaData::processLineParameters(LdDecodeMetaData::LineParameters &_lineParameters)
+{
+    _lineParameters.process(videoParameters.fieldHeight);
+    lineParameters = _lineParameters;
+    
+    videoParameters.firstActiveFieldLine = lineParameters.firstActiveFieldLine;
+    videoParameters.lastActiveFieldLine = lineParameters.lastActiveFieldLine;
+    videoParameters.firstActiveFrameLine = lineParameters.firstActiveFrameLine;
+    videoParameters.lastActiveFrameLine = lineParameters.lastActiveFrameLine;
+}
+
+// Validate and process line parameters, setting defaults if not overridden by the user.
+void LdDecodeMetaData::LineParameters::process(qint32 fieldHeight)
+{
+    const bool firstFieldLineExists = firstActiveFieldLine != -1;
+    const bool lastFieldLineExists = lastActiveFieldLine != -1;
+    const bool firstFrameLineExists = firstActiveFrameLine != -1;
+    const bool lastFrameLineExists = lastActiveFrameLine != -1;
+    
+    const bool isPal = fieldHeight == sDefaultPALFieldHeightCheck;
+    const bool isNtsc = fieldHeight == sDefaultNTSCFieldHeightCheck;
+    
+    const qint32 defaultFirstFieldLine = isNtsc ? sDefaultNTSCFirstActiveFieldLine : (isPal ? sDefaultPALFirstActiveFieldLine : sDefaultAutoFirstActiveFieldLine);
+    const qint32 defaultLastFieldLine = isNtsc ? sDefaultNTSCLastActiveFieldLine : (isPal ? sDefaultPALLastActiveFieldLine : -1);
+    const qint32 minFirstFrameLine = isNtsc ? sMinNTSCFirstActiveFrameLine : (isPal ? sMinPALFirstActiveFrameLine : 1);
+    const qint32 defaultFirstFrameLine = isNtsc ? sDefaultNTSCFirstActiveFrameLine : (isPal ? sDefaultPALFirstActiveFrameLine : -1);
+    const qint32 defaultLastFrameLine = isNtsc ? sDefaultNTSCLastActiveFrameLine : (isPal ? sDefaultPALLastActiveFrameLine : -1);
+
+    // Validate and potentially fix the first active field line (needs to be valid in case we're not in PAL or NTSC mode).    
+    if (firstActiveFieldLine < 1 || firstActiveFieldLine > defaultLastFieldLine) {
+        if (firstFieldLineExists) {
+            qInfo().nospace() << "Specified first active field line " << firstActiveFieldLine << " out of bounds (1 to "
+                              << defaultLastFieldLine << "), restting to default (" << defaultFirstFieldLine << ").";
+        }
+        firstActiveFieldLine = defaultFirstFieldLine;
+    }
+
+    // Unknown video system, guessing some stuff for now instead of risking going out of bounds.
+    if (!isPal && !isNtsc) {
+        qCritical("Unknown video system! Output may not be correct!");
+
+        lastActiveFieldLine = lastFieldLineExists ? lastActiveFieldLine : (fieldHeight - 5);
+        firstActiveFrameLine = firstFrameLineExists ? firstActiveFrameLine : (firstActiveFieldLine * 2);
+        lastActiveFrameLine = lastFrameLineExists ? lastActiveFrameLine : (lastActiveFieldLine * 2);
+        return;
+    }
+    
+    // Validate and potentially fix the last active field line.
+    if (lastActiveFieldLine < 1 || lastActiveFieldLine > defaultLastFieldLine) {
+        if (lastFieldLineExists) {
+            qInfo().nospace() << "Specified last active field line " << lastActiveFieldLine << " out of bounds (1 to "
+                              << defaultLastFieldLine << "), restting to default (" << defaultLastFieldLine << ").";
+        }
+        lastActiveFieldLine = defaultLastFieldLine;
+    }
+    
+    // Range-check the first and last active field lines.
+    if (firstActiveFieldLine > lastActiveFieldLine) {
+       qInfo().nospace() << "Specified last active field line " << lastActiveFieldLine << " is before specified first active field line"
+                         << firstActiveFieldLine << ", resetting to defaults (" << defaultFirstFieldLine << "-" << defaultLastFieldLine << ").";
+        firstActiveFieldLine = defaultFirstFieldLine;
+        lastActiveFieldLine = defaultLastFieldLine;
+    }
+
+    // Validate and potentially fix the first active frame line.
+    if (firstActiveFrameLine < minFirstFrameLine || firstActiveFrameLine > defaultLastFrameLine) {
+        if (firstFrameLineExists) {
+            qInfo().nospace() << "Specified first active frame line " << firstActiveFrameLine << " out of bounds (" << minFirstFrameLine << " to "
+                              << defaultLastFrameLine << "), restting to default (" << defaultFirstFrameLine << ").";
+        }
+        firstActiveFrameLine = defaultFirstFrameLine;
+    }
+
+    // Validate and potentially fix the last active frame line.
+    if (lastActiveFrameLine < minFirstFrameLine || lastActiveFrameLine > defaultLastFrameLine) {
+        if (lastFrameLineExists) {
+            qInfo().nospace() << "Specified last active frame line " << lastActiveFrameLine << " out of bounds (" << minFirstFrameLine << " to "
+                              << defaultLastFrameLine << "), restting to default (" << defaultLastFrameLine << ").";
+        }
+        lastActiveFrameLine = defaultLastFrameLine;
+    }
+
+    // Range-check the first and last active frame lines.
+    if (firstActiveFrameLine > lastActiveFrameLine) {
+       qInfo().nospace() << "Specified last active frame line " << lastActiveFrameLine << " is before specified first active frame line"
+                         << firstActiveFrameLine << ", resetting to defaults (" << defaultFirstFrameLine << "-" << defaultLastFrameLine << ").";
+        firstActiveFrameLine = defaultFirstFrameLine;
+        lastActiveFrameLine = defaultLastFrameLine;
+    }
 }
 
 // This method gets the metadata for the specified sequential field number (indexed from 1 (not 0!))
@@ -484,6 +578,7 @@ void LdDecodeMetaData::clearFieldDropOuts(qint32 sequentialFieldNumber)
     json.remove({"fields", fieldNumber, "dropOuts", "endx"});
     json.remove({"fields", fieldNumber, "dropOuts", "fieldLine"});
 }
+
 
 // This method appends a new field to the existing metadata
 void LdDecodeMetaData::appendField(LdDecodeMetaData::Field _field)

--- a/tools/library/tbc/lddecodemetadata.cpp
+++ b/tools/library/tbc/lddecodemetadata.cpp
@@ -28,7 +28,9 @@
 const qint32 LdDecodeMetaData::LineParameters::sMinPALFirstActiveFrameLine = 2;
 const qint32 LdDecodeMetaData::LineParameters::sDefaultPALFirstActiveFieldLine = 22;
 const qint32 LdDecodeMetaData::LineParameters::sDefaultPALLastActiveFieldLine = 308;
+// Interlaced line 44 is PAL line 23 (the first active half-line)
 const qint32 LdDecodeMetaData::LineParameters::sDefaultPALFirstActiveFrameLine = 44;
+// Interlaced line 619 is PAL line 623 (the last active half-line)
 const qint32 LdDecodeMetaData::LineParameters::sDefaultPALLastActiveFrameLine = 620;
 const qint32 LdDecodeMetaData::LineParameters::sDefaultPALFieldHeightCheck = 313;
 
@@ -36,7 +38,9 @@ const qint32 LdDecodeMetaData::LineParameters::sDefaultPALFieldHeightCheck = 313
 const qint32 LdDecodeMetaData::LineParameters::sMinNTSCFirstActiveFrameLine = 1;
 const qint32 LdDecodeMetaData::LineParameters::sDefaultNTSCFirstActiveFieldLine = 20;
 const qint32 LdDecodeMetaData::LineParameters::sDefaultNTSCLastActiveFieldLine = 259;
+// Interlaced line 40 is NTSC line 21 (the closed-caption line before the first active half-line)
 const qint32 LdDecodeMetaData::LineParameters::sDefaultNTSCFirstActiveFrameLine = 40;
+// Interlaced line 524 is NTSC line 263 (the last active half-line).
 const qint32 LdDecodeMetaData::LineParameters::sDefaultNTSCLastActiveFrameLine = 525;
 const qint32 LdDecodeMetaData::LineParameters::sDefaultNTSCFieldHeightCheck = 263;
 
@@ -578,7 +582,6 @@ void LdDecodeMetaData::clearFieldDropOuts(qint32 sequentialFieldNumber)
     json.remove({"fields", fieldNumber, "dropOuts", "endx"});
     json.remove({"fields", fieldNumber, "dropOuts", "fieldLine"});
 }
-
 
 // This method appends a new field to the existing metadata
 void LdDecodeMetaData::appendField(LdDecodeMetaData::Field _field)


### PR DESCRIPTION
- Added options --ffll / --first_active_field_line, --lfll / --last_active_field_line, --ffrl / --first_active_frame_line, --lfrl / --last_active_frame_line.
- Added value and range validation for both PAL and NTSC modes.
- Added option --pad / --output-padding to optionally pad along X and Y from 1 (disabled) to 32 pixels.
- Made LdDecodeMetaData cache the current VideoParameters struct rather than always pulling it from JSON on every getVideoParameters call.