### PR TITLE
Fix discmap.cpp warning and don't use pyfftw on windows

### DIFF
--- a/ld-decode
+++ b/ld-decode
@@ -4,8 +4,6 @@ import sys
 import argparse
 import traceback
 
-from multiprocessing import Process, Pipe
-
 from lddecode.core import *
 from lddecode.utils import *
 from lddecode.utils_logging import init_logging

--- a/lddecode/core.py
+++ b/lddecode/core.py
@@ -19,13 +19,18 @@ import scipy.signal as sps
 import scipy.interpolate as spi
 
 # Use PyFFTW's faster FFT implementation if available
-try:
-    import pyfftw.interfaces.numpy_fft as npfft
-    import pyfftw.interfaces
+if platform.system != "Windows":
+    try:
+        import pyfftw.interfaces.numpy_fft as npfft
+        import pyfftw.interfaces
 
-    pyfftw.interfaces.cache.enable()
-    pyfftw.interfaces.cache.set_keepalive_time(10)
-except ImportError:
+        pyfftw.interfaces.cache.enable()
+        pyfftw.interfaces.cache.set_keepalive_time(10)
+    except ImportError:
+        import numpy.fft as npfft
+else:
+    # Don't use pyfftw on windows as we have to use Thread and that causes
+    # issues if also using pyfftw.
     import numpy.fft as npfft
 
 # internal libraries
@@ -33,11 +38,11 @@ except ImportError:
 from . import efm_pll
 from .utils import get_git_info, ldf_pipe, traceback
 from .utils import nb_mean, nb_median, nb_round, nb_min, nb_max, nb_absmax
-from .utils import polar2z, pi, sqsum, genwave, dsa_rescale, scale, rms
+from .utils import polar2z, sqsum, genwave, dsa_rescale, scale, rms
 from .utils import findpeaks, findpulses, calczc, inrange, roundfloat
 from .utils import LRUupdate, clb_findnextburst, angular_mean, phase_distance
 from .utils import build_hilbert, unwrap_hilbert, emphasis_iir, filtfft
-from .utils import fft_do_slice, fft_determine_slices, StridedCollector
+from .utils import fft_do_slice, fft_determine_slices
 
 try:
     # If Anaconda's numpy is installed, mkl will use all threads for fft etc
@@ -584,7 +589,7 @@ class RFDecode:
                 self.blocklen,
             )
 
