### PR TITLE
Fix a comparison in ld-process-efm that doesn't work with Qt 6

### DIFF
--- a/tools/ld-process-efm/mainwindow.cpp
+++ b/tools/ld-process-efm/mainwindow.cpp
@@ -69,7 +69,7 @@ MainWindow::MainWindow(bool debugOn, bool _nonInteractive, QString _outputAudioF
 
     ui->audio_padSampleStart_checkBox->setChecked(pad);
 
-    if (outputDataFilename!=NULL) {
+    if (outputDataFilename != "") {
         ui->options_decodeAsData_checkbox->setChecked(true);
         ui->tabWidget->setTabEnabled(ui->tabWidget->indexOf(ui->dataTab), true);
     }


### PR DESCRIPTION
The string is empty if the filename hasn't been set.

(This bit of code was introduced in #717.)