### PR TITLE
Add NTSC-J support to ld-chroma-encoder

### DIFF
--- a/tools/ld-chroma-decoder/encoder/main.cpp
+++ b/tools/ld-chroma-decoder/encoder/main.cpp
@@ -81,6 +81,11 @@ int main(int argc, char *argv[])
                                      QCoreApplication::translate("main", "chroma-mode"));
     parser.addOption(chromaOption);
 
+    // Option to disable 7.5 IRE setup, as in NTSC-J (--no-setup)
+    QCommandLineOption setupOption(QStringList() << "no-setup",
+                                     QCoreApplication::translate("main", "NTSC only. Do not add 7.5 IRE setup (as in NTSC-J)"));
+    parser.addOption(setupOption);
+
     // -- Positional arguments --
 
     // Positional argument to specify input video file
@@ -129,6 +134,8 @@ int main(int argc, char *argv[])
         }
     }
 
+    bool addSetup = !parser.isSet(setupOption);
+
     ChromaMode chromaMode = WIDEBAND_YUV;
     QString chromaName;
     if (parser.isSet(chromaOption)) {
@@ -168,7 +175,7 @@ int main(int argc, char *argv[])
     // Encode the data
     LdDecodeMetaData metaData;
     if( system == NTSC ) {
-        NTSCEncoder encoder(rgbFile, tbcFile, metaData, chromaMode);
+        NTSCEncoder encoder(rgbFile, tbcFile, metaData, chromaMode, addSetup);
         if (!encoder.encode()) {
             return -1;
         }

--- a/tools/ld-chroma-decoder/encoder/ntscencoder.h
+++ b/tools/ld-chroma-decoder/encoder/ntscencoder.h
@@ -40,7 +40,7 @@ enum ChromaMode {
 class NTSCEncoder
 {
 public:
-    NTSCEncoder(QFile &rgbFile, QFile &tbcFile, LdDecodeMetaData &metaData, ChromaMode &chromaMode);
+    NTSCEncoder(QFile &rgbFile, QFile &tbcFile, LdDecodeMetaData &metaData, ChromaMode &chromaMode, bool &addSetup);
 
     // Encode RGB stream to NTSC.
     // Returns true on success; on failure, prints an error and returns false.
@@ -51,10 +51,14 @@ private:
     bool encodeField(qint32 fieldNo);
     void encodeLine(qint32 fieldNo, qint32 frameLine, const quint16 *rgbData, QVector<quint16> &outputLine);
 
+    const qint32 blankingIre = 0x3C00;
+    const qint32 setupIreOffset = 0x0A80; // 10.5 * 256
+
     QFile &rgbFile;
     QFile &tbcFile;
     LdDecodeMetaData &metaData;
     ChromaMode chromaMode;
+    bool addSetup;
 
     LdDecodeMetaData::VideoParameters videoParameters;
     qint32 activeWidth;


### PR DESCRIPTION
Adds '--no-setup' to disable adding setup.

On the decoder side, all this really does is change black16bIre in the JSON.  test-chroma.sh will need some refactoring if we care to test these various NTSC-specific encoder options (no-setup and the wideband-yuv/wideband-yiq modes).