### PR TITLE
Add a vectorscope display to ld-analyse

### DIFF
--- a/tools/ld-analyse/configuration.cpp
+++ b/tools/ld-analyse/configuration.cpp
@@ -72,6 +72,7 @@ void Configuration::writeConfiguration(void)
     configuration->setValue("mainWindowScaleFactor", settings.windows.mainWindowScaleFactor);
     configuration->setValue("vbiDialogGeometry", settings.windows.vbiDialogGeometry);
     configuration->setValue("oscilloscopeDialogGeometry", settings.windows.oscilloscopeDialogGeometry);
+    configuration->setValue("vectorscopeDialogGeometry", settings.windows.vectorscopeDialogGeometry);
     configuration->setValue("dropoutAnalysisDialogGeometry", settings.windows.dropoutAnalysisDialogGeometry);
     configuration->setValue("visibleDropoutAnalysisDialogGeometry", settings.windows.visibleDropoutAnalysisDialogGeometry);
     configuration->setValue("blackSnrAnalysisDialogGeometry", settings.windows.blackSnrAnalysisDialogGeometry);
@@ -104,6 +105,7 @@ void Configuration::readConfiguration(void)
     settings.windows.mainWindowScaleFactor = configuration->value("mainWindowScaleFactor").toReal();
     settings.windows.vbiDialogGeometry = configuration->value("vbiDialogGeometry").toByteArray();
     settings.windows.oscilloscopeDialogGeometry = configuration->value("oscilloscopeDialogGeometry").toByteArray();
+    settings.windows.vectorscopeDialogGeometry = configuration->value("vectorscopeDialogGeometry").toByteArray();
     settings.windows.dropoutAnalysisDialogGeometry = configuration->value("dropoutAnalysisDialogGeometry").toByteArray();
     settings.windows.visibleDropoutAnalysisDialogGeometry = configuration->value("visibleDropoutAnalysisDialogGeometry").toByteArray();
     settings.windows.blackSnrAnalysisDialogGeometry = configuration->value("blackSnrAnalysisDialogGeometry").toByteArray();
@@ -127,6 +129,7 @@ void Configuration::setDefault(void)
     settings.windows.mainWindowScaleFactor = 1.0;
     settings.windows.vbiDialogGeometry = QByteArray();
     settings.windows.oscilloscopeDialogGeometry = QByteArray();
+    settings.windows.vectorscopeDialogGeometry = QByteArray();
     settings.windows.dropoutAnalysisDialogGeometry = QByteArray();
     settings.windows.visibleDropoutAnalysisDialogGeometry = QByteArray();
     settings.windows.blackSnrAnalysisDialogGeometry = QByteArray();
