### PR TITLE
Fixed issue #707

### DIFF
--- a/tools/ld-analyse/tbcsource.cpp
+++ b/tools/ld-analyse/tbcsource.cpp
@@ -818,6 +818,10 @@ void TbcSource::startBackgroundLoad(QString sourceFilename)
         // Get the video parameters from the metadata
         LdDecodeMetaData::VideoParameters videoParameters = ldDecodeMetaData.getVideoParameters();
 
+        // Use default line parameters, as the user will not override it
+        LdDecodeMetaData::LineParameters lineParameters;
+        ldDecodeMetaData.processLineParameters(lineParameters);
+
         // Open the new source video
         qDebug() << "TbcSource::startBackgroundLoad(): Loading TBC file...";
         emit busyLoading("Loading TBC file...");


### PR DESCRIPTION
ld-analyse's TBC source was not initialising the line parameters for the video parameters.