### PR TITLE
Handle open failures in ld-analyse more gracefully

### DIFF
--- a/tools/ld-analyse/mainwindow.cpp
+++ b/tools/ld-analyse/mainwindow.cpp
@@ -972,6 +972,9 @@ void MainWindow::on_finishedLoading()
 {
     qDebug() << "MainWindow::on_finishedLoading(): Called";
 
+    // Hide the busy dialogue
+    busyDialog->hide();
+
     // Ensure source loaded ok
     if (tbcSource.getIsSourceLoaded()) {
         // Generate the graph data
@@ -1018,8 +1021,7 @@ void MainWindow::on_finishedLoading()
         messageBox.setFixedSize(500, 200);
     }
 
-    // Hide the busy dialogue and enable the main window
-    busyDialog->hide();
+    // Enable the main window
     this->setEnabled(true);
 }
 

--- a/tools/ld-analyse/mainwindow.cpp
+++ b/tools/ld-analyse/mainwindow.cpp
@@ -1015,9 +1015,9 @@ void MainWindow::on_finishedLoading()
         // Load failed
         updateGuiUnloaded();
 
-        // Show an error to the user
+        // Show the error to the user
         QMessageBox messageBox;
-        messageBox.warning(this, "Error", "Could not load source TBC file");
+        messageBox.warning(this, "Error", tbcSource.getLastLoadError());
         messageBox.setFixedSize(500, 200);
     }
 

--- a/tools/ld-analyse/tbcsource.cpp
+++ b/tools/ld-analyse/tbcsource.cpp
@@ -83,6 +83,14 @@ QString TbcSource::getCurrentSourceFilename()
     return currentSourceFilename;
 }
 
+// If loadSource failed, return a description of the last error
+QString TbcSource::getLastLoadError()
+{
+    if (sourceReady) return QString();
+
+    return lastLoadError;
+}
+
 // Method to set the highlight dropouts mode (true = dropouts highlighted)
 void TbcSource::setHighlightDropouts(bool _state)
 {

--- a/tools/ld-analyse/tbcsource.cpp
+++ b/tools/ld-analyse/tbcsource.cpp
@@ -847,7 +847,7 @@ void TbcSource::startBackgroundLoad(QString sourceFilename)
         palColour.updateConfiguration(videoParameters, palConfiguration);
     } else {
         // Enable this option by default if we are loading a vhs-decode chroma only tbc file.
-        if(chroma_tbc) {
+        if (chroma_tbc) {
             ntscConfiguration.phaseCompensation = true;
         }
         ntscColour.updateConfiguration(videoParameters, ntscConfiguration);

--- a/tools/ld-analyse/tbcsource.cpp
+++ b/tools/ld-analyse/tbcsource.cpp
@@ -4,7 +4,7 @@
 
     ld-analyse - TBC output analysis
     Copyright (C) 2018-2021 Simon Inns
-    Copyright (C) 2021 Adam Sampson
+    Copyright (C) 2021-2022 Adam Sampson
 
     This file is part of ld-decode-tools.
 
@@ -812,35 +812,34 @@ void TbcSource::startBackgroundLoad(QString sourceFilename)
         qWarning() << "Open TBC JSON metadata failed for filename" << sourceFilename;
         currentSourceFilename.clear();
 
-        // Show an error to the user
-        lastLoadError = "Could not open TBC JSON metadata file for the TBC input file!";
-    } else {
-        // Get the video parameters from the metadata
-        LdDecodeMetaData::VideoParameters videoParameters = ldDecodeMetaData.getVideoParameters();
-
-        // Use default line parameters, as the user will not override it
-        LdDecodeMetaData::LineParameters lineParameters;
-        ldDecodeMetaData.processLineParameters(lineParameters);
-
-        // Open the new source video
-        qDebug() << "TbcSource::startBackgroundLoad(): Loading TBC file...";
-        emit busyLoading("Loading TBC file...");
-        if (!sourceVideo.open(sourceFilename, videoParameters.fieldWidth * videoParameters.fieldHeight)) {
-            // Open failed
-            qWarning() << "Open TBC file failed for filename" << sourceFilename;
-            currentSourceFilename.clear();
-
-            // Show an error to the user
-            lastLoadError = "Could not open TBC data file!";
-        } else {
-            // Both the video and metadata files are now open
-            sourceReady = true;
-            currentSourceFilename = sourceFilename;
-        }
+        // Show an error to the user and give up
+        lastLoadError = "Could not load source TBC JSON metadata file";
+        return;
     }
 
-    // Get the video parameters
+    // Get the video parameters from the metadata
     LdDecodeMetaData::VideoParameters videoParameters = ldDecodeMetaData.getVideoParameters();
+
+    // Use default line parameters, as the user will not override it
+    LdDecodeMetaData::LineParameters lineParameters;
+    ldDecodeMetaData.processLineParameters(lineParameters);
+
+    // Open the new source video
+    qDebug() << "TbcSource::startBackgroundLoad(): Loading TBC file...";
+    emit busyLoading("Loading TBC file...");
+    if (!sourceVideo.open(sourceFilename, videoParameters.fieldWidth * videoParameters.fieldHeight)) {
+        // Open failed
+        qWarning() << "Open TBC file failed for filename" << sourceFilename;
+        currentSourceFilename.clear();
+
+        // Show an error to the user and give up
+        lastLoadError = "Could not open source TBC data file";
+        return;
+    }
+
+    // Both the video and metadata files are now open
+    sourceReady = true;
+    currentSourceFilename = sourceFilename;
 
     // Configure the chroma decoder
     if (getIsSourcePal()) {

--- a/tools/ld-analyse/tbcsource.h
+++ b/tools/ld-analyse/tbcsource.h
@@ -68,6 +68,7 @@ public:
     void unloadSource();
     bool getIsSourceLoaded();
     QString getCurrentSourceFilename();
+    QString getLastLoadError();
 
     void setHighlightDropouts(bool _state);
     void setChromaDecoder(bool _state);


### PR DESCRIPTION
Fixes #724.

Starting ld-analyse with an invalid filename will now give a more useful error dialogue.