### PR TITLE
Clear LdDecodeMetaData contents before reading a file

### DIFF
--- a/tools/library/tbc/lddecodemetadata.cpp
+++ b/tools/library/tbc/lddecodemetadata.cpp
@@ -355,21 +355,33 @@ void LdDecodeMetaData::Field::write(JsonWriter &writer) const
 
 LdDecodeMetaData::LdDecodeMetaData()
 {
-    // Set defaults
-    isFirstFieldFirst = false;
+    clear();
+}
+
+// Reset the metadata to the defaults
+void LdDecodeMetaData::clear()
+{
+    // Default to the standard still-frame field order (of first field first)
+    isFirstFieldFirst = true;
+
+    // Reset the parameters to their defaults
+    videoParameters = VideoParameters();
+    lineParameters = LineParameters();
+    pcmAudioParameters = PcmAudioParameters();
+
+    fields.clear();
 }
 
 // Read all metadata from a JSON file
 bool LdDecodeMetaData::read(QString fileName)
 {
-    // Default to the standard still-frame field order (of first field first)
-    isFirstFieldFirst = true;
-
     std::ifstream jsonFile(fileName.toStdString());
     if (jsonFile.fail()) {
         qCritical("Opening JSON input file failed: JSON file cannot be opened/does not exist");
         return false;
     }
+
+    clear();
 
     JsonReader reader(jsonFile);
 

--- a/tools/library/tbc/lddecodemetadata.h
+++ b/tools/library/tbc/lddecodemetadata.h
@@ -194,6 +194,7 @@ public:
     LdDecodeMetaData(const LdDecodeMetaData &) = delete;
     LdDecodeMetaData& operator=(const LdDecodeMetaData &) = delete;
 
+    void clear();
     bool read(QString fileName);
     bool write(QString fileName) const;
     void readFields(JsonReader &reader);


### PR DESCRIPTION
ld-analyse reuses the same object when you reload a file, which failed because the existing metadata and fields were still present.

Fixes #722.