### PR TITLE
chroma-encoder: Fix phase error in wideband-yuv mode

### DIFF
--- a/tools/ld-chroma-decoder/encoder/ntscencoder.cpp
+++ b/tools/ld-chroma-decoder/encoder/ntscencoder.cpp
@@ -408,8 +408,8 @@ void NTSCEncoder::encodeLine(qint32 fieldNo, qint32 frameLine, const quint16 *rg
         // Encode the chroma signal
         double chroma;
         if (chromaMode == WIDEBAND_YUV) {
-            // Y'UV [Poynton p338]
-            chroma = C1[x] * sin(a - 33.0 - 123.0) + C2[x] * cos(a - 33.0 - 123.0);
+            // Y'UV [Poynton p338], offset 57 degrees
+            chroma = C1[x] * sin(a + 57.0 * M_PI / 180.0) + C2[x] * cos(a + 57.0 * M_PI / 180.0);
         } else {
             // Y'IQ [Poynton p368]
             chroma = C2[x] * sin(a + 33.0) + C1[x] * cos(a + 33.0);


### PR DESCRIPTION
NTSC .tbc files use IQ sampling per SMPTE 244M. Encode Y'UV and convert to Y'IQ, except do it correctly this time. It was about 5 degrees off before.

I had this correct locally at some point, but I managed to break it before making #752  I don't like replacing magic numbers with more magic numbers, but shifting 57 degrees does make sense (zeroH is 57/90 between samples).

The new vectorscope makes it much easier to verify correctness, too.