### PR TITLE
When opening a new file, load a frame before updating dialogs

### DIFF
--- a/tools/ld-analyse/mainwindow.cpp
+++ b/tools/ld-analyse/mainwindow.cpp
@@ -229,12 +229,12 @@ void MainWindow::updateGuiLoaded()
         ui->aspectPushButton->setText(tr(Aspect::DAR_169_S));
     }
 
+    // Load and show the current frame
+    showFrame();
+
     // Update the chroma decoder configuration dialogue
     chromaDecoderConfigDialog->setConfiguration(tbcSource.getSystem(), tbcSource.getPalConfiguration(),
                                                 tbcSource.getNtscConfiguration(), tbcSource.getOutputConfiguration());
-
-    // Show the current frame
-    showFrame();
 
     // Ensure the busy dialogue is hidden
     busyDialog->hide();


### PR DESCRIPTION
Without this, updating the chroma decoder dialogue emits an event which causes the other main window displays to be updated -- and some of them (e.g. the scope) expect a frame to be loaded.

Fixes #745.