### PR TITLE
Use double values for sampleRates and fSC

### DIFF
--- a/lddecode/core.py
+++ b/lddecode/core.py
@@ -3966,10 +3966,8 @@ class LDdecode:
 
         vp["isSourcePal"] = True if f.rf.system == "PAL" else False
 
-        vp["fsc"] = int(f.rf.SysParams["fsc_mhz"] * 1000000)
         vp["fieldWidth"] = f.rf.SysParams["outlinelen"]
-        vp["sampleRate"] = vp["fsc"] * 4
-        spu = vp["sampleRate"] / 1000000
+        vp["sampleRate"] = f.rf.SysParams["outfreq"] * 1000000
 
         vp["black16bIre"] = np.float(f.hz_to_output(f.rf.iretohz(self.blackIRE)))
         vp["white16bIre"] = np.float(f.hz_to_output(f.rf.iretohz(100)))
@@ -3978,6 +3976,7 @@ class LDdecode:
 
         # current burst adjustment as of 2/27/19, update when #158 is fixed!
         badj = -1.4
+        spu = f.rf.SysParams["outfreq"]
         vp["colourBurstStart"] = np.round(
             (f.rf.SysParams["colorBurstUS"][0] * spu) + badj
         )

--- a/tools/ld-analyse/tbcsource.cpp
+++ b/tools/ld-analyse/tbcsource.cpp
@@ -828,10 +828,6 @@ void TbcSource::startBackgroundLoad(QString sourceFilename)
     // Get the video parameters from the metadata
     LdDecodeMetaData::VideoParameters videoParameters = ldDecodeMetaData.getVideoParameters();
 
-    // Use default line parameters, as the user will not override it
-    LdDecodeMetaData::LineParameters lineParameters;
-    ldDecodeMetaData.processLineParameters(lineParameters);
-
     // Open the new source video
     qDebug() << "TbcSource::startBackgroundLoad(): Loading TBC file...";
     emit busyLoading("Loading TBC file...");