-            # Determine the frequency offset (a1_freq) and bins (lowbin+nbin) that cover the audio RF 
+            # Determine the frequency offset (a1_freq) and bins (lowbin+nbin) that cover the audio RF
             # frequencies for this channel
             self.audio[channel].lowbin, self.audio[channel].nbins, self.audio[channel].a1_freq = fft_determine_slices(
                 center_freq, 200000, self.freq_hz, self.blocklen
@@ -1250,7 +1255,7 @@ def downscale_audio(audio, lineinfo, rf, linecount, timeoffset=0, freq=44100):
 
     frametime = linecount / (1000000 / rf.SysParams["line_period"])
     soundgap = 1 / freq
-    
+
     # include one extra 'tick' to interpolate the last one and use as a return value
     # for the next frame
     arange = np.arange(

--- a/lddecode/core.py
+++ b/lddecode/core.py
@@ -3765,7 +3765,7 @@ class LDdecode:
 
         return metrics_rounded
 
-    def buildmetadata(self, f):
+    def buildmetadata(self, f, check_phase=True):
         """ returns field information JSON and whether or not a backfill field is needed """
         prevfi = self.fieldinfo[-1] if len(self.fieldinfo) else None
 
@@ -3793,12 +3793,12 @@ class LDdecode:
         fi["fieldPhaseID"] = f.fieldPhaseID
 
         if prevfi is not None:
-            if not (
+            if check_phase and (not (
                 (
                     fi["fieldPhaseID"] == 1
                     and prevfi["fieldPhaseID"] == f.rf.SysParams["fieldPhases"]
                 )
-                or (fi["fieldPhaseID"] == prevfi["fieldPhaseID"] + 1)
+                or (fi["fieldPhaseID"] == prevfi["fieldPhaseID"] + 1))
             ):
                 logger.warning(
                     "At field #{0}, Field phaseID sequence mismatch ({1}->{2}) (player may be paused)".format(

--- a/tools/ld-discmap/discmap.cpp
+++ b/tools/ld-discmap/discmap.cpp
@@ -24,8 +24,8 @@
 
 #include "discmap.h"
 
-DiscMap::DiscMap(const QFileInfo &metadataFileInfo, const bool &reverseFieldOrder,
-                 const bool &noStrict)
+DiscMap::DiscMap(const QFileInfo &metadataFileInfo, const bool reverseFieldOrder,
+                 const bool noStrict)
             : m_metadataFileInfo(metadataFileInfo), m_reverseFieldOrder(reverseFieldOrder),
               m_noStrict(noStrict)
 {
@@ -632,6 +632,7 @@ bool DiscMap::isNtscAmendment2ClvFrameNumber(qint32 frameNumber)
 // disc map must be sorted afterwards.
 void DiscMap::addPadding(qint32 startFrame, qint32 numberOfFrames)
 {
+    m_frames.reserve(m_frames.size() + numberOfFrames);
     qint32 currentVbi = m_frames[startFrame].vbiFrameNumber() + 1;
     for (qint32 i = 0; i < numberOfFrames; i++) {
         Frame paddingFrame;
@@ -639,7 +640,7 @@ void DiscMap::addPadding(qint32 startFrame, qint32 numberOfFrames)
         paddingFrame.seqFrameNumber(-1);
         paddingFrame.isPadded(true);
 
-        m_frames.append(paddingFrame);
+        m_frames.push_back(paddingFrame);
     }
 
     m_numberOfFrames = m_frames.size();

--- a/tools/ld-discmap/discmap.h
+++ b/tools/ld-discmap/discmap.h
@@ -44,7 +44,7 @@ public:
     DiscMap(const DiscMap &) = default;
     DiscMap &operator=(const DiscMap &) = default;
 
-    DiscMap(const QFileInfo &metadataFileInfo, const bool &reverseFieldOrder, const bool &noStrict);
+    DiscMap(const QFileInfo &metadataFileInfo, const bool reverseFieldOrder, const bool noStrict);
 
     QString filename() const;
     bool valid() const;
@@ -101,7 +101,7 @@ private:
     qint32 m_audioFieldByteLength;
     qint32 m_audioFieldSampleLength;
 
-    QVector<Frame> m_frames;
+    std::vector<Frame> m_frames;
     LdDecodeMetaData *ldDecodeMetaData;
 
     bool isNtscAmendment2ClvFrameNumber(qint32 frameNumber);

--- a/tools/ld-discmap/frame.cpp
+++ b/tools/ld-discmap/frame.cpp
@@ -24,11 +24,11 @@
 
 #include "frame.h"
 
-Frame::Frame(const qint32 &seqFrameNumber, const qint32 &vbiFrameNumber, const bool &isPictureStop,
-             const bool &isPullDown, const bool &isLeadInOrOut, const bool &isMarkedForDeletion,
-             const double &frameQuality, const bool &isPadded, const bool &isClvOffset,
-             const qint32 &firstField, const qint32 &secondField,
-             const qint32 &firstFieldPhase, const qint32 &secondFieldPhase)
+Frame::Frame(const qint32 seqFrameNumber, const qint32 vbiFrameNumber, const bool isPictureStop,
+             const bool isPullDown, const bool isLeadInOrOut, const bool isMarkedForDeletion,
+             const double frameQuality, const bool isPadded, const bool isClvOffset,
+             const qint32 firstField, const qint32 secondField,
+             const qint32 firstFieldPhase, const qint32 secondFieldPhase)
            : m_seqFrameNumber(seqFrameNumber),  m_vbiFrameNumber(vbiFrameNumber), m_isPictureStop(isPictureStop),
              m_isPullDown(isPullDown), m_isLeadInOrOut(isLeadInOrOut), m_isMarkedForDeletion(isMarkedForDeletion),
              m_frameQuality(frameQuality), m_isPadded(isPadded), m_isClvOffset(isClvOffset),

--- a/tools/ld-discmap/frame.h
+++ b/tools/ld-discmap/frame.h
@@ -31,11 +31,11 @@
 class Frame
 {
 public:
-    Frame(const qint32 &seqFrameNumber = -1, const qint32 &vbiFrameNumber = -1, const bool &isPictureStop = false,
-          const bool &isPullDown = false, const bool &isLeadInOrOut = false, const bool &isMarkedForDeletion = false,
-          const double &frameQuality = 0, const bool &isPadded = false, const bool &isClvOffset = false,
-          const qint32 &firstField = -1, const qint32 &secondField = -1,
-          const qint32 &firstFieldPhase = -1, const qint32 &secondFieldPhase = -1);
+    Frame(const qint32 seqFrameNumber = -1, const qint32 vbiFrameNumber = -1, const bool isPictureStop = false,
+          const bool isPullDown = false, const bool isLeadInOrOut = false, const bool isMarkedForDeletion = false,
+          const double frameQuality = 0, const bool isPadded = false, const bool isClvOffset = false,
+          const qint32 firstField = -1, const qint32 secondField = -1,
+          const qint32 firstFieldPhase = -1, const qint32 secondFieldPhase = -1);
     ~Frame() = default;
     Frame(const Frame &) = default;
     Frame &operator=(const Frame &) = default;


### PR DESCRIPTION
Seems pyfftw and python threads don't mix so disable on windows where we have to use Thread.
It doesn't play super well with Process either but at least it doesn't completely break.


Could potentially make the discmap.cpp thing a bit cleaner but wasn't sure if the constructor for Frame was used elsewhere.