### PR TITLE
add -qt5 option to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ DESTDIR =
 
 # Tools you might want to override
 PYTHON3 ?= python3
-QMAKE ?= qmake
+QMAKE ?= qmake -qt5
 
 ### Get the current git commit information ###
 BRANCH = $(shell git rev-parse --abbrev-ref HEAD)

--- a/tools/ld-analyse/mainwindow.ui
+++ b/tools/ld-analyse/mainwindow.ui
@@ -621,7 +621,7 @@
   </action>
   <action name="actionReload_TBC">
    <property name="text">
-    <string>Reload TBC...</string>
+    <string>Reload TBC</string>
    </property>
    <property name="shortcut">
     <string>Ctrl+A</string>


### PR DESCRIPTION
add -qt5 option to qmake line in Makefile
    
qt5-default no longer exists under Debian bullseye and Ubuntu 21.04