--- a/tools/ld-chroma-decoder/comb.cpp
+++ b/tools/ld-chroma-decoder/comb.cpp
@@ -123,9 +123,11 @@ void Comb::updateConfiguration(const LdDecodeMetaData::VideoParameters &_videoPa
     // Range check the video start
     if (videoParameters.activeVideoStart < 16) qCritical() << "Comb::Comb(): activeVideoStart must be > 16!";
 
-    if (videoParameters.sampleRate / videoParameters.fsc != 4)
+    // Check the sample rate is close to 4 * fSC.
+    // Older versions of ld-decode used integer approximations, so this needs
+    // to be an approximate comparison.
+    if (fabs((videoParameters.sampleRate / videoParameters.fSC) - 4.0) > 1.0e-6)
     {
-        // Decoder assumes 4fsc sample rate at the moment.
         qCritical() << "Data is not in 4fsc sample rate, color decoding will not work properly!";
     }
 

--- a/tools/ld-chroma-decoder/encoder/palencoder.cpp
+++ b/tools/ld-chroma-decoder/encoder/palencoder.cpp
@@ -53,7 +53,9 @@ PALEncoder::PALEncoder(QFile &_rgbFile, QFile &_tbcFile, LdDecodeMetaData &_meta
     : rgbFile(_rgbFile), tbcFile(_tbcFile), metaData(_metaData), scLocked(_scLocked)
 {
     // PAL subcarrier frequency [Poynton p529] [EBU p5]
-    fSC = 4433618.75;
+    videoParameters.fSC = 4433618.75;
+
+    videoParameters.sampleRate = 4 * videoParameters.fSC;
 
     if (scLocked) {
         // Parameters for 4fSC subcarrier-locked sampling:
@@ -74,11 +76,9 @@ PALEncoder::PALEncoder(QFile &_rgbFile, QFile &_tbcFile, LdDecodeMetaData &_meta
         // 957 and 958. [EBU p7]
         const double zeroH = 957.5 - 948;
 
-        sampleRate = 4 * fSC;
-
         // Burst gate opens 5.6 usec after 0H, and closes 10 cycles later.
         // [Poynton p530]
-        const double burstStartPos = zeroH + (5.6e-6 * sampleRate);
+        const double burstStartPos = zeroH + (5.6e-6 * videoParameters.sampleRate);
         const double burstEndPos = burstStartPos + (10 * 4);
         videoParameters.colourBurstStart = static_cast<qint32>(lrint(burstStartPos));
         videoParameters.colourBurstEnd = static_cast<qint32>(lrint(burstEndPos));
@@ -91,8 +91,6 @@ PALEncoder::PALEncoder(QFile &_rgbFile, QFile &_tbcFile, LdDecodeMetaData &_meta
         videoParameters.activeVideoEnd = videoParameters.activeVideoStart + 922;
     } else {
         // Parameters for line-locked sampling, based on ld-decode's usual output:
-
-        sampleRate = 1135 / 64.0e-6;
 
         videoParameters.colourBurstStart = 98;
         videoParameters.colourBurstEnd = 138;
@@ -110,10 +108,6 @@ PALEncoder::PALEncoder(QFile &_rgbFile, QFile &_tbcFile, LdDecodeMetaData &_meta
     videoParameters.black16bIre = 0x4000;
     videoParameters.fieldWidth = 1135;
     videoParameters.fieldHeight = 313;
-    // sampleRate and fsc are integers in this struct, so they're not precise;
-    // the code below uses fSC and sampleRate instead
-    videoParameters.sampleRate = static_cast<qint32>(lrint(sampleRate));
-    videoParameters.fsc = static_cast<qint32>(lrint(fSC));
     videoParameters.isMapped = false;
 
     // Compute the location of the input image within the PAL frame, based on
@@ -326,7 +320,7 @@ void PALEncoder::encodeLine(qint32 fieldNo, qint32 frameLine, const quint16 *rgb
     // Compute the time at which 0H occurs within the line (see above)
     double zeroH;
     if (videoParameters.isSubcarrierLocked) {
-        zeroH = ((957.5 - 948) + ((prevLines % 625) * (4.0 / 625))) / sampleRate;
+        zeroH = ((957.5 - 948) + ((prevLines % 625) * (4.0 / 625))) / videoParameters.sampleRate;
     } else {
         zeroH = 0.0;
     }
@@ -344,16 +338,16 @@ void PALEncoder::encodeLine(qint32 fieldNo, qint32 frameLine, const quint16 *rgb
     // Compute colourburst gating times, relative to 0H [Poynton p530]
     const double halfBurstRiseTime = 300.0e-9 / 2.0;
     const double burstStartTime = 5.6e-6;
-    const double burstEndTime = burstStartTime + (10.0 / fSC);
+    const double burstEndTime = burstStartTime + (10.0 / videoParameters.fSC);
 
     // Compute luma/chroma gating times, relative to 0H, to avoid sharp
     // transitions at the edge of the active region. The rise times are as
     // suggested in [Poynton p323], timed so that the video reaches full
     // amplitude at the start/end of the active region.
-    const double halfLumaRiseTime = 2.0 / (4.0 * fSC);
-    const double halfChromaRiseTime = 3.0 / (4.0 * fSC);
-    double activeStartTime = (videoParameters.activeVideoStart / sampleRate) - zeroH - (2.0 * halfChromaRiseTime);
-    double activeEndTime = (videoParameters.activeVideoEnd / sampleRate) - zeroH + (2.0 * halfChromaRiseTime);
+    const double halfLumaRiseTime = 2.0 / (4.0 * videoParameters.fSC);
+    const double halfChromaRiseTime = 3.0 / (4.0 * videoParameters.fSC);
+    double activeStartTime = (videoParameters.activeVideoStart / videoParameters.sampleRate) - zeroH - (2.0 * halfChromaRiseTime);
+    double activeEndTime = (videoParameters.activeVideoEnd / videoParameters.sampleRate) - zeroH + (2.0 * halfChromaRiseTime);
 
     // Adjust gating for half-lines [Poynton p525]
     if (frameLine == 44) {
@@ -425,8 +419,8 @@ void PALEncoder::encodeLine(qint32 fieldNo, qint32 frameLine, const quint16 *rgb
 
     for (qint32 x = 0; x < outputLine.size(); x++) {
         // For this sample, compute time relative to 0H, and subcarrier phase
-        const double t = (x / sampleRate) - zeroH;
-        const double a = 2.0 * M_PI * ((fSC * t) + prevCycles);
+        const double t = (x / videoParameters.sampleRate) - zeroH;
+        const double a = 2.0 * M_PI * ((videoParameters.fSC * t) + prevCycles);
 
         // Generate colourburst
         const double burst = sin(a + burstOffset) * burstAmplitude / 2.0;

--- a/tools/ld-chroma-decoder/encoder/palencoder.h
+++ b/tools/ld-chroma-decoder/encoder/palencoder.h
@@ -51,8 +51,6 @@ private:
     bool scLocked;
 
     LdDecodeMetaData::VideoParameters videoParameters;
-    double fSC;
-    double sampleRate;
     qint32 activeWidth;
     qint32 activeHeight;
     qint32 activeLeft;

--- a/tools/ld-chroma-decoder/palcolour.cpp
+++ b/tools/ld-chroma-decoder/palcolour.cpp
@@ -147,7 +147,7 @@ void PalColour::buildLookUpTables()
     //   so we can rotate the chroma samples to put U/V on the right axes
     if(videoParameters.fieldHeight != 263) {
         for (qint32 i = 0; i < videoParameters.fieldWidth; i++) {
-            const double rad = 2 * M_PI * i * videoParameters.fsc / videoParameters.sampleRate;
+            const double rad = 2 * M_PI * i * videoParameters.fSC / videoParameters.sampleRate;
             sine[i] = sin(rad);
             cosine[i] = cos(rad);
         }
@@ -157,7 +157,7 @@ void PalColour::buildLookUpTables()
         // swapping the cos and sin references seem to work around that.
         // TODO: Find a proper solution to this.
         for (qint32 i = 0; i < videoParameters.fieldWidth; i++) {
-            const double rad = 2 * M_PI * i * videoParameters.fsc / videoParameters.sampleRate;
+            const double rad = 2 * M_PI * i * videoParameters.fSC / videoParameters.sampleRate;
             sine[i] = cos(rad);
             cosine[i] = sin(rad);
         }

--- a/tools/library/tbc/lddecodemetadata.cpp
+++ b/tools/library/tbc/lddecodemetadata.cpp
@@ -542,7 +542,7 @@ void LdDecodeMetaData::LineParameters::process(qint32 fieldHeight)
     if (firstActiveFieldLine < 1 || firstActiveFieldLine > defaultLastFieldLine) {
         if (firstFieldLineExists) {
             qInfo().nospace() << "Specified first active field line " << firstActiveFieldLine << " out of bounds (1 to "
-                              << defaultLastFieldLine << "), restting to default (" << defaultFirstFieldLine << ").";
+                              << defaultLastFieldLine << "), resetting to default (" << defaultFirstFieldLine << ").";
         }
         firstActiveFieldLine = defaultFirstFieldLine;
     }
@@ -561,7 +561,7 @@ void LdDecodeMetaData::LineParameters::process(qint32 fieldHeight)
     if (lastActiveFieldLine < 1 || lastActiveFieldLine > defaultLastFieldLine) {
         if (lastFieldLineExists) {
             qInfo().nospace() << "Specified last active field line " << lastActiveFieldLine << " out of bounds (1 to "
-                              << defaultLastFieldLine << "), restting to default (" << defaultLastFieldLine << ").";
+                              << defaultLastFieldLine << "), resetting to default (" << defaultLastFieldLine << ").";
         }
         lastActiveFieldLine = defaultLastFieldLine;
     }
@@ -578,7 +578,7 @@ void LdDecodeMetaData::LineParameters::process(qint32 fieldHeight)
     if (firstActiveFrameLine < minFirstFrameLine || firstActiveFrameLine > defaultLastFrameLine) {
         if (firstFrameLineExists) {
             qInfo().nospace() << "Specified first active frame line " << firstActiveFrameLine << " out of bounds (" << minFirstFrameLine << " to "
-                              << defaultLastFrameLine << "), restting to default (" << defaultFirstFrameLine << ").";
+                              << defaultLastFrameLine << "), resetting to default (" << defaultFirstFrameLine << ").";
         }
         firstActiveFrameLine = defaultFirstFrameLine;
     }
@@ -587,15 +587,15 @@ void LdDecodeMetaData::LineParameters::process(qint32 fieldHeight)
     if (lastActiveFrameLine < minFirstFrameLine || lastActiveFrameLine > defaultLastFrameLine) {
         if (lastFrameLineExists) {
             qInfo().nospace() << "Specified last active frame line " << lastActiveFrameLine << " out of bounds (" << minFirstFrameLine << " to "
-                              << defaultLastFrameLine << "), restting to default (" << defaultLastFrameLine << ").";
+                              << defaultLastFrameLine << "), resetting to default (" << defaultLastFrameLine << ").";
         }
         lastActiveFrameLine = defaultLastFrameLine;
     }
 
     // Range-check the first and last active frame lines.
     if (firstActiveFrameLine > lastActiveFrameLine) {
-       qInfo().nospace() << "Specified last active frame line " << lastActiveFrameLine << " is before specified first active frame line"
-                         << firstActiveFrameLine << ", resetting to defaults (" << defaultFirstFrameLine << "-" << defaultLastFrameLine << ").";
+        qInfo().nospace() << "Specified last active frame line " << lastActiveFrameLine << " is before specified first active frame line"
+                          << firstActiveFrameLine << ", resetting to defaults (" << defaultFirstFrameLine << "-" << defaultLastFrameLine << ").";
         firstActiveFrameLine = defaultFirstFrameLine;
         lastActiveFrameLine = defaultLastFrameLine;
     }

--- a/tools/library/tbc/lddecodemetadata.cpp
+++ b/tools/library/tbc/lddecodemetadata.cpp
@@ -366,7 +366,6 @@ void LdDecodeMetaData::clear()
 
     // Reset the parameters to their defaults
     videoParameters = VideoParameters();
-    lineParameters = LineParameters();
     pcmAudioParameters = PcmAudioParameters();
 
     fields.clear();
@@ -512,10 +511,9 @@ void LdDecodeMetaData::setPcmAudioParameters(const LdDecodeMetaData::PcmAudioPar
 }
 
 // Validate any user-specified line parameters and set them to reasonable defaults + warn if invalid.
-void LdDecodeMetaData::processLineParameters(LdDecodeMetaData::LineParameters &_lineParameters)
+void LdDecodeMetaData::processLineParameters(LdDecodeMetaData::LineParameters &lineParameters)
 {
-    _lineParameters.process(videoParameters.fieldHeight);
-    lineParameters = _lineParameters;
+    lineParameters.process(videoParameters.fieldHeight);
 
     videoParameters.firstActiveFieldLine = lineParameters.firstActiveFieldLine;
     videoParameters.lastActiveFieldLine = lineParameters.lastActiveFieldLine;

--- a/tools/library/tbc/lddecodemetadata.cpp
+++ b/tools/library/tbc/lddecodemetadata.cpp
@@ -34,6 +34,7 @@
 // Default values used when configuring VideoParameters for a particular video system.
 // See the comments in VideoParameters for the meanings of these values.
 struct VideoSystemDefaults {
+    double fSC;
     qint32 minActiveFrameLine;
     qint32 firstActiveFieldLine;
     qint32 lastActiveFieldLine;
@@ -43,6 +44,7 @@ struct VideoSystemDefaults {
 
 // PAL
 static constexpr VideoSystemDefaults palDefaults {
+    (283.75 * 15625) + 25,
     2,
     22, 308,
     // Interlaced line 44 is PAL line 23 (the first active half-line)
@@ -52,6 +54,7 @@ static constexpr VideoSystemDefaults palDefaults {
 
 // NTSC
 static constexpr VideoSystemDefaults ntscDefaults {
+    315.0e6 / 88.0,
     1,
     20, 259,
     // Interlaced line 40 is NTSC line 21 (the closed-caption line before the first active half-line)
@@ -129,7 +132,6 @@ void LdDecodeMetaData::VideoParameters::read(JsonReader &reader)
         else if (member == "colourBurstStart") reader.read(colourBurstStart);
         else if (member == "fieldHeight") reader.read(fieldHeight);
         else if (member == "fieldWidth") reader.read(fieldWidth);
-        else if (member == "fsc") reader.read(fsc);
         else if (member == "gitBranch") reader.read(gitBranch);
         else if (member == "gitCommit") reader.read(gitCommit);
         else if (member == "isMapped") reader.read(isMapped);
@@ -162,7 +164,6 @@ void LdDecodeMetaData::VideoParameters::write(JsonWriter &writer) const
     writer.writeMember("colourBurstStart", colourBurstStart);
     writer.writeMember("fieldHeight", fieldHeight);
     writer.writeMember("fieldWidth", fieldWidth);
-    writer.writeMember("fsc", fsc);
     if (gitBranch != "") {
         writer.writeMember("gitBranch", gitBranch);
     }
@@ -525,7 +526,7 @@ void LdDecodeMetaData::setPcmAudioParameters(const LdDecodeMetaData::PcmAudioPar
 void LdDecodeMetaData::initialiseVideoSystemParameters()
 {
     const VideoSystemDefaults &defaults = getSystemDefaults(videoParameters);
-    videoParameters.fsc = defaults.fsc;
+    videoParameters.fSC = defaults.fSC;
 
     // Set default LineParameters
     LdDecodeMetaData::LineParameters lineParameters;

--- a/tools/library/tbc/lddecodemetadata.h
+++ b/tools/library/tbc/lddecodemetadata.h
@@ -51,36 +51,10 @@ public:
         void write(JsonWriter &writer) const;
     };
 
-    // Pseudo metadata items - these values are populated automatically by the library
-    // if not otherwise specified by the user. These are half-open ranges, where lines are
-    // numbered sequentially from 1 within each field or interlaced frame.
-    struct LineParameters {
-        void process(qint32 fieldHeight);
-
-        qint32 firstActiveFieldLine = -1;
-        qint32 lastActiveFieldLine = -1;
-        qint32 firstActiveFrameLine = -1;
-        qint32 lastActiveFrameLine = -1;
-
-        static const qint32 sMinPALFirstActiveFrameLine;
-        static const qint32 sDefaultPALFirstActiveFieldLine;
-        static const qint32 sDefaultPALLastActiveFieldLine;
-        static const qint32 sDefaultPALFirstActiveFrameLine;
-        static const qint32 sDefaultPALLastActiveFrameLine;
-        static const qint32 sDefaultPALFieldHeightCheck;
-
-        static const qint32 sMinNTSCFirstActiveFrameLine;
-        static const qint32 sDefaultNTSCFirstActiveFieldLine;
-        static const qint32 sDefaultNTSCLastActiveFieldLine;
-        static const qint32 sDefaultNTSCFirstActiveFrameLine;
-        static const qint32 sDefaultNTSCLastActiveFrameLine;
-        static const qint32 sDefaultNTSCFieldHeightCheck;
-
-        static const qint32 sDefaultAutoFirstActiveFieldLine;
-    };
-
     // Video metadata definition
     struct VideoParameters {
+        // -- Members stored in the JSON metadata --
+
         qint32 numberOfSequentialFields = -1;
 
         bool isSourcePal = false;
@@ -105,7 +79,14 @@ public:
         QString gitBranch;
         QString gitCommit;
 
-        // Copy of the members in LineParameters; filled in based on our LineParameters when retrieving VideoParameters
+        // -- Members set by the library --
+
+        // The range of active lines within a frame.
+        // This is the same information represented in two different ways, for
+        // field- and frame-based processing respectively; the field range
+        // should cover the active lines in both fields of a frame.
+        // These are half-open ranges, where lines are numbered sequentially
+        // from 1 within each field or interlaced frame.
         qint32 firstActiveFieldLine = -1;
         qint32 lastActiveFieldLine = -1;
         qint32 firstActiveFrameLine = -1;
@@ -116,6 +97,17 @@ public:
 
         void read(JsonReader &reader);
         void write(JsonWriter &writer) const;
+    };
+
+    // Specification for customising the range of active lines in VideoParameters.
+    // -1 for any of these means to use the default for the standard.
+    struct LineParameters {
+        qint32 firstActiveFieldLine = -1;
+        qint32 lastActiveFieldLine = -1;
+        qint32 firstActiveFrameLine = -1;
+        qint32 lastActiveFrameLine = -1;
+
+        void applyTo(VideoParameters &videoParameters);
     };
 
     // VITS metrics metadata definition
@@ -250,6 +242,7 @@ private:
     QVector<qint32> pcmAudioFieldStartSampleMap;
     QVector<qint32> pcmAudioFieldLengthMap;
 
+    void initialiseVideoSystemParameters();
     qint32 getFieldNumber(qint32 frameNumber, qint32 field);
     void generatePcmAudioMap();
 };

--- a/tools/library/tbc/lddecodemetadata.h
+++ b/tools/library/tbc/lddecodemetadata.h
@@ -245,7 +245,6 @@ public:
 private:
     bool isFirstFieldFirst;
     VideoParameters videoParameters;
-    LineParameters lineParameters;
     PcmAudioParameters pcmAudioParameters;
     QVector<Field> fields;
     QVector<qint32> pcmAudioFieldStartSampleMap;

--- a/tools/library/tbc/lddecodemetadata.h
+++ b/tools/library/tbc/lddecodemetadata.h
@@ -71,8 +71,7 @@ public:
 
         qint32 fieldWidth = -1;
         qint32 fieldHeight = -1;
-        qint32 sampleRate = -1;
-        qint32 fsc = -1;
+        double sampleRate = -1.0;
 
         bool isMapped = false;
 
@@ -80,6 +79,9 @@ public:
         QString gitCommit;
 
         // -- Members set by the library --
+
+        // Colour subcarrier frequency in Hz
+        double fSC = -1.0;
 
         // The range of active lines within a frame.
         // This is the same information represented in two different ways, for
@@ -136,7 +138,7 @@ public:
 
     // PCM sound metadata definition
     struct PcmAudioParameters {
-        qint32 sampleRate = -1;
+        double sampleRate = -1.0;
         bool isLittleEndian = false;
         bool isSigned = false;
         qint32 bits = -1;


### PR DESCRIPTION
Fixes #726. This is built on a slightly-refactored version of MooglyGuy's LineParameters work - the big changes are in the last commit:

Use double values for `sampleRate` and `fSC`. Several of the tools want exact values for these.

For video `sampleRate`, previously ld-decode output `int(fSC) * 4` to the JSON, while actually using `fSC * 4` internally. Output the full floating-point value of `fSC * 4` instead. Correct ld-chroma-encoder to match this.

The audio `sampleRate` has always been an integer anyway in ld-decode.

For `fsc`, previously ld-decode output `int(fSC)`. Since fSC is fixed for each video standard, there is no need to store it in the JSON; set it to the exact value in `initialiseVideoSystemParameters` along with the other system-dependent parameters.

This is backwards-compatible, in that the tools can still work with older JSON files.

(Why not have ld-decode continue to output `fsc` anyway, for backwards compatibility with older versions of the tools? Because comb.cpp checked that the integer sample rate was exactly 4 * the integer fSC -- and that isn't true for the correct NTSC values when rounded to integers.)