@@ -200,6 +203,16 @@ void Configuration::setOscilloscopeDialogGeometry(QByteArray oscilloscopeDialogG
 QByteArray Configuration::getOscilloscopeDialogGeometry(void)
 {
     return settings.windows.oscilloscopeDialogGeometry;
+}
+
+void Configuration::setVectorscopeDialogGeometry(QByteArray vectorscopeDialogGeometry)
+{
+    settings.windows.vectorscopeDialogGeometry = vectorscopeDialogGeometry;
+}
+
+QByteArray Configuration::getVectorscopeDialogGeometry(void)
+{
+    return settings.windows.vectorscopeDialogGeometry;
 }
 
 void Configuration::setDropoutAnalysisDialogGeometry(QByteArray dropoutAnalysisDialogGeometry)

--- a/tools/ld-analyse/configuration.h
+++ b/tools/ld-analyse/configuration.h
@@ -58,6 +58,8 @@ public:
     QByteArray getVbiDialogGeometry(void);
     void setOscilloscopeDialogGeometry(QByteArray oscilloscopeDialogGeometry);
     QByteArray getOscilloscopeDialogGeometry(void);
+    void setVectorscopeDialogGeometry(QByteArray vectorscopeDialogGeometry);
+    QByteArray getVectorscopeDialogGeometry(void);
     void setDropoutAnalysisDialogGeometry(QByteArray dropoutAnalysisDialogGeometry);
     QByteArray getDropoutAnalysisDialogGeometry(void);
     void setVisibleDropoutAnalysisDialogGeometry(QByteArray visibleDropoutDialogGeometry);
@@ -90,6 +92,7 @@ private:
         qreal mainWindowScaleFactor;
         QByteArray vbiDialogGeometry;
         QByteArray oscilloscopeDialogGeometry;
+        QByteArray vectorscopeDialogGeometry;
         QByteArray dropoutAnalysisDialogGeometry;
         QByteArray visibleDropoutAnalysisDialogGeometry;
         QByteArray blackSnrAnalysisDialogGeometry;

--- a/tools/ld-analyse/ld-analyse.pro
+++ b/tools/ld-analyse/ld-analyse.pro
@@ -31,6 +31,7 @@ SOURCES += \
     main.cpp \
     mainwindow.cpp \
     oscilloscopedialog.cpp \
+    vectorscopedialog.cpp \
     aboutdialog.cpp \
     chromadecoderconfigdialog.cpp \
     tbcsource.cpp \
@@ -62,6 +63,7 @@ HEADERS += \
     closedcaptionsdialog.h \
     mainwindow.h \
     oscilloscopedialog.h \
+    vectorscopedialog.h \
     aboutdialog.h \
     chromadecoderconfigdialog.h \
     tbcsource.h \
@@ -95,6 +97,7 @@ FORMS += \
     closedcaptionsdialog.ui \
     mainwindow.ui \
     oscilloscopedialog.ui \
+    vectorscopedialog.ui \
     aboutdialog.ui \
     chromadecoderconfigdialog.ui \
     vbidialog.ui \

--- a/tools/ld-analyse/mainwindow.h
+++ b/tools/ld-analyse/mainwindow.h
@@ -35,6 +35,7 @@
 #include <QMouseEvent>
 
 #include "oscilloscopedialog.h"
+#include "vectorscopedialog.h"
 #include "aboutdialog.h"
 #include "vbidialog.h"
 #include "dropoutanalysisdialog.h"
@@ -65,6 +66,7 @@ private slots:
     void on_actionOpen_TBC_file_triggered();
     void on_actionReload_TBC_triggered();
     void on_actionLine_scope_triggered();
+    void on_actionVectorscope_triggered();
     void on_actionAbout_ld_analyse_triggered();
     void on_actionVBI_triggered();
     void on_actionDropout_analysis_triggered();
@@ -99,6 +101,7 @@ private slots:
 
     // Miscellaneous handlers
     void scopeCoordsChangedSignalHandler(qint32 xCoord, qint32 yCoord);
+    void vectorscopeChangedSignalHandler();
     void mousePressEvent(QMouseEvent *event);
     void mouseMoveEvent(QMouseEvent *event);
     void chromaDecoderConfigChangedSignalHandler();
@@ -112,6 +115,7 @@ private:
 
     // Dialogues
     OscilloscopeDialog* oscilloscopeDialog;
+    VectorscopeDialog* vectorscopeDialog;
     AboutDialog* aboutDialog;
     VbiDialog* vbiDialog;
     DropoutAnalysisDialog* dropoutAnalysisDialog;
@@ -148,6 +152,7 @@ private:
     // TBC source signal handlers
     void loadTbcFile(QString inputFileName);
     void updateOscilloscopeDialogue();
+    void updateVectorscopeDialogue();
     void mouseScanLineSelect(qint32 oX, qint32 oY);
 };
 

--- a/tools/ld-analyse/mainwindow.ui
+++ b/tools/ld-analyse/mainwindow.ui
@@ -474,6 +474,7 @@
     <addaction name="actionWhite_SNR_analysis"/>
     <addaction name="actionVBI"/>
     <addaction name="actionLine_scope"/>
+    <addaction name="actionVectorscope"/>
     <addaction name="actionClosed_Captions"/>
     <addaction name="separator"/>
     <addaction name="actionChroma_decoder_configuration"/>
