### PR TITLE
Add LineNumber and rework how line numbers are shown in the scope

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -80,6 +80,7 @@ clean-tools:
 
 TESTCASES = \
 	check-library-filter \
+	check-library-linenumber \
 	check-library-metadata \
 	check-library-vbidecoder \
 	check-chroma-ntsc \
@@ -99,6 +100,10 @@ TESTING = printf '\n\#\# Testing %s\n\n'
 check-library-filter:
 	@$(TESTING) "library: filter"
 	@tools/library/filter/testfilter/testfilter
+
+check-library-linenumber:
+	@$(TESTING) "library: linenumber"
+	@tools/library/tbc/testlinenumber/testlinenumber
 
 check-library-metadata:
 	@$(TESTING) "library: metadata"

--- a/tools/.gitignore
+++ b/tools/.gitignore
@@ -54,6 +54,7 @@ CMakeLists.txt.user*
 /ld-disc-stacker/ld-disc-stacker
 /ld-process-vits/ld-process-vits
 /library/filter/testfilter/testfilter
+/library/tbc/testlinenumber/testlinenumber
 /library/tbc/testvbidecoder/testvbidecoder
 /library/tbc/testmetadata/testmetadata
 

--- a/tools/ld-analyse/ld-analyse.pro
+++ b/tools/ld-analyse/ld-analyse.pro
@@ -82,6 +82,7 @@ HEADERS += \
     ../library/tbc/filters.h \
     ../library/tbc/jsonio.h \
     ../library/tbc/lddecodemetadata.h \
+    ../library/tbc/linenumber.h \
     ../library/tbc/logging.h \
     ../library/tbc/sourcevideo.h \
     ../library/tbc/vbidecoder.h \

--- a/tools/ld-analyse/mainwindow.cpp
+++ b/tools/ld-analyse/mainwindow.cpp
@@ -360,7 +360,7 @@ void MainWindow::showFrame()
     // If the scope window is open, update it too (using the last scope line selected by the user)
     if (oscilloscopeDialog->isVisible()) {
         // Show the oscilloscope dialogue for the selected scan-line
-        updateOscilloscopeDialogue(lastScopeLine, lastScopeDot);
+        updateOscilloscopeDialogue();
     }
 
     // Update the closed caption dialog
@@ -449,11 +449,12 @@ void MainWindow::loadTbcFile(QString inputFileName)
 }
 
 // Method to update the line oscilloscope based on the frame number and scan line
-void MainWindow::updateOscilloscopeDialogue(qint32 scanLine, qint32 pictureDot)
+void MainWindow::updateOscilloscopeDialogue()
 {
     // Update the oscilloscope dialogue
-    oscilloscopeDialog->showTraceImage(tbcSource.getScanLineData(scanLine),
-                                       scanLine, pictureDot, tbcSource.getFrameHeight());
+    oscilloscopeDialog->showTraceImage(tbcSource.getScanLineData(lastScopeLine),
+                                       lastScopeLine, lastScopeDot,
+                                       tbcSource.getFrameHeight());
 }
 
 // Menu bar signal handlers -------------------------------------------------------------------------------------------
@@ -497,7 +498,7 @@ void MainWindow::on_actionLine_scope_triggered()
 {
     if (tbcSource.getIsSourceLoaded()) {
         // Show the oscilloscope dialogue for the selected scan-line
-        updateOscilloscopeDialogue(lastScopeLine, lastScopeDot);
+        updateOscilloscopeDialogue();
         oscilloscopeDialog->show();
     }
 }
@@ -845,7 +846,7 @@ void MainWindow::on_mouseModePushButton_clicked()
     if (ui->mouseModePushButton->isChecked()) {
         // Show the oscilloscope view if currently hidden
         if (!oscilloscopeDialog->isVisible()) {
-            updateOscilloscopeDialogue(lastScopeLine, lastScopeDot);
+            updateOscilloscopeDialogue();
             oscilloscopeDialog->show();
         }
     }
@@ -882,7 +883,7 @@ void MainWindow::scanLineChangedSignalHandler(qint32 scanLine, qint32 pictureDot
         // Show the oscilloscope dialogue for the selected scan-line
         lastScopeDot = pictureDot;
         lastScopeLine = scanLine;
-        updateOscilloscopeDialogue(lastScopeLine, lastScopeDot);
+        updateOscilloscopeDialogue();
         oscilloscopeDialog->show();
 
         // Update the frame viewer
@@ -971,7 +972,7 @@ void MainWindow::mouseScanLineSelect(qint32 oX, qint32 oY)
         lastScopeLine = unscaledY;
         lastScopeDot = unscaledX;
 
-        updateOscilloscopeDialogue(lastScopeLine, lastScopeDot);
+        updateOscilloscopeDialogue();
         oscilloscopeDialog->show();
 
         // Update the frame viewer
@@ -992,7 +993,7 @@ void MainWindow::chromaDecoderConfigChangedSignalHandler()
 
     // If the scope window is open, update it too
     if (oscilloscopeDialog->isVisible()) {
-        updateOscilloscopeDialogue(lastScopeLine, lastScopeDot);
+        updateOscilloscopeDialogue();
     }
 }
 

