### PR TITLE
Fix some compiler warnings

### DIFF
--- a/tools/ld-chroma-decoder/encoder/palencoder.cpp
+++ b/tools/ld-chroma-decoder/encoder/palencoder.cpp
@@ -298,14 +298,6 @@ static constexpr auto uvFilter = makeFIRFilter(uvFilterCoeffs);
 void PALEncoder::encodeLine(qint32 fieldNo, qint32 frameLine, const quint16 *rgbData, QVector<quint16> &outputLine)
 {
     // Resize the output line and fill with black
-    qint32 lineLen = videoParameters.fieldWidth;
-    if (!videoParameters.isSubcarrierLocked) {
-        // Line-locked -- all lines are the same length
-    } else if (frameLine == 625) {
-        lineLen -= 4;
-    } else if (frameLine == 623 || frameLine == 624) {
-        lineLen += 2;
-    }
     outputLine.resize(videoParameters.fieldWidth);
     outputLine.fill(videoParameters.black16bIre);
     if (frameLine == 625) {

--- a/tools/ld-chroma-decoder/main.cpp
+++ b/tools/ld-chroma-decoder/main.cpp
@@ -29,9 +29,9 @@
 #include <QDebug>
 #include <QtGlobal>
 #include <QCommandLineParser>
-#include <QScopedPointer>
 #include <QThread>
 #include <fstream>
+#include <memory>
 
 #include "decoderpool.h"
 #include "lddecodemetadata.h"
@@ -490,7 +490,7 @@ int main(int argc, char *argv[])
     }
 
     // Select the decoder
-    QScopedPointer<Decoder> decoder;
+    std::unique_ptr<Decoder> decoder;
     if (decoderName == "pal2d") {
         decoder.reset(new PalDecoder(palConfig));
     } else if (decoderName == "transform2d") {

--- a/tools/ld-chroma-decoder/palcolour.h
+++ b/tools/ld-chroma-decoder/palcolour.h
@@ -28,9 +28,9 @@
 
 #include <QtGlobal>
 #include <QDebug>
-#include <QScopedPointer>
 #include <QVector>
 #include <QtMath>
+#include <memory>
 
 #include "lddecodemetadata.h"
 
@@ -109,7 +109,7 @@ private:
     LdDecodeMetaData::VideoParameters videoParameters;
 
     // Transform PAL filter
-    QScopedPointer<TransformPal> transformPal;
+    std::unique_ptr<TransformPal> transformPal;
 
     // The subcarrier reference signal
     double sine[MAX_WIDTH], cosine[MAX_WIDTH];


### PR DESCRIPTION
Some of QScopedPointer's API is deprecated in favour of std::unique_ptr in Qt 6.1; use std::unique_ptr instead.

Avoid a signed/unsigned comparison in ld-ldf-reader. **Edit:** with CI, this revealed a fault in the seeking logic - fixed.

Remove some dead code in ld-chroma-encoder. (I had to do some testing to convince myself it really wasn't needed; separate PR coming to add the test.)