@@ -527,6 +528,14 @@
    </property>
    <property name="shortcut">
     <string>Ctrl+L</string>
+   </property>
+  </action>
+  <action name="actionVectorscope">
+   <property name="text">
+    <string>Vectorscope...</string>
+   </property>
+   <property name="shortcut">
+    <string>Ctrl+U</string>
    </property>
   </action>
   <action name="actionVBI">

--- a/tools/ld-analyse/tbcsource.cpp
+++ b/tools/ld-analyse/tbcsource.cpp
@@ -327,6 +327,22 @@ bool TbcSource::getIsDropoutPresent()
     return false;
 }
 
+// Get the decoded ComponentFrame for the current frame
+const ComponentFrame &TbcSource::getComponentFrame()
+{
+    // Load and decode SourceFields for the current frame
+    loadInputFields();
+    decodeFrame();
+
+    return componentFrames[0];
+}
+
+// Get the VideoParameters for the current source
+const LdDecodeMetaData::VideoParameters &TbcSource::getVideoParameters()
+{
+    return ldDecodeMetaData.getVideoParameters();
+}
+
 // Get scan line data from the frame
 TbcSource::ScanLineData TbcSource::getScanLineData(qint32 scanLine)
 {
@@ -353,14 +369,10 @@ TbcSource::ScanLineData TbcSource::getScanLineData(qint32 scanLine)
     scanLineData.isActiveLine = (scanLine - 1) >= videoParameters.firstActiveFrameLine
                                 && (scanLine -1) < videoParameters.lastActiveFrameLine;
 
-    // Load and decode SourceFields for the current frame
-    loadInputFields();
-    decodeFrame();
-
     // Get the field video and dropout data
     const SourceVideo::Data &fieldData = lineNumber.isFirstField() ? inputFields[inputStartIndex].data
                                                                    : inputFields[inputStartIndex + 1].data;
-    const ComponentFrame &componentFrame = componentFrames[0];
+    const ComponentFrame &componentFrame = getComponentFrame();
     DropOuts &dropouts = lineNumber.isFirstField() ? firstField.dropOuts
                                                    : secondField.dropOuts;
 

--- a/tools/ld-analyse/tbcsource.h
+++ b/tools/ld-analyse/tbcsource.h
@@ -109,6 +109,8 @@ public:
     qint32 getGraphDataSize();
 
     bool getIsDropoutPresent();
+    const ComponentFrame &getComponentFrame();
+    const LdDecodeMetaData::VideoParameters &getVideoParameters();
     ScanLineData getScanLineData(qint32 scanLine);
 
     qint32 getFirstFieldNumber();

--- a/tools/ld-analyse/vectorscopedialog.cpp
+++ b/tools/ld-analyse/vectorscopedialog.cpp
@@ -1,0 +1,183 @@
+﻿/************************************************************************
+
+    vectorscopedialog.cpp
+
+    ld-analyse - TBC output analysis
+    Copyright (C) 2018-2022 Simon Inns
+    Copyright (C) 2022 Adam Sampson
+
+    This file is part of ld-decode-tools.
+
+    ld-analyse is free software: you can redistribute it and/or
+    modify it under the terms of the GNU General Public License as
+    published by the Free Software Foundation, either version 3 of the
+    License, or (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+************************************************************************/
+
+#include "vectorscopedialog.h"
+#include "ui_vectorscopedialog.h"
+
+#include <cmath>
+#include <random>
+
+#include <QDebug>
+#include <QPainter>
+
+VectorscopeDialog::VectorscopeDialog(QWidget *parent) :
+    QDialog(parent),
+    ui(new Ui::VectorscopeDialog)
+{
+    ui->setupUi(this);
+    setWindowFlags(Qt::Window);
+}
+
+VectorscopeDialog::~VectorscopeDialog()
+{
+    delete ui;
+}
+
+void VectorscopeDialog::showTraceImage(const ComponentFrame &componentFrame, const LdDecodeMetaData::VideoParameters &videoParameters)
+{
+    qDebug() << "VectorscopeDialog::showTraceImage(): Called";
+
+    // Draw the image
+    QImage traceImage = getTraceImage(componentFrame, videoParameters);
+
+    // Add the QImage to the QLabel in the dialogue
+    ui->scopeLabel->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
+    ui->scopeLabel->setAlignment(Qt::AlignCenter);
+    ui->scopeLabel->setScaledContents(true);
+    ui->scopeLabel->setPixmap(QPixmap::fromImage(traceImage));
+
+    // QT Bug workaround for some macOS versions
+    #if defined(Q_OS_MACOS)
+    	repaint();
+    #endif
+}
+
+QImage VectorscopeDialog::getTraceImage(const ComponentFrame &componentFrame, const LdDecodeMetaData::VideoParameters &videoParameters)
+{
+    // Scope size and scale
+    constexpr qint32 SIZE = 1024;
+    constexpr qint32 SCALE = 65536 / SIZE;
+    constexpr qint32 HALF_SIZE = SIZE / 2;
+
+    // Define image with width, height and format
+    QImage scopeImage(SIZE, SIZE, QImage::Format_RGB888);
+    QPainter scopePainter;
+
+    // Set the background to black
+    scopeImage.fill(Qt::black);
+
+    // Attach the scope image to the painter
+    scopePainter.begin(&scopeImage);
+
+    // Initialise a cheap, predictable random number generator, for defocussing
+    std::minstd_rand randomEngine(12345);
+    std::normal_distribution<double> normalDist(0.0, 100.0);
+
+    // For each sample in the active area, plot its U/V values on the chart
+    scopePainter.setPen(Qt::green);
+    bool defocus = ui->defocusCheckBox->isChecked();
+    for (qint32 lineNumber = videoParameters.firstActiveFrameLine; lineNumber < videoParameters.lastActiveFrameLine; lineNumber++) {
+        const auto &uLine = componentFrame.u(lineNumber);
+        const auto &vLine = componentFrame.v(lineNumber);
+
+        for (qint32 xPosition = videoParameters.activeVideoStart; xPosition < videoParameters.activeVideoEnd; xPosition++) {
+            // If defocussing, add a random (but normally-distributed) value to U/V
+            double uOffset = defocus ? normalDist(randomEngine) : 0.0;
+            double vOffset = defocus ? normalDist(randomEngine) : 0.0;
+
+            // On a real vectorscope, U is positive to the right, and V is positive *upwards*
+            qint32 x = HALF_SIZE + (static_cast<qint32>(uLine[xPosition] + uOffset) / SCALE);
+            qint32 y = HALF_SIZE - (static_cast<qint32>(vLine[xPosition] + vOffset) / SCALE);
+
+            scopePainter.drawPoint(x, y);
+        }
+    }
+
+    // Overlay the graticule, unless it's disabled
+    if (!ui->graticuleNoneRadioButton->isChecked()) {
+        scopePainter.setPen(Qt::white);
+
+        // Draw the vertical/horizontal graticule lines and circle
+        scopePainter.drawLine(HALF_SIZE, 0, HALF_SIZE, SIZE - 1);
+        scopePainter.drawLine(0, HALF_SIZE, SIZE - 1, HALF_SIZE);
+        scopePainter.drawEllipse(0, 0, SIZE - 1, SIZE - 1);
+
+        // For NTSC: draw I/Q graticule lines, 33 degrees offset from the axes
+        if (videoParameters.system == NTSC) {
+            double theta = (-33.0 * M_PI) / 180;
+            for (qint32 i = 0; i < 4; i++) {
+                scopePainter.drawLine(HALF_SIZE + (0.2 * HALF_SIZE * cos(theta)),
+                                      HALF_SIZE + (0.2 * HALF_SIZE * sin(theta)),
+                                      HALF_SIZE + (HALF_SIZE * cos(theta)),
+                                      HALF_SIZE + (HALF_SIZE * sin(theta)));
+                theta += M_PI / 2.0;
+            }
+        }
+
+        // Scaling factor for which graticule
+        const double percent = ui->graticule75RadioButton->isChecked() ? 0.75 : 1.0;
+
+        // Draw graticule targets for the six colour bars
+        for (qint32 rgb = 1; rgb < 7; rgb++) {
+            // R'G'B' for this bar
+            const double R = percent * static_cast<double>((rgb >> 2) & 1);
+            const double G = percent * static_cast<double>((rgb >> 1) & 1);
+            const double B = percent * static_cast<double>(rgb & 1);
+
+            // Convert R'G'B' to Y'UV [Poynton p337 eq 28.5]
+            const double U = (R * -0.147141) + (G * -0.288869) + (B * 0.436010);
+            const double V = (R * 0.614975)  + (G * -0.514965) + (B * -0.100010);
+
+            // Convert to angle and magnitude, scaled to match scope coords
+            const double barTheta = atan2(-V, U);
+            const double barMag = sqrt((V * V) + (U * U)) * (videoParameters.white16bIre - videoParameters.black16bIre) / SCALE;
+
+            // Draw the target grid, with 10 degree angle and 10% magnitude steps
+            const double stepTheta = (10.0 * M_PI) / 180.0;
+            const double stepMag = 0.1 * barMag;
+            for (qint32 step = -1; step < 2; step++) {
+                // XXX These should really be curved lines
+                const double theta = barTheta + (step * stepTheta);
+                scopePainter.drawLine(HALF_SIZE + ((barMag - stepMag) * cos(theta)), HALF_SIZE + ((barMag - stepMag) * sin(theta)),
+                                      HALF_SIZE + ((barMag + stepMag) * cos(theta)), HALF_SIZE + ((barMag + stepMag) * sin(theta)));
+            }
+            for (qint32 step = -1; step < 2; step++) {
+                const double mag = barMag + (step * stepMag);
+                scopePainter.drawLine(HALF_SIZE + (mag * cos(barTheta - stepTheta)), HALF_SIZE + (mag * sin(barTheta - stepTheta)),
+                                      HALF_SIZE + (mag * cos(barTheta + stepTheta)), HALF_SIZE + (mag * sin(barTheta + stepTheta)));
+
+            }
+        }
+
+        // XXX Draw a line for the colourburst -- we don't decode it at the moment
+    }
+
+    // Return the QImage
+    scopePainter.end();
+    return scopeImage;
+}
+
+// GUI signal handlers ------------------------------------------------------------------------------------------------
+
+void VectorscopeDialog::on_defocusCheckBox_clicked()
+{
+    emit scopeChanged();
+}
+
+void VectorscopeDialog::on_graticuleButtonGroup_buttonClicked(QAbstractButton *button)
+{
+    (void) button;
+    emit scopeChanged();
+}

--- a/tools/ld-analyse/vectorscopedialog.h
+++ b/tools/ld-analyse/vectorscopedialog.h
@@ -1,0 +1,62 @@
+﻿/************************************************************************
+
+    vectorscopedialog.cpp
+
+    ld-analyse - TBC output analysis
+    Copyright (C) 2022 Adam Sampson
+
+    This file is part of ld-decode-tools.
+
+    ld-analyse is free software: you can redistribute it and/or
+    modify it under the terms of the GNU General Public License as
+    published by the Free Software Foundation, either version 3 of the
+    License, or (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+************************************************************************/
+
+#ifndef VECTORSCOPEDIALOG_H
+#define VECTORSCOPEDIALOG_H
+
+#include <QAbstractButton>
+#include <QGraphicsPixmapItem>
+#include <QDialog>
+
+#include "componentframe.h"
+#include "lddecodemetadata.h"
+
+namespace Ui {
+class VectorscopeDialog;
+}
+
+class VectorscopeDialog : public QDialog
+{
+    Q_OBJECT
+
+public:
+    explicit VectorscopeDialog(QWidget *parent = nullptr);
+    ~VectorscopeDialog();
+
+    void showTraceImage(const ComponentFrame &componentFrame, const LdDecodeMetaData::VideoParameters &videoParameters);
+
+signals:
+    void scopeChanged();
+
+private slots:
+    void on_defocusCheckBox_clicked();
+    void on_graticuleButtonGroup_buttonClicked(QAbstractButton *button);
+
+private:
+    Ui::VectorscopeDialog *ui;
+
+    QImage getTraceImage(const ComponentFrame &componentFrame, const LdDecodeMetaData::VideoParameters &videoParameters);
+};
+
+#endif // VECTORSCOPEDIALOG_H

--- a/tools/ld-analyse/vectorscopedialog.ui
+++ b/tools/ld-analyse/vectorscopedialog.ui
@@ -1,0 +1,130 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>VectorscopeDialog</class>
+ <widget class="QDialog" name="VectorscopeDialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>520</width>
+    <height>300</height>
+   </rect>
+  </property>
+  <property name="minimumSize">
+   <size>
+    <width>520</width>
+    <height>300</height>
+   </size>
+  </property>
+  <property name="maximumSize">
+   <size>
+    <width>16777215</width>
+    <height>16777215</height>
+   </size>
+  </property>
+  <property name="windowTitle">
+   <string>Vectorscope</string>
+  </property>
+  <layout class="QHBoxLayout" name="horizontalLayout">
+   <item>
+    <widget class="QLabel" name="scopeLabel">
+     <property name="text">
+      <string>Graphics go here :)</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QFrame" name="frame">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="minimumSize">
+      <size>
+       <width>120</width>
+       <height>0</height>
+      </size>
+     </property>
+     <property name="frameShape">
+      <enum>QFrame::StyledPanel</enum>
+     </property>
+     <property name="frameShadow">
+      <enum>QFrame::Raised</enum>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayout">
+      <item>
+       <widget class="QCheckBox" name="defocusCheckBox">
+        <property name="toolTip">
+         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Blur the display to make small points more visible&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+        </property>
+        <property name="text">
+         <string>Defocus</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <spacer name="verticalSpacer">
+        <property name="orientation">
+         <enum>Qt::Vertical</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>20</width>
+          <height>40</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+      <item>
+       <widget class="QLabel" name="graticuleLabel">
+        <property name="text">
+         <string>Graticule:</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QRadioButton" name="graticuleNoneRadioButton">
+        <property name="text">
+         <string>None</string>
+        </property>
+        <attribute name="buttonGroup">
+         <string notr="true">graticuleButtonGroup</string>
+        </attribute>
+       </widget>
+      </item>
+      <item>
+       <widget class="QRadioButton" name="graticule75RadioButton">
+        <property name="text">
+         <string>75% bars</string>
+        </property>
+        <property name="checked">
+         <bool>true</bool>
+        </property>
+        <attribute name="buttonGroup">
+         <string notr="true">graticuleButtonGroup</string>
+        </attribute>
+       </widget>
+      </item>
+      <item>
+       <widget class="QRadioButton" name="graticule100RadioButton">
+        <property name="text">
+         <string>100% bars</string>
+        </property>
+        <attribute name="buttonGroup">
+         <string notr="true">graticuleButtonGroup</string>
+        </attribute>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+ <buttongroups>
+  <buttongroup name="graticuleButtonGroup"/>
+ </buttongroups>
+</ui>


### PR DESCRIPTION
This can be used to adjust the chroma gain and phase, given colourbars or a similar test signal. Graticule targets are provided for 75% and 100% bars, and a Defocus mode that blurs the display so you can see very small dots more easily (e.g. in files generated by ld-chroma-encoder).

I'm open to suggestions for interface changes - one thing I'm wondering about is whether the default scale is too small...

![vectorscope](https://user-images.githubusercontent.com/436317/172739241-b6ddf4b6-5039-4a63-a65c-1d89c849174b.png)