--- a/tools/ld-analyse/mainwindow.cpp
+++ b/tools/ld-analyse/mainwindow.cpp
@@ -72,7 +72,7 @@ MainWindow::MainWindow(QString inputFilenameParam, QWidget *parent) :
     if (tbcSource.getIsWidescreen()) aspectRatio = Aspect::DAR_169;
 
     // Connect to the scan line changed signal from the oscilloscope dialogue
-    connect(oscilloscopeDialog, &OscilloscopeDialog::scanLineChanged, this, &MainWindow::scanLineChangedSignalHandler);
+    connect(oscilloscopeDialog, &OscilloscopeDialog::scopeCoordsChanged, this, &MainWindow::scopeCoordsChangedSignalHandler);
     lastScopeLine = 1;
     lastScopeDot = 1;
 
@@ -453,8 +453,8 @@ void MainWindow::updateOscilloscopeDialogue()
 {
     // Update the oscilloscope dialogue
     oscilloscopeDialog->showTraceImage(tbcSource.getScanLineData(lastScopeLine),
-                                       lastScopeLine, lastScopeDot,
-                                       tbcSource.getFrameHeight());
+                                       lastScopeDot, lastScopeLine - 1,
+                                       tbcSource.getFrameWidth(), tbcSource.getFrameHeight());
 }
 
 // Menu bar signal handlers -------------------------------------------------------------------------------------------
@@ -875,14 +875,14 @@ void MainWindow::on_aspectPushButton_clicked()
 // Miscellaneous handler methods --------------------------------------------------------------------------------------
 
 // Handler called when another class changes the currenly selected scan line
-void MainWindow::scanLineChangedSignalHandler(qint32 scanLine, qint32 pictureDot)
+void MainWindow::scopeCoordsChangedSignalHandler(qint32 xCoord, qint32 yCoord)
 {
-    qDebug() << "MainWindow::scanLineChangedSignalHandler(): Called with scanLine =" << scanLine << "and picture dot" << pictureDot;
+    qDebug() << "MainWindow::scanLineChangedSignalHandler(): Called with xCoord =" << xCoord << "and yCoord =" << yCoord;
 
     if (tbcSource.getIsSourceLoaded()) {
         // Show the oscilloscope dialogue for the selected scan-line
-        lastScopeDot = pictureDot;
-        lastScopeLine = scanLine;
+        lastScopeDot = xCoord;
+        lastScopeLine = yCoord + 1;
         updateOscilloscopeDialogue();
         oscilloscopeDialog->show();
 

--- a/tools/ld-analyse/mainwindow.h
+++ b/tools/ld-analyse/mainwindow.h
@@ -147,7 +147,7 @@ private:
 
     // TBC source signal handlers
     void loadTbcFile(QString inputFileName);
-    void updateOscilloscopeDialogue(qint32 scanLine, qint32 pictureDot);
+    void updateOscilloscopeDialogue();
     void mouseScanLineSelect(qint32 oX, qint32 oY);
 };
 

--- a/tools/ld-analyse/mainwindow.h
+++ b/tools/ld-analyse/mainwindow.h
@@ -98,7 +98,7 @@ private slots:
     void on_aspectPushButton_clicked();
 
     // Miscellaneous handlers
-    void scanLineChangedSignalHandler(qint32 scanLine, qint32 pictureDot);
+    void scopeCoordsChangedSignalHandler(qint32 xCoord, qint32 yCoord);
     void mousePressEvent(QMouseEvent *event);
     void mouseMoveEvent(QMouseEvent *event);
     void chromaDecoderConfigChangedSignalHandler();

--- a/tools/ld-analyse/oscilloscopedialog.cpp
+++ b/tools/ld-analyse/oscilloscopedialog.cpp
@@ -34,14 +34,17 @@ OscilloscopeDialog::OscilloscopeDialog(QWidget *parent) :
     ui->setupUi(this);
     setWindowFlags(Qt::Window);
 
-    maximumScanLines = 625;
-    lastScopeLine = 0;
-    lastScopeDot = 0;
+    maximumX = 1135;
+    maximumY = 625;
+    lastScopeX = 0;
+    lastScopeY = 0;
     scopeWidth = 0;
 
     // Configure the GUI
-    ui->scanLineSpinBox->setMinimum(1);
-    ui->scanLineSpinBox->setMaximum(625);
+    ui->xCoordSpinBox->setMinimum(0);
+    ui->xCoordSpinBox->setMaximum(maximumX - 1);
+    ui->yCoordSpinBox->setMinimum(0);
+    ui->yCoordSpinBox->setMaximum(maximumY - 1);
 
     ui->previousPushButton->setAutoRepeat(true);
     ui->previousPushButton->setAutoRepeatInterval(50);
@@ -58,19 +61,18 @@ OscilloscopeDialog::~OscilloscopeDialog()
     delete ui;
 }
 
