### PR TITLE
Remove ellipsis from "Reload TBC" option

### DIFF
--- a/tools/ld-analyse/mainwindow.ui
+++ b/tools/ld-analyse/mainwindow.ui
@@ -621,7 +621,7 @@
   </action>
   <action name="actionReload_TBC">
    <property name="text">
-    <string>Reload TBC...</string>
+    <string>Reload TBC</string>
    </property>
    <property name="shortcut">
     <string>Ctrl+A</string>


### PR DESCRIPTION
Ellipses mean there's a dialogue box, and in this case there isn't.