-void OscilloscopeDialog::showTraceImage(TbcSource::ScanLineData scanLineData, qint32 scanLine, qint32 pictureDot, qint32 frameHeight)
+void OscilloscopeDialog::showTraceImage(TbcSource::ScanLineData scanLineData, qint32 xCoord, qint32 yCoord, qint32 frameWidth, qint32 frameHeight)
 {
-    qDebug() << "OscilloscopeDialog::showTraceImage(): Called for scan-line" << scanLine << "with picture dot" << pictureDot;
+    qDebug() << "OscilloscopeDialog::showTraceImage(): Called with xCoord =" << xCoord << "and yCoord =" << yCoord;
 
-    // Set the dialogue title based on the scan-line
-    this->setWindowTitle("Oscilloscope trace for scan-line #" + QString::number(scanLine));
+    // Store coordinates
+    maximumX = frameWidth;
+    maximumY = frameHeight;
+    lastScopeX = xCoord;
+    lastScopeY = yCoord;
 
     // Get the raw field data for the selected line
-    QImage traceImage;
-    lastScopeLine = scanLine;
-    lastScopeDot = pictureDot;
-
-    traceImage = getFieldLineTraceImage(scanLineData, pictureDot);
+    QImage traceImage = getFieldLineTraceImage(scanLineData, lastScopeX);
 
     // Add the QImage to the QLabel in the dialogue
     ui->scopeLabel->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
@@ -78,12 +80,22 @@ void OscilloscopeDialog::showTraceImage(TbcSource::ScanLineData scanLineData, qi
     ui->scopeLabel->setScaledContents(true);
     ui->scopeLabel->setPixmap(QPixmap::fromImage(traceImage));
 
-    // Update the scan-line spinbox
-    ui->scanLineSpinBox->setMaximum(frameHeight);
-    ui->scanLineSpinBox->setValue(scanLine);
+    // Update the X coordinate spinbox
+    ui->xCoordSpinBox->setMaximum(maximumX - 1);
+    ui->xCoordSpinBox->setValue(lastScopeX);
 
-    // Update the maximum scan-lines limit
-    maximumScanLines = frameHeight;
+    // Update the Y coordinate spinbox
+    ui->yCoordSpinBox->setMaximum(maximumY - 1);
+    ui->yCoordSpinBox->setValue(lastScopeY);
+
+    // Update the line number displays
+    ui->standardLineLabel->setText(QString("%1 line %2")
+                                   .arg(scanLineData.systemDescription)
+                                   .arg(scanLineData.lineNumber.standard()));
+    ui->fieldLineLabel->setText(QString("Field %1 line %2")
+                                        .arg(scanLineData.lineNumber.isFirstField() ? "1" : "2")
+                                        .arg(scanLineData.lineNumber.field1()));
+
     // QT Bug workaround for some macOS versions
     #if defined(Q_OS_MACOS)
     	repaint();
@@ -233,43 +245,50 @@ QImage OscilloscopeDialog::getFieldLineTraceImage(TbcSource::ScanLineData scanLi
 
 void OscilloscopeDialog::on_previousPushButton_clicked()
 {
-    if (ui->scanLineSpinBox->value() != 1) {
-        emit scanLineChanged(ui->scanLineSpinBox->value() - 1, lastScopeDot);
+    if (ui->yCoordSpinBox->value() != 0) {
+        emit scopeCoordsChanged(lastScopeX, ui->yCoordSpinBox->value() - 1);
     }
 }
 
 void OscilloscopeDialog::on_nextPushButton_clicked()
 {
-    if (ui->scanLineSpinBox->value() < maximumScanLines) {
-        emit scanLineChanged(ui->scanLineSpinBox->value() + 1, lastScopeDot);
+    if (ui->yCoordSpinBox->value() < maximumY - 1) {
+        emit scopeCoordsChanged(lastScopeX, ui->yCoordSpinBox->value() + 1);
     }
 }
 
-void OscilloscopeDialog::on_scanLineSpinBox_valueChanged(int arg1)
+void OscilloscopeDialog::on_xCoordSpinBox_valueChanged(int arg1)
 {
     (void)arg1;
-    if (ui->scanLineSpinBox->value() != lastScopeLine)
-        emit scanLineChanged(ui->scanLineSpinBox->value(), lastScopeDot);
+    if (ui->xCoordSpinBox->value() != lastScopeX)
+        emit scopeCoordsChanged(ui->xCoordSpinBox->value(), lastScopeY);
+}
+
+void OscilloscopeDialog::on_yCoordSpinBox_valueChanged(int arg1)
+{
+    (void)arg1;
+    if (ui->yCoordSpinBox->value() != lastScopeY)
+        emit scopeCoordsChanged(lastScopeX, ui->yCoordSpinBox->value() );
 }
 
 void OscilloscopeDialog::on_YCcheckBox_clicked()
 {
-    emit scanLineChanged(ui->scanLineSpinBox->value(), lastScopeDot);
+    emit scopeCoordsChanged(lastScopeX, lastScopeY);
 }
 
 void OscilloscopeDialog::on_YcheckBox_clicked()
 {
-    emit scanLineChanged(ui->scanLineSpinBox->value(), lastScopeDot);
+    emit scopeCoordsChanged(lastScopeX, lastScopeY);
 }
 
 void OscilloscopeDialog::on_CcheckBox_clicked()
 {
-    emit scanLineChanged(ui->scanLineSpinBox->value(), lastScopeDot);
+    emit scopeCoordsChanged(lastScopeX, lastScopeY);
 }
 
 void OscilloscopeDialog::on_dropoutsCheckBox_clicked()
 {
-    emit scanLineChanged(ui->scanLineSpinBox->value(), lastScopeDot);
+    emit scopeCoordsChanged(lastScopeX, lastScopeY);
 }
 
 // Mouse press event handler
@@ -322,7 +341,7 @@ void OscilloscopeDialog::mousePictureDotSelect(qint32 oX)
     if (unscaledX < 0) unscaledX = 0;
 
     // Remember the last dot selected
-    lastScopeDot = unscaledX;
+    lastScopeX = unscaledX;
 
-    emit scanLineChanged(ui->scanLineSpinBox->value(), lastScopeDot);
+    emit scopeCoordsChanged(lastScopeX, lastScopeY);
 }

--- a/tools/ld-analyse/oscilloscopedialog.h
+++ b/tools/ld-analyse/oscilloscopedialog.h
@@ -47,15 +47,16 @@ public:
     explicit OscilloscopeDialog(QWidget *parent = nullptr);
     ~OscilloscopeDialog();
 
-    void showTraceImage(TbcSource::ScanLineData scanLineData, qint32 scanLine, qint32 pictureDot, qint32 frameHeight);
+    void showTraceImage(TbcSource::ScanLineData scanLineData, qint32 xCoord, qint32 yCoord, qint32 frameWidth, qint32 frameHeight);
 
 signals:
-    void scanLineChanged(qint32 scanLine, qint32 lastScopeDot);
+    void scopeCoordsChanged(qint32 xCoord, qint32 yCoord);
 
 private slots:
     void on_previousPushButton_clicked();
     void on_nextPushButton_clicked();
-    void on_scanLineSpinBox_valueChanged(int arg1);
+    void on_xCoordSpinBox_valueChanged(int arg1);
+    void on_yCoordSpinBox_valueChanged(int arg1);
     void on_YCcheckBox_clicked();
     void on_YcheckBox_clicked();
     void on_CcheckBox_clicked();
@@ -66,10 +67,11 @@ private slots:
 
 private:
     Ui::OscilloscopeDialog *ui;
-    qint32 maximumScanLines;
+    qint32 maximumX;
+    qint32 maximumY;
     qint32 scopeWidth;
-    qint32 lastScopeLine;
-    qint32 lastScopeDot;
+    qint32 lastScopeX;
+    qint32 lastScopeY;
 
     QImage getFieldLineTraceImage(TbcSource::ScanLineData scanLineData, qint32 pictureDot);
     void mousePictureDotSelect(qint32 oX);

--- a/tools/ld-analyse/oscilloscopedialog.ui
+++ b/tools/ld-analyse/oscilloscopedialog.ui
@@ -7,13 +7,13 @@
     <x>0</x>
     <y>0</y>
     <width>480</width>
-    <height>250</height>
+    <height>300</height>
    </rect>
   </property>
   <property name="minimumSize">
    <size>
     <width>480</width>
-    <height>250</height>
+    <height>300</height>
    </size>
   </property>
   <property name="maximumSize">
@@ -37,13 +37,13 @@
     <widget class="QFrame" name="frame">
      <property name="minimumSize">
       <size>
-       <width>120</width>
+       <width>180</width>
        <height>130</height>
       </size>
      </property>
      <property name="maximumSize">
       <size>
-       <width>100</width>
+       <width>180</width>
        <height>16777215</height>
       </size>
      </property>
@@ -64,7 +64,7 @@
         </property>
         <property name="maximumSize">
          <size>
-          <width>100</width>
+          <width>32767</width>
           <height>16777215</height>
          </size>
         </property>
@@ -86,7 +86,7 @@
         </property>
         <property name="maximumSize">
          <size>
-          <width>100</width>
+          <width>32767</width>
           <height>16777215</height>
          </size>
         </property>
@@ -99,20 +99,116 @@
        </widget>
       </item>
       <item>
-       <widget class="QSpinBox" name="scanLineSpinBox">
-        <property name="minimumSize">
-         <size>
-          <width>50</width>
-          <height>0</height>
-         </size>
+       <widget class="QFrame" name="positionFrame">
+        <property name="frameShape">
+         <enum>QFrame::NoFrame</enum>
         </property>
-        <property name="maximumSize">
-         <size>
-          <width>100</width>
-          <height>16777215</height>
-         </size>
+        <property name="frameShadow">
+         <enum>QFrame::Raised</enum>
+        </property>
+        <layout class="QHBoxLayout" name="horizontalLayout_2">
+         <property name="spacing">
+          <number>6</number>
+         </property>
+         <property name="leftMargin">
+          <number>0</number>
+         </property>
+         <property name="topMargin">
+          <number>0</number>
+         </property>
+         <property name="rightMargin">
+          <number>0</number>
+         </property>
+         <property name="bottomMargin">
+          <number>0</number>
+         </property>
+         <item>
+          <widget class="QLabel" name="xCoordLabel">
+           <property name="text">
+            <string>X:</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QSpinBox" name="xCoordSpinBox">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Expanding" vsizetype="Minimum">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="minimumSize">
+            <size>
+             <width>50</width>
+             <height>28</height>
+            </size>
+           </property>
+           <property name="maximumSize">
+            <size>
+             <width>100</width>
+             <height>16777215</height>
+            </size>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QLabel" name="yCoordLabel">
+           <property name="text">
+            <string> Y:</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QSpinBox" name="yCoordSpinBox">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Expanding" vsizetype="Minimum">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="minimumSize">
+            <size>
+             <width>50</width>
+             <height>28</height>
+            </size>
+           </property>
+           <property name="maximumSize">
+            <size>
+             <width>100</width>
+             <height>16777215</height>
+            </size>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </widget>
+      </item>
+      <item>
+       <widget class="QLabel" name="standardLineLabel">
+        <property name="text">
+         <string>SECAM line 888</string>
         </property>
        </widget>
+      </item>
+      <item>
+       <widget class="QLabel" name="fieldLineLabel">
+        <property name="text">
+         <string>Field 8 line 888</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <spacer name="verticalSpacer">
+        <property name="orientation">
+         <enum>Qt::Vertical</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>20</width>
+          <height>40</height>
+         </size>
+        </property>
+       </spacer>
       </item>
       <item>
        <widget class="QCheckBox" name="YCcheckBox">
@@ -147,19 +243,6 @@
          <bool>true</bool>
         </property>
        </widget>
-      </item>
-      <item>
-       <spacer name="verticalSpacer">
-        <property name="orientation">
-         <enum>Qt::Vertical</enum>
-        </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>20</width>
-          <height>40</height>
-         </size>
-        </property>
-       </spacer>
       </item>
      </layout>
     </widget>

--- a/tools/ld-analyse/oscilloscopedialog.ui
+++ b/tools/ld-analyse/oscilloscopedialog.ui
@@ -53,117 +53,113 @@
      <property name="frameShadow">
       <enum>QFrame::Raised</enum>
      </property>
-     <layout class="QVBoxLayout" name="verticalLayout_2">
+     <layout class="QVBoxLayout" name="verticalLayout">
       <item>
-       <layout class="QVBoxLayout" name="verticalLayout">
-        <item>
-         <widget class="QPushButton" name="previousPushButton">
-          <property name="minimumSize">
-           <size>
-            <width>50</width>
-            <height>0</height>
-           </size>
-          </property>
-          <property name="maximumSize">
-           <size>
-            <width>100</width>
-            <height>16777215</height>
-           </size>
-          </property>
-          <property name="text">
-           <string>Previous</string>
-          </property>
-          <property name="autoRepeat">
-           <bool>true</bool>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QPushButton" name="nextPushButton">
-          <property name="minimumSize">
-           <size>
-            <width>50</width>
-            <height>0</height>
-           </size>
-          </property>
-          <property name="maximumSize">
-           <size>
-            <width>100</width>
-            <height>16777215</height>
-           </size>
-          </property>
-          <property name="text">
-           <string>Next</string>
-          </property>
-          <property name="autoRepeat">
-           <bool>true</bool>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QSpinBox" name="scanLineSpinBox">
-          <property name="minimumSize">
-           <size>
-            <width>50</width>
-            <height>0</height>
-           </size>
-          </property>
-          <property name="maximumSize">
-           <size>
-            <width>100</width>
-            <height>16777215</height>
-           </size>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QCheckBox" name="YCcheckBox">
-          <property name="text">
-           <string>YC</string>
-          </property>
-          <property name="checked">
-           <bool>true</bool>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QCheckBox" name="YcheckBox">
-          <property name="text">
-           <string>Y</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QCheckBox" name="CcheckBox">
-          <property name="text">
-           <string>C</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QCheckBox" name="dropoutsCheckBox">
-          <property name="text">
-           <string>Dropouts</string>
-          </property>
-          <property name="checked">
-           <bool>true</bool>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <spacer name="verticalSpacer">
-          <property name="orientation">
-           <enum>Qt::Vertical</enum>
-          </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>20</width>
-            <height>40</height>
-           </size>
-          </property>
-         </spacer>
-        </item>
-       </layout>
+       <widget class="QPushButton" name="previousPushButton">
+        <property name="minimumSize">
+         <size>
+          <width>50</width>
+          <height>0</height>
+         </size>
+        </property>
+        <property name="maximumSize">
+         <size>
+          <width>100</width>
+          <height>16777215</height>
+         </size>
+        </property>
+        <property name="text">
+         <string>Previous</string>
+        </property>
+        <property name="autoRepeat">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QPushButton" name="nextPushButton">
+        <property name="minimumSize">
+         <size>
+          <width>50</width>
+          <height>0</height>
+         </size>
+        </property>
+        <property name="maximumSize">
+         <size>
+          <width>100</width>
+          <height>16777215</height>
+         </size>
+        </property>
+        <property name="text">
+         <string>Next</string>
+        </property>
+        <property name="autoRepeat">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QSpinBox" name="scanLineSpinBox">
+        <property name="minimumSize">
+         <size>
+          <width>50</width>
+          <height>0</height>
+         </size>
+        </property>
+        <property name="maximumSize">
+         <size>
+          <width>100</width>
+          <height>16777215</height>
+         </size>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="YCcheckBox">
+        <property name="text">
+         <string>YC</string>
+        </property>
+        <property name="checked">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="YcheckBox">
+        <property name="text">
+         <string>Y</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="CcheckBox">
+        <property name="text">
+         <string>C</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="dropoutsCheckBox">
+        <property name="text">
+         <string>Dropouts</string>
+        </property>
+        <property name="checked">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <spacer name="verticalSpacer">
+        <property name="orientation">
+         <enum>Qt::Vertical</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>20</width>
+          <height>40</height>
+         </size>
+        </property>
+       </spacer>
       </item>
      </layout>
     </widget>

--- a/tools/ld-analyse/tbcsource.h
+++ b/tools/ld-analyse/tbcsource.h
@@ -35,6 +35,7 @@
 // TBC library includes
 #include "sourcevideo.h"
 #include "lddecodemetadata.h"
+#include "linenumber.h"
 #include "vbidecoder.h"
 #include "filters.h"
 
@@ -50,6 +51,8 @@ public:
     explicit TbcSource(QObject *parent = nullptr);
 
     struct ScanLineData {
+        QString systemDescription;
+        LineNumber lineNumber;
         QVector<qint32> composite;
         QVector<qint32> luma;
         QVector<bool> isDropout;

--- a/tools/ld-chroma-decoder/encoder/main.cpp
+++ b/tools/ld-chroma-decoder/encoder/main.cpp
@@ -121,11 +121,8 @@ int main(int argc, char *argv[])
     QString systemName;
     if (parser.isSet(systemOption)) {
         systemName = parser.value(systemOption);
-        if (systemName == "ntsc" || systemName == "NTSC") {
-            system = NTSC;
-        } else if (systemName == "pal" || systemName == "PAL") {
-            system = PAL;
-        } else {
+        if (!parseVideoSystemName(systemName.toUpper(), system)
+            || (system != NTSC && system != PAL)) {
             // Quit with error
             qCritical("Unsupported color system");
             return -1;

--- a/tools/ld-decode-tools.pro
+++ b/tools/ld-decode-tools.pro
@@ -14,5 +14,6 @@ SUBDIRS = \
     ld-disc-stacker \
     ld-process-vits \
     library/filter/testfilter \
+    library/tbc/testlinenumber \
     library/tbc/testmetadata \
     library/tbc/testvbidecoder

--- a/tools/ld-process-efm/efmprocess.h
+++ b/tools/ld-process-efm/efmprocess.h
@@ -62,8 +62,6 @@ public:
     void reset();
 
 private:
-    bool processingDone;
-
     // Debug
     bool debug_efmToF3Frames;
     bool debug_f3ToF2Frames;

--- a/tools/library/tbc/lddecodemetadata.h
+++ b/tools/library/tbc/lddecodemetadata.h
@@ -27,6 +27,7 @@
 #ifndef LDDECODEMETADATA_H
 #define LDDECODEMETADATA_H
 
+#include <QString>
 #include <QVector>
 #include <QTemporaryFile>
 #include <QDebug>
@@ -39,12 +40,14 @@ class JsonReader;
 class JsonWriter;
 
 // The video system (combination of a line standard and a colour standard)
-// Note: If you update this, be sure to update the getVideoSystemDescription method also
+// Note: If you update this, be sure to update VIDEO_SYSTEM_DEFAULTS also
 enum VideoSystem {
     PAL = 0,    // 625-line PAL
     NTSC,       // 525-line NTSC
     PAL_M,      // 525-line PAL
 };
+
+bool parseVideoSystemName(QString name, VideoSystem &system);
 
 class LdDecodeMetaData
 {
@@ -245,7 +248,7 @@ public:
     qint32 getFieldPcmAudioLength(qint32 sequentialFieldNumber);
 
     // Video system helper methods
-    QString getVideoSystemDescription();
+    QString getVideoSystemDescription() const;
 
 private:
     bool isFirstFieldFirst;

--- a/tools/library/tbc/linenumber.h
+++ b/tools/library/tbc/linenumber.h
@@ -1,0 +1,165 @@
+/************************************************************************
+
+    linenumber.h
+
+    ld-decode-tools TBC library
+    Copyright (C) 2022 Adam Sampson
+
+    This file is part of ld-decode-tools.
+
+    ld-decode-tools is free software: you can redistribute it and/or
+    modify it under the terms of the GNU General Public License as
+    published by the Free Software Foundation, either version 3 of the
+    License, or (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+************************************************************************/
+
+#ifndef LINENUMBER_H
+#define LINENUMBER_H
+
+#include <QtGlobal>
+#include <cassert>
+
+#include "lddecodemetadata.h"
+
+/*
+The lines in a ComponentField or OutputField are numbered as follows:
+
+For 525-line standards: [Poynton p500 table 41.1]
+
+frame0  field0  first?  standard
+0       0       1       1           first of 5 lines of equalisation pulses
+1       0       0       264
+2       1       1       2
+3       1       0       265
+...
+523     261     0       525
+524     262     1       263         last half-line of active area + half-line of equalisation pulses
+
+For 625-line standards: [Poynton p520 table 43.1]
+
+frame0  field0  first?  standard
+0       0       1       1           first of 4 lines of broad pulses
+1       0       0       314
+2       1       1       2
+3       1       0       315
+...
+623     311     0       625         last of 4 lines of equalisation pulses
+624     312     1       313         half-line of equalisation pulses + half-line of broad pulses
+
+All fields in a TBC file have the same size, so the second field has an extra
+line of padding at the end -- this is not included in the output.
+
+In 625-line standards, line 313 is treated by ld-decode as being part of the
+first field, so the first field has 313 lines and the second has 312 plus a
+padding line. (Poynton says line 313 is part of the second field; EBU Tech 3280
+says the field boundary occurs in the middle of line 313.)
+*/
+
+// A line number within a video frame in a particular VideoStandard
+class LineNumber {
+public:
+    // Default constructor: initialise to an invalid line number
+    LineNumber()
+        : frame0Line(-1), firstFieldLines(0)
+    {}
+
+    // Return the line number in standard terminology:
+    // 1-based, in the order in which lines are transmitted
+    qint32 standard() const {
+        return (frame0Line / 2) + 1 + (firstFieldLines * (frame0Line % 2));
+    }
+
+    // Return true if this line is in the first field in standard terminology:
+    // the field containing frame0() == 0 and standard() == 1
+    bool isFirstField() const {
+        return (frame0Line % 2) == 0;
+    }
+
+    // Return 0-based line number within the frame
+    qint32 frame0() const {
+        return frame0Line;
+    }
+
+    // Return 1-based line number within the frame
+    qint32 frame1() const {
+        return frame0Line + 1;
+    }
+
+    // Return 0-based line number within the field
+    qint32 field0() const {
+        return frame0Line / 2;
+    }
+
+    // Return 1-based line number within the field
+    qint32 field1() const {
+        return field0() + 1;
+    }
+
+    // Construct from a standard line number
+    static LineNumber fromStandard(qint32 standardLine, VideoSystem system) {
+        return LineNumber(standardLine, system, true);
+    }
+
+    // Construct from a 0-based line number within the frame
+    static LineNumber fromFrame0(qint32 frame0Line, VideoSystem system) {
+        return LineNumber(frame0Line, system);
+    }
+
+    // Construct from a 1-based line number within the frame
+    static LineNumber fromFrame1(qint32 frame1Line, VideoSystem system) {
+        return LineNumber(frame1Line - 1, system);
+    }
+
+    // Construct from a 0-based line number within the field
+    static LineNumber fromField0(qint32 field0Line, bool isFirstField, VideoSystem system) {
+        return LineNumber((field0Line * 2) + (isFirstField ? 0 : 1), system);
+    }
+
+    // Construct from a 1-based line number within the field
+    static LineNumber fromField1(qint32 field1Line, bool isFirstField, VideoSystem system) {
+        return fromField0(field1Line - 1, isFirstField, system);
+    }
+
+protected:
+    // Private constructor used by from* static methods
+    LineNumber(qint32 number, VideoSystem system, bool isStandard = false)
+    {
+        const qint32 numLines = (system == PAL) ? 625 : 525;
+        firstFieldLines = (numLines / 2) + 1;
+
+        // In both cases, we allow an extra two lines at the end, so we can
+        // represent the padding line in the second field, plus a
+        // one-past-the-end value for ranges.
+
+        if (isStandard) {
+            // number is in standard form (so we have to know firstFieldLines to convert it)
+
+            assert(number >= 1);
+            assert(number <= numLines + 2);
+
+            frame0Line = (((number - 1) % firstFieldLines) * 2) + (number / (firstFieldLines + 1));
+        } else {
+            // number is in frame0 form
+
+            assert(number >= 0);
+            assert(number < numLines + 2);
+
+            frame0Line = number;
+        }
+    }
+
+private:
+    qint32 frame0Line;
+    qint32 firstFieldLines;
+};
+
+#endif

--- a/tools/library/tbc/testlinenumber/testlinenumber.cpp
+++ b/tools/library/tbc/testlinenumber/testlinenumber.cpp
@@ -1,0 +1,88 @@
+/************************************************************************
+
+    testlinenumber.cpp
+
+    Unit tests for metadata classes
+    Copyright (C) 2022 Adam Sampson
+
+    This file is part of ld-decode-tools.
+
+    ld-decode-tools is free software: you can redistribute it and/or
+    modify it under the terms of the GNU General Public License as
+    published by the Free Software Foundation, either version 3 of the
+    License, or (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+************************************************************************/
+
+#include <cassert>
+#include <cstdio>
+
+#include "lddecodemetadata.h"
+#include "linenumber.h"
+
+void testAllValues(VideoSystem system, qint32 lines) {
+    printf("-- %d line --\n", lines);
+    printf("%8s %8s %8s %8s %8s %8s\n",
+           "std", "frame0", "frame1", "field0", "field1", "isFirst");
+
+    // Check up to the padding line at the end
+    for (qint32 i = 0; i <= lines; i++) {
+        LineNumber num = LineNumber::fromFrame0(i, system);
+
+        if (i < 6 || i > lines - 6) {
+            printf("%8d %8d %8d %8d %8d %8s\n",
+                   num.standard(), num.frame0(), num.frame1(),
+                   num.field0(), num.field1(),
+                   num.isFirstField() ? "true" : "false");
+        } else if (i == 6) {
+            printf("...\n");
+        }
+
+        // Check that we can round-trip all the formats for this line number.
+        assert(LineNumber::fromStandard(num.standard(), system).frame0() == i);
+        assert(LineNumber::fromFrame0(num.frame0(), system).frame0() == i);
+        assert(LineNumber::fromFrame1(num.frame1(), system).frame0() == i);
+        assert(LineNumber::fromField0(num.field0(), num.isFirstField(), system).frame0() == i);
+        assert(LineNumber::fromField1(num.field1(), num.isFirstField(), system).frame0() == i);
+    }
+}
+
+int main()
+{
+    testAllValues(PAL, 625);
+    testAllValues(NTSC, 525);
+
+    // PAL bounds
+    assert(LineNumber::fromFrame0(0, PAL).standard() == 1);
+    assert(LineNumber::fromFrame0(0, PAL).isFirstField());
+    assert(LineNumber::fromFrame0(1, PAL).standard() == 314);
+    assert(!LineNumber::fromFrame0(1, PAL).isFirstField());
+    assert(LineNumber::fromFrame0(623, PAL).standard() == 625);
+    assert(LineNumber::fromFrame0(624, PAL).standard() == 313);
+
+    // NTSC bounds
+    assert(LineNumber::fromFrame0(0, NTSC).standard() == 1);
+    assert(LineNumber::fromFrame0(0, NTSC).isFirstField());
+    assert(LineNumber::fromFrame0(1, NTSC).standard() == 264);
+    assert(!LineNumber::fromFrame0(1, NTSC).isFirstField());
+    assert(LineNumber::fromFrame0(523, NTSC).standard() == 525);
+    assert(LineNumber::fromFrame0(524, NTSC).standard() == 263);
+
+    // ld-decode treats the "middle" line as being part of the first field
+    assert(LineNumber::fromStandard(313, PAL).isFirstField());
+    assert(LineNumber::fromStandard(263, NTSC).isFirstField());
+
+    // Check other systems have the right number of lines
+    assert(LineNumber::fromFrame0(524, PAL_M).standard() == 263);
+
+    return 0;
+}
+

--- a/tools/library/tbc/testlinenumber/testlinenumber.pro
+++ b/tools/library/tbc/testlinenumber/testlinenumber.pro
@@ -1,0 +1,21 @@
+CONFIG += c++11 testcase
+CONFIG -= app_bundle
+
+SOURCES += \
+    testlinenumber.cpp \
+    ../dropouts.cpp \
+    ../jsonio.cpp \
+    ../lddecodemetadata.cpp \
+    ../vbidecoder.cpp
+
+HEADERS += \
+    ../dropouts.h \
+    ../jsonio.h \
+    ../lddecodemetadata.h \
+    ../linenumber.h \
+    ../vbidecoder.h
+
+INCLUDEPATH += \
+    ..
+
+target.CONFIG += no_default_install

--- a/tools/library/tbc/testmetadata/testmetadata.cpp
+++ b/tools/library/tbc/testmetadata/testmetadata.cpp
@@ -205,6 +205,28 @@ void testJsonReader()
     }
 }
 
+// Run unit tests for VideoSystem
+void testVideoSystem() {
+    std::cerr << "Testing VideoSystem\n";
+
+    VideoSystem system;
+    bool b;
+
+    b = parseVideoSystemName("PAL", system);
+    assert(b);
+    assert(system == PAL);
+    b = parseVideoSystemName("NTSC", system);
+    assert(b);
+    assert(system == NTSC);
+    b = parseVideoSystemName("PAL-M", system);
+    assert(b);
+    assert(system == PAL_M);
+    b = parseVideoSystemName("", system);
+    assert(!b);
+    b = parseVideoSystemName("SPURIOUS", system);
+    assert(!b);
+}
+
 int main(int argc, char *argv[])
 {
     // Initialise Qt
@@ -240,6 +262,7 @@ int main(int argc, char *argv[])
     if (positionalArguments.count() == 0) {
         // Run unit tests
         testJsonReader();
+        testVideoSystem();
         return 0;
     }
     if (positionalArguments.count() > 2) {


### PR DESCRIPTION
The LineNumber class represents a line number within a ComponentFrame/OutputFrame, and can convert between the various different representations of line numbers that the ld-decode tools use - plus the standard way of numbering PAL/NTSC lines. There are various places in the code that could potentially use this in the future, but for now...

The oscilloscope view has been converted to use LineNumber, so it now shows the selected X/Y coordinates within the frame, and the line numbers that you need if you're referring to a standard or working with the metadata:
![scope3](https://user-images.githubusercontent.com/436317/172511934-895855a3-8f84-4a91-a394-fbea0657fb15.png)

Thanks to various people on IRC/Discord for workshopping the UI changes!