### PR TITLE
Add Video Parameters dialogue to ld-analyse

### DIFF
--- a/tools/ld-analyse/blacksnranalysisdialog.cpp
+++ b/tools/ld-analyse/blacksnranalysisdialog.cpp
@@ -54,7 +54,7 @@ BlackSnrAnalysisDialog::BlackSnrAnalysisDialog(QWidget *parent) :
     numberOfFrames = 0;
 
     // Connect to scale changed slot
-    connect(((QObject*)plot->axisWidget(QwtPlot::xBottom)) , SIGNAL(scaleDivChanged () ), this, SLOT(scaleDivChangedSlot () ));
+    connect(plot->axisWidget(QwtPlot::xBottom), &QwtScaleWidget::scaleDivChanged, this, &BlackSnrAnalysisDialog::scaleDivChangedSlot);
 }
 
 BlackSnrAnalysisDialog::~BlackSnrAnalysisDialog()

--- a/tools/ld-analyse/chromadecoderconfigdialog.ui
+++ b/tools/ld-analyse/chromadecoderconfigdialog.ui
@@ -7,13 +7,16 @@
     <x>0</x>
     <y>0</y>
     <width>460</width>
-    <height>514</height>
+    <height>637</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>Chroma Decoder Configuration</string>
   </property>
   <layout class="QVBoxLayout" name="outerVerticalLayout">
+   <property name="sizeConstraint">
+    <enum>QLayout::SetFixedSize</enum>
+   </property>
    <item>
     <widget class="QLabel" name="chromaGainLabel">
      <property name="text">
@@ -23,6 +26,18 @@
    </item>
    <item>
     <widget class="QSlider" name="chromaGainHorizontalSlider">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="minimumSize">
+      <size>
+       <width>400</width>
+       <height>0</height>
+      </size>
+     </property>
      <property name="maximum">
       <number>200</number>
      </property>
@@ -93,6 +108,19 @@
     </widget>
    </item>
    <item>
+    <spacer name="verticalSpacer_1">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>15</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item>
     <widget class="QTabWidget" name="standardTabs">
      <property name="currentIndex">
       <number>1</number>
@@ -147,7 +175,7 @@
          <property name="sizeHint" stdset="0">
           <size>
            <width>20</width>
-           <height>40</height>
+           <height>15</height>
           </size>
          </property>
         </spacer>
@@ -167,7 +195,7 @@
          <property name="sizeHint" stdset="0">
           <size>
            <width>20</width>
-           <height>40</height>
+           <height>15</height>
           </size>
          </property>
         </spacer>
@@ -207,7 +235,7 @@
          <property name="sizeHint" stdset="0">
           <size>
            <width>20</width>
-           <height>40</height>
+           <height>15</height>
           </size>
          </property>
         </spacer>
@@ -234,7 +262,7 @@
          <property name="sizeHint" stdset="0">
           <size>
            <width>20</width>
-           <height>40</height>
+           <height>0</height>
           </size>
          </property>
         </spacer>
@@ -291,7 +319,7 @@
          <property name="sizeHint" stdset="0">
           <size>
            <width>20</width>
-           <height>40</height>
+           <height>15</height>
           </size>
          </property>
         </spacer>
@@ -339,7 +367,7 @@
          <property name="sizeHint" stdset="0">
           <size>
            <width>20</width>
-           <height>40</height>
+           <height>15</height>
           </size>
          </property>
         </spacer>
@@ -376,7 +404,7 @@
          <property name="sizeHint" stdset="0">
           <size>
            <width>20</width>
-           <height>40</height>
+           <height>0</height>
           </size>
          </property>
         </spacer>
@@ -385,25 +413,12 @@
      </widget>
     </widget>
    </item>
-   <item>
-    <spacer name="verticalSpacer_1">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>20</width>
-       <height>40</height>
-      </size>
-     </property>
-    </spacer>
-   </item>
   </layout>
  </widget>
  <resources/>
  <connections/>
  <buttongroups>
-  <buttongroup name="palFilterButtonGroup"/>
   <buttongroup name="ntscFilterButtonGroup"/>
+  <buttongroup name="palFilterButtonGroup"/>
  </buttongroups>
 </ui>

--- a/tools/ld-analyse/configuration.cpp
+++ b/tools/ld-analyse/configuration.cpp
@@ -78,6 +78,7 @@ void Configuration::writeConfiguration(void)
     configuration->setValue("blackSnrAnalysisDialogGeometry", settings.windows.blackSnrAnalysisDialogGeometry);
     configuration->setValue("whiteSnrAnalysisDialogGeometry", settings.windows.whiteSnrAnalysisDialogGeometry);
     configuration->setValue("closedCaptionDialogGeometry", settings.windows.closedCaptionDialogGeometry);
+    configuration->setValue("videoParametersDialogGeometry", settings.windows.videoParametersDialogGeometry);
     configuration->setValue("chromaDecoderConfigDialogGeometry", settings.windows.chromaDecoderConfigDialogGeometry);
     configuration->endGroup();
 
@@ -111,6 +112,7 @@ void Configuration::readConfiguration(void)
     settings.windows.blackSnrAnalysisDialogGeometry = configuration->value("blackSnrAnalysisDialogGeometry").toByteArray();
     settings.windows.whiteSnrAnalysisDialogGeometry = configuration->value("whiteSnrAnalysisDialogGeometry").toByteArray();
     settings.windows.closedCaptionDialogGeometry = configuration->value("closedCaptionDialogGeometry").toByteArray();
+    settings.windows.videoParametersDialogGeometry = configuration->value("videoParametersDialogGeometry").toByteArray();
     settings.windows.chromaDecoderConfigDialogGeometry = configuration->value("chromaDecoderConfigDialogGeometry").toByteArray();
     configuration->endGroup();
 }
@@ -135,6 +137,7 @@ void Configuration::setDefault(void)
     settings.windows.blackSnrAnalysisDialogGeometry = QByteArray();
     settings.windows.whiteSnrAnalysisDialogGeometry = QByteArray();
     settings.windows.closedCaptionDialogGeometry = QByteArray();
+    settings.windows.videoParametersDialogGeometry = QByteArray();
     settings.windows.chromaDecoderConfigDialogGeometry = QByteArray();
 
     // Write the configuration
@@ -263,6 +266,16 @@ void Configuration::setClosedCaptionDialogGeometry(QByteArray closedCaptionDialo
 QByteArray Configuration::getClosedCaptionDialogGeometry(void)
 {
     return settings.windows.closedCaptionDialogGeometry;
+}
+
+void Configuration::setVideoParametersDialogGeometry(QByteArray videoParametersDialogGeometry)
+{
+    settings.windows.videoParametersDialogGeometry = videoParametersDialogGeometry;
+}
+
+QByteArray Configuration::getVideoParametersDialogGeometry(void)
+{
+    return settings.windows.videoParametersDialogGeometry;
 }
 
 void Configuration::setChromaDecoderConfigDialogGeometry(QByteArray chromaDecoderConfigDialogGeometry)

--- a/tools/ld-analyse/configuration.h
+++ b/tools/ld-analyse/configuration.h
@@ -70,6 +70,8 @@ public:
     QByteArray getWhiteSnrAnalysisDialogGeometry(void);
     void setClosedCaptionDialogGeometry(QByteArray closedCaptionDialogGeometry);
     QByteArray getClosedCaptionDialogGeometry(void);
+    void setVideoParametersDialogGeometry(QByteArray videoParametersConfigDialogGeometry);
+    QByteArray getVideoParametersDialogGeometry(void);
     void setChromaDecoderConfigDialogGeometry(QByteArray chromaDecoderConfigDialogGeometry);
     QByteArray getChromaDecoderConfigDialogGeometry(void);
 
@@ -98,6 +100,7 @@ private:
         QByteArray blackSnrAnalysisDialogGeometry;
         QByteArray whiteSnrAnalysisDialogGeometry;
         QByteArray closedCaptionDialogGeometry;
+        QByteArray videoParametersDialogGeometry;
         QByteArray chromaDecoderConfigDialogGeometry;
     };
 

--- a/tools/ld-analyse/dropoutanalysisdialog.cpp
+++ b/tools/ld-analyse/dropoutanalysisdialog.cpp
@@ -52,7 +52,7 @@ DropoutAnalysisDialog::DropoutAnalysisDialog(QWidget *parent) :
     numberOfFrames = 0;
 
     // Connect to scale changed slot
-    connect(((QObject*)plot->axisWidget(QwtPlot::xBottom)) , SIGNAL(scaleDivChanged() ), this, SLOT(scaleDivChangedSlot() ));
+    connect(plot->axisWidget(QwtPlot::xBottom), &QwtScaleWidget::scaleDivChanged, this, &DropoutAnalysisDialog::scaleDivChangedSlot);
 }
 
 DropoutAnalysisDialog::~DropoutAnalysisDialog()

--- a/tools/ld-analyse/ld-analyse.pro
+++ b/tools/ld-analyse/ld-analyse.pro
@@ -33,6 +33,7 @@ SOURCES += \
     oscilloscopedialog.cpp \
     vectorscopedialog.cpp \
     aboutdialog.cpp \
+    videoparametersdialog.cpp \
     chromadecoderconfigdialog.cpp \
     tbcsource.cpp \
     vbidialog.cpp \
@@ -65,6 +66,7 @@ HEADERS += \
     oscilloscopedialog.h \
     vectorscopedialog.h \
     aboutdialog.h \
+    videoparametersdialog.h \
     chromadecoderconfigdialog.h \
     tbcsource.h \
     vbidialog.h \
@@ -99,6 +101,7 @@ FORMS += \
     oscilloscopedialog.ui \
     vectorscopedialog.ui \
     aboutdialog.ui \
+    videoparametersdialog.ui \
     chromadecoderconfigdialog.ui \
     vbidialog.ui \
     dropoutanalysisdialog.ui \

--- a/tools/ld-analyse/mainwindow.cpp
+++ b/tools/ld-analyse/mainwindow.cpp
@@ -363,15 +363,9 @@ void MainWindow::showFrame()
     ui->frameViewerLabel->clear();
     ui->frameViewerLabel->setScaledContents(false);
     ui->frameViewerLabel->setAlignment(Qt::AlignCenter);
-    updateFrameViewer();
 
-    // If the scope dialogues are open, update them
-    if (oscilloscopeDialog->isVisible()) {
-        updateOscilloscopeDialogue();
-    }
-    if (vectorscopeDialog->isVisible()) {
-        updateVectorscopeDialogue();
-    }
+    // Update the frame views
+    updateFrame();
 
     // Update the closed caption dialog
     if (tbcSource.getSystem() == NTSC) {
@@ -381,6 +375,21 @@ void MainWindow::showFrame()
     #if defined(Q_OS_MACOS)
     	repaint();
     #endif
+}
+
+// Redraw all the GUI elements that depend on the decoded frame
+void MainWindow::updateFrame()
+{
+    // Update the main frame viewer
+    updateFrameViewer();
+
+    // If the scope dialogues are open, update them
+    if (oscilloscopeDialog->isVisible()) {
+        updateOscilloscopeDialogue();
+    }
+    if (vectorscopeDialog->isVisible()) {
+        updateVectorscopeDialogue();
+    }
 }
 
 // Redraw the frame viewer (for example, when scaleFactor has been changed)
@@ -1026,16 +1035,8 @@ void MainWindow::chromaDecoderConfigChangedSignalHandler()
                                      chromaDecoderConfigDialog->getNtscConfiguration(),
                                      chromaDecoderConfigDialog->getOutputConfiguration());
 
-    // Update the frame viewer
-    updateFrameViewer();
-
-    // If the scope windows are open, update them
-    if (oscilloscopeDialog->isVisible()) {
-        updateOscilloscopeDialogue();
-    }
-    if (vectorscopeDialog->isVisible()) {
-        updateVectorscopeDialogue();
-    }
+    // Update the frame views
+    updateFrame();
 }
 
 // TbcSource class signal handlers ------------------------------------------------------------------------------------

--- a/tools/ld-analyse/mainwindow.cpp
+++ b/tools/ld-analyse/mainwindow.cpp
@@ -644,7 +644,6 @@ void MainWindow::on_actionSave_frame_as_PNG_triggered()
 
             QMessageBox messageBox;
             messageBox.warning(this, "Warning","Could not save a PNG using the specified filename!");
-            messageBox.setFixedSize(500, 200);
         }
 
         // Update the configuration for the PNG directory
@@ -1109,7 +1108,6 @@ void MainWindow::on_finishedLoading()
         // Show the error to the user
         QMessageBox messageBox;
         messageBox.warning(this, "Error", tbcSource.getLastLoadError());
-        messageBox.setFixedSize(500, 200);
     }
 
     // Enable the main window

--- a/tools/ld-analyse/mainwindow.cpp
+++ b/tools/ld-analyse/mainwindow.cpp
@@ -72,8 +72,8 @@ MainWindow::MainWindow(QString inputFilenameParam, QWidget *parent) :
     // Connect to the chroma decoder configuration changed signal
     connect(chromaDecoderConfigDialog, &ChromaDecoderConfigDialog::chromaDecoderConfigChanged, this, &MainWindow::chromaDecoderConfigChangedSignalHandler);
 
-    // Connect to the TbcSource signals (busy loading and finished loading)
-    connect(&tbcSource, &TbcSource::busyLoading, this, &MainWindow::on_busyLoading);
+    // Connect to the TbcSource signals (busy and finished loading)
+    connect(&tbcSource, &TbcSource::busy, this, &MainWindow::on_busy);
     connect(&tbcSource, &TbcSource::finishedLoading, this, &MainWindow::on_finishedLoading);
 
     // Load the window geometry and settings from the configuration
@@ -1025,10 +1025,10 @@ void MainWindow::chromaDecoderConfigChangedSignalHandler()
 
 // TbcSource class signal handlers ------------------------------------------------------------------------------------
 
-// Signal handler for busyLoading signal from TbcSource class
-void MainWindow::on_busyLoading(QString infoMessage)
+// Signal handler for busy signal from TbcSource class
+void MainWindow::on_busy(QString infoMessage)
 {
-    qDebug() << "MainWindow::on_busyLoading(): Got signal with message" << infoMessage;
+    qDebug() << "MainWindow::on_busy(): Got signal with message" << infoMessage;
     // Set the busy message and centre the dialog in the parent window
     busyDialog->setMessage(infoMessage);
     busyDialog->move(this->geometry().center() - busyDialog->rect().center());
@@ -1043,7 +1043,7 @@ void MainWindow::on_busyLoading(QString infoMessage)
 }
 
 // Signal handler for finishedLoading signal from TbcSource class
-void MainWindow::on_finishedLoading()
+void MainWindow::on_finishedLoading(bool success)
 {
     qDebug() << "MainWindow::on_finishedLoading(): Called";
 
@@ -1051,7 +1051,7 @@ void MainWindow::on_finishedLoading()
     busyDialog->hide();
 
     // Ensure source loaded ok
-    if (tbcSource.getIsSourceLoaded()) {
+    if (success) {
         // Generate the graph data
         dropoutAnalysisDialog->startUpdate(tbcSource.getNumberOfFrames());
         visibleDropoutAnalysisDialog->startUpdate(tbcSource.getNumberOfFrames());
@@ -1092,7 +1092,7 @@ void MainWindow::on_finishedLoading()
 
         // Show the error to the user
         QMessageBox messageBox;
-        messageBox.warning(this, "Error", tbcSource.getLastLoadError());
+        messageBox.warning(this, "Error", tbcSource.getLastIOError());
     }
 
     // Enable the main window

--- a/tools/ld-analyse/mainwindow.cpp
+++ b/tools/ld-analyse/mainwindow.cpp
@@ -132,17 +132,51 @@ MainWindow::~MainWindow()
 
 // Update GUI methods for when TBC source files are loaded and unloaded -----------------------------------------------
 
+// Enable or disable all the GUI controls
+void MainWindow::setGuiEnabled(bool enabled)
+{
+    // Enable the frame controls
+    ui->frameNumberSpinBox->setEnabled(enabled);
+    ui->previousPushButton->setEnabled(enabled);
+    ui->nextPushButton->setEnabled(enabled);
+    ui->startFramePushButton->setEnabled(enabled);
+    ui->endFramePushButton->setEnabled(enabled);
+    ui->frameHorizontalSlider->setEnabled(enabled);
+    ui->mediaControl_frame->setEnabled(enabled);
+
+    // Enable menu options
+    ui->actionLine_scope->setEnabled(enabled);
+    ui->actionVectorscope->setEnabled(enabled);
+    ui->actionVBI->setEnabled(enabled);
+    ui->actionNTSC->setEnabled(enabled);
+    ui->actionVideo_metadata->setEnabled(enabled);
+    ui->actionVITS_Metrics->setEnabled(enabled);
+    ui->actionZoom_In->setEnabled(enabled);
+    ui->actionZoom_Out->setEnabled(enabled);
+    ui->actionZoom_1x->setEnabled(enabled);
+    ui->actionZoom_2x->setEnabled(enabled);
+    ui->actionZoom_3x->setEnabled(enabled);
+    ui->actionDropout_analysis->setEnabled(enabled);
+    ui->actionVisible_Dropout_analysis->setEnabled(enabled);
+    ui->actionSNR_analysis->setEnabled(enabled); // Black SNR
+    ui->actionWhite_SNR_analysis->setEnabled(enabled);
+    ui->actionSave_frame_as_PNG->setEnabled(enabled);
+    ui->actionClosed_Captions->setEnabled(enabled);
+    ui->actionVideo_parameters->setEnabled(enabled);
+    ui->actionChroma_decoder_configuration->setEnabled(enabled);
+    ui->actionReload_TBC->setEnabled(enabled);
+
+    // Set zoom button states
+    ui->zoomInPushButton->setEnabled(enabled);
+    ui->zoomOutPushButton->setEnabled(enabled);
+    ui->originalSizePushButton->setEnabled(enabled);
+}
+
 // Method to update the GUI when a file is loaded
 void MainWindow::updateGuiLoaded()
 {
-    // Enable the frame controls
-    ui->frameNumberSpinBox->setEnabled(true);
-    ui->previousPushButton->setEnabled(true);
-    ui->nextPushButton->setEnabled(true);
-    ui->startFramePushButton->setEnabled(true);
-    ui->endFramePushButton->setEnabled(true);
-    ui->frameHorizontalSlider->setEnabled(true);
-    ui->mediaControl_frame->setEnabled(true);
+    // Enable the GUI controls
+    setGuiEnabled(true);
 
     // Update the current frame number
     currentFrameNumber = 1;
@@ -162,28 +196,6 @@ void MainWindow::updateGuiLoaded()
     ui->nextPushButton->setAutoRepeatDelay(500);
     ui->nextPushButton->setAutoRepeatInterval(1);
 
-    // Enable menu options
-    ui->actionLine_scope->setEnabled(true);
-    ui->actionVectorscope->setEnabled(true);
-    ui->actionVBI->setEnabled(true);
-    ui->actionNTSC->setEnabled(true);
-    ui->actionVideo_metadata->setEnabled(true);
-    ui->actionVITS_Metrics->setEnabled(true);
-    ui->actionZoom_In->setEnabled(true);
-    ui->actionZoom_Out->setEnabled(true);
-    ui->actionZoom_1x->setEnabled(true);
-    ui->actionZoom_2x->setEnabled(true);
-    ui->actionZoom_3x->setEnabled(true);
-    ui->actionDropout_analysis->setEnabled(true);
-    ui->actionVisible_Dropout_analysis->setEnabled(true);
-    ui->actionSNR_analysis->setEnabled(true); // Black SNR
-    ui->actionWhite_SNR_analysis->setEnabled(true);
-    ui->actionSave_frame_as_PNG->setEnabled(true);
-    ui->actionClosed_Captions->setEnabled(true);
-    ui->actionVideo_parameters->setEnabled(true);
-    ui->actionChroma_decoder_configuration->setEnabled(true);
-    ui->actionReload_TBC->setEnabled(true);
-
     // Set option button states
     ui->videoPushButton->setText(tr("Source"));
     ui->dropoutsPushButton->setText(tr("Dropouts Off"));
@@ -192,11 +204,7 @@ void MainWindow::updateGuiLoaded()
     updateSourcesPushButton();
     ui->fieldOrderPushButton->setText(tr("Normal Field-order"));
 
-    // Set zoom button states
-    ui->zoomInPushButton->setEnabled(true);
-    ui->zoomOutPushButton->setEnabled(true);
-    ui->originalSizePushButton->setEnabled(true);
-
+    // Zoom button options
     ui->zoomInPushButton->setAutoRepeat(true);
     ui->zoomInPushButton->setAutoRepeatDelay(500);
     ui->zoomInPushButton->setAutoRepeatInterval(100);
@@ -229,14 +237,8 @@ void MainWindow::updateGuiLoaded()
 // Method to update the GUI when a file is unloaded
 void MainWindow::updateGuiUnloaded()
 {
-    // Disable the frame controls
-    ui->frameNumberSpinBox->setEnabled(false);
-    ui->previousPushButton->setEnabled(false);
-    ui->nextPushButton->setEnabled(false);
-    ui->startFramePushButton->setEnabled(false);
-    ui->endFramePushButton->setEnabled(false);
-    ui->frameHorizontalSlider->setEnabled(false);
-    ui->mediaControl_frame->setEnabled(false);
+    // Disable the GUI controls
+    setGuiEnabled(false);
 
     // Update the current frame number
     currentFrameNumber = 1;
@@ -252,28 +254,6 @@ void MainWindow::updateGuiUnloaded()
     sourceVideoStatus.setText(tr("No source video file loaded"));
     fieldNumberStatus.setText(tr(" -  Fields: ./."));
 
-    // Disable menu options
-    ui->actionLine_scope->setEnabled(false);
-    ui->actionVectorscope->setEnabled(false);
-    ui->actionVBI->setEnabled(false);
-    ui->actionNTSC->setEnabled(false);
-    ui->actionVideo_metadata->setEnabled(false);
-    ui->actionVITS_Metrics->setEnabled(false);
-    ui->actionZoom_In->setEnabled(false);
-    ui->actionZoom_Out->setEnabled(false);
-    ui->actionZoom_1x->setEnabled(false);
-    ui->actionZoom_2x->setEnabled(false);
-    ui->actionZoom_3x->setEnabled(false);
-    ui->actionDropout_analysis->setEnabled(false);
-    ui->actionVisible_Dropout_analysis->setEnabled(false);
-    ui->actionSNR_analysis->setEnabled(false); // Black SNR
-    ui->actionWhite_SNR_analysis->setEnabled(false);
-    ui->actionSave_frame_as_PNG->setEnabled(false);
-    ui->actionClosed_Captions->setEnabled(false);
-    ui->actionVideo_parameters->setEnabled(false);
-    ui->actionChroma_decoder_configuration->setEnabled(false);
-    ui->actionReload_TBC->setEnabled(false);
-
     // Set option button states
     ui->videoPushButton->setText(tr("Source"));
     ui->dropoutsPushButton->setText(tr("Dropouts Off"));
@@ -281,11 +261,6 @@ void MainWindow::updateGuiUnloaded()
     updateAspectPushButton();
     updateSourcesPushButton();
     ui->fieldOrderPushButton->setText(tr("Normal Field-order"));
-
-    // Set zoom button states
-    ui->zoomInPushButton->setEnabled(false);
-    ui->zoomOutPushButton->setEnabled(false);
-    ui->originalSizePushButton->setEnabled(false);
 
     // Hide the displayed frame
     hideFrame();

--- a/tools/ld-analyse/mainwindow.h
+++ b/tools/ld-analyse/mainwindow.h
@@ -92,6 +92,7 @@ private slots:
     void on_frameNumberSpinBox_editingFinished();
     void on_frameHorizontalSlider_valueChanged(int value);
     void on_videoPushButton_clicked();
+    void on_aspectPushButton_clicked();
     void on_dropoutsPushButton_clicked();
     void on_sourcesPushButton_clicked();
     void on_fieldOrderPushButton_clicked();
@@ -99,7 +100,6 @@ private slots:
     void on_zoomOutPushButton_clicked();
     void on_originalSizePushButton_clicked();
     void on_mouseModePushButton_clicked();
-    void on_aspectPushButton_clicked();
 
     // Miscellaneous handlers
     void scopeCoordsChangedSignalHandler(qint32 xCoord, qint32 yCoord);
@@ -135,7 +135,7 @@ private:
     QLabel sourceVideoStatus;
     QLabel fieldNumberStatus;
     TbcSource tbcSource;
-    quint8 aspectRatio;
+    bool displayAspectRatio;
     qint32 lastScopeLine;
     qint32 lastScopeDot;
     qint32 currentFrameNumber;
@@ -146,11 +146,13 @@ private:
     // Update GUI methods
     void updateGuiLoaded();
     void updateGuiUnloaded();
+    void updateAspectPushButton();
     void updateSourcesPushButton();
 
     // Frame display methods
     void showFrame();
     void updateFrame();
+    qint32 getAspectAdjustment();
     void updateFrameViewer();
     void hideFrame();
 

--- a/tools/ld-analyse/mainwindow.h
+++ b/tools/ld-analyse/mainwindow.h
@@ -144,6 +144,7 @@ private:
     QString lastFilename;
 
     // Update GUI methods
+    void setGuiEnabled(bool enabled);
     void updateGuiLoaded();
     void updateGuiUnloaded();
     void updateAspectPushButton();

--- a/tools/ld-analyse/mainwindow.h
+++ b/tools/ld-analyse/mainwindow.h
@@ -146,6 +146,7 @@ private:
 
     // Frame display methods
     void showFrame();
+    void updateFrame();
     void updateFrameViewer();
     void hideFrame();
 

--- a/tools/ld-analyse/mainwindow.h
+++ b/tools/ld-analyse/mainwindow.h
@@ -66,6 +66,7 @@ private slots:
     void on_actionExit_triggered();
     void on_actionOpen_TBC_file_triggered();
     void on_actionReload_TBC_triggered();
+    void on_actionSave_JSON_triggered();
     void on_actionLine_scope_triggered();
     void on_actionVectorscope_triggered();
     void on_actionAbout_ld_analyse_triggered();
@@ -112,6 +113,7 @@ private slots:
     // Tbc Source signal handlers
     void on_busy(QString infoMessage);
     void on_finishedLoading(bool success);
+    void on_finishedSaving(bool success);
 
 private:
     Ui::MainWindow *ui;

--- a/tools/ld-analyse/mainwindow.h
+++ b/tools/ld-analyse/mainwindow.h
@@ -44,6 +44,7 @@
 #include "whitesnranalysisdialog.h"
 #include "busydialog.h"
 #include "closedcaptionsdialog.h"
+#include "videoparametersdialog.h"
 #include "chromadecoderconfigdialog.h"
 #include "configuration.h"
 #include "tbcsource.h"
@@ -80,6 +81,7 @@ private slots:
     void on_actionZoom_2x_triggered();
     void on_actionZoom_3x_triggered();
     void on_actionClosed_Captions_triggered();
+    void on_actionVideo_parameters_triggered();
     void on_actionChroma_decoder_configuration_triggered();
 
     // Media control frame handlers
@@ -104,6 +106,7 @@ private slots:
     void vectorscopeChangedSignalHandler();
     void mousePressEvent(QMouseEvent *event);
     void mouseMoveEvent(QMouseEvent *event);
+    void videoParametersChangedSignalHandler(const LdDecodeMetaData::VideoParameters &videoParameters);
     void chromaDecoderConfigChangedSignalHandler();
 
     // Tbc Source signal handlers
@@ -124,6 +127,7 @@ private:
     WhiteSnrAnalysisDialog* whiteSnrAnalysisDialog;
     BusyDialog* busyDialog;
     ClosedCaptionsDialog *closedCaptionDialog;
+    VideoParametersDialog *videoParametersDialog;
     ChromaDecoderConfigDialog *chromaDecoderConfigDialog;
 
     // Class globals

--- a/tools/ld-analyse/mainwindow.h
+++ b/tools/ld-analyse/mainwindow.h
@@ -110,8 +110,8 @@ private slots:
     void chromaDecoderConfigChangedSignalHandler();
 
     // Tbc Source signal handlers
-    void on_busyLoading(QString infoMessage);
-    void on_finishedLoading();    
+    void on_busy(QString infoMessage);
+    void on_finishedLoading(bool success);
 
 private:
     Ui::MainWindow *ui;

--- a/tools/ld-analyse/mainwindow.ui
+++ b/tools/ld-analyse/mainwindow.ui
@@ -459,6 +459,7 @@
     </property>
     <addaction name="actionOpen_TBC_file"/>
     <addaction name="actionReload_TBC"/>
+    <addaction name="actionSave_JSON"/>
     <addaction name="separator"/>
     <addaction name="actionSave_frame_as_PNG"/>
     <addaction name="separator"/>
@@ -662,6 +663,11 @@
    </property>
    <property name="shortcut">
     <string>Ctrl+A</string>
+   </property>
+  </action>
+  <action name="actionSave_JSON">
+   <property name="text">
+    <string>Save JSON</string>
    </property>
   </action>
   <action name="actionWhite_SNR_analysis">

--- a/tools/ld-analyse/mainwindow.ui
+++ b/tools/ld-analyse/mainwindow.ui
@@ -643,6 +643,9 @@
    <property name="text">
     <string>Chroma decoder configuration...</string>
    </property>
+   <property name="shortcut">
+    <string>Ctrl+K</string>
+   </property>
   </action>
   <action name="actionReload_TBC">
    <property name="text">

--- a/tools/ld-analyse/mainwindow.ui
+++ b/tools/ld-analyse/mainwindow.ui
@@ -477,6 +477,7 @@
     <addaction name="actionVectorscope"/>
     <addaction name="actionClosed_Captions"/>
     <addaction name="separator"/>
+    <addaction name="actionVideo_parameters"/>
     <addaction name="actionChroma_decoder_configuration"/>
    </widget>
    <widget class="QMenu" name="menuHelp">
@@ -637,6 +638,14 @@
   <action name="actionClosed_Captions">
    <property name="text">
     <string>Closed Captions...</string>
+   </property>
+  </action>
+  <action name="actionVideo_parameters">
+   <property name="text">
+    <string>Video parameters...</string>
+   </property>
+   <property name="shortcut">
+    <string>Ctrl+P</string>
    </property>
   </action>
   <action name="actionChroma_decoder_configuration">

--- a/tools/ld-analyse/oscilloscopedialog.cpp
+++ b/tools/ld-analyse/oscilloscopedialog.cpp
@@ -306,7 +306,12 @@ void OscilloscopeDialog::mousePressEvent(QMouseEvent *event)
             oX + 1 <= ui->scopeLabel->width() &&
             oY <= ui->scopeLabel->height()) {
 
-        mousePictureDotSelect(oX);
+        // Is shift held down?
+        if (event->modifiers().testFlag(Qt::ShiftModifier)) {
+            mouseLevelSelect(oY);
+        } else {
+            mousePictureDotSelect(oX);
+        }
         event->accept();
     }
 }
@@ -318,6 +323,16 @@ void OscilloscopeDialog::mouseMoveEvent(QMouseEvent *event)
     mousePressEvent(event);
 }
 
+// Handle a click on the scope with shift held down, to select a level
+void OscilloscopeDialog::mouseLevelSelect(qint32 oY)
+{
+    qreal unscaledYR = (65536.0 / static_cast<qreal>(ui->scopeLabel->height())) * static_cast<qreal>(oY);
+
+    qint32 level = qBound(0, 65535 - static_cast<qint32>(unscaledYR), 65535);
+    emit scopeLevelSelect(level);
+}
+
+// Handle a click on the scope without shift held down, to select a sample
 void OscilloscopeDialog::mousePictureDotSelect(qint32 oX)
 {
     qreal unscaledXR = (static_cast<qreal>(scopeWidth) /

--- a/tools/ld-analyse/oscilloscopedialog.cpp
+++ b/tools/ld-analyse/oscilloscopedialog.cpp
@@ -314,21 +314,8 @@ void OscilloscopeDialog::mousePressEvent(QMouseEvent *event)
 // Mouse drag event handler
 void OscilloscopeDialog::mouseMoveEvent(QMouseEvent *event)
 {
-    // Get the mouse position relative to our scene
-    QPoint origin = ui->scopeLabel->mapFromGlobal(QCursor::pos());
-
-    // Check that the mouse click is within bounds of the current picture
-    qint32 oX = origin.x();
-    qint32 oY = origin.y();
-
-    if (oX + 1 >= 0 &&
-            oY >= 0 &&
-            oX + 1 <= ui->scopeLabel->width() &&
-            oY <= ui->scopeLabel->height()) {
-
-        mousePictureDotSelect(oX);
-        event->accept();
-    }
+    // Handle this the same way as a click
+    mousePressEvent(event);
 }
 
 void OscilloscopeDialog::mousePictureDotSelect(qint32 oX)

--- a/tools/ld-analyse/oscilloscopedialog.h
+++ b/tools/ld-analyse/oscilloscopedialog.h
@@ -51,6 +51,7 @@ public:
 
 signals:
     void scopeCoordsChanged(qint32 xCoord, qint32 yCoord);
+    void scopeLevelSelect(qint32 value);
 
 private slots:
     void on_previousPushButton_clicked();
@@ -74,6 +75,7 @@ private:
     qint32 lastScopeY;
 
     QImage getFieldLineTraceImage(TbcSource::ScanLineData scanLineData, qint32 pictureDot);
+    void mouseLevelSelect(qint32 oY);
     void mousePictureDotSelect(qint32 oX);
 };
 

--- a/tools/ld-analyse/tbcsource.cpp
+++ b/tools/ld-analyse/tbcsource.cpp
@@ -49,11 +49,11 @@ void TbcSource::loadSource(QString sourceFilename)
     // Set the current file name
     QFileInfo inFileInfo(sourceFilename);
     currentSourceFilename = inFileInfo.fileName();
-    qDebug() << "TbcSource::startBackgroundLoad(): Opening TBC source file:" << currentSourceFilename;
+    qDebug() << "TbcSource::loadSource(): Opening TBC source file:" << currentSourceFilename;
 
     // Set up and fire-off background loading thread
     qDebug() << "TbcSource::loadSource(): Setting up background loader thread";
-    connect(&watcher, SIGNAL(finished()), this, SLOT(finishBackgroundLoad()));
+    connect(&watcher, &QFutureWatcher<void>::finished, this, &TbcSource::finishBackgroundLoad);
 #if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
     future = QtConcurrent::run(this, &TbcSource::startBackgroundLoad, sourceFilename);
 #else

--- a/tools/ld-analyse/tbcsource.h
+++ b/tools/ld-analyse/tbcsource.h
@@ -167,7 +167,7 @@ private:
 
     // Background loader globals
     QFutureWatcher<void> watcher;
-    QFuture <void> future;
+    QFuture<void> future;
 
     // Metadata for the loaded frame
     qint32 firstFieldNumber, secondFieldNumber;

--- a/tools/ld-analyse/tbcsource.h
+++ b/tools/ld-analyse/tbcsource.h
@@ -69,6 +69,7 @@ public:
     void loadSource(QString inputFileName);
     void unloadSource();
     bool getIsSourceLoaded();
+    void saveSourceJson();
     QString getCurrentSourceFilename();
     QString getLastIOError();
 
@@ -134,9 +135,11 @@ public:
 signals:
     void busy(QString information);
     void finishedLoading(bool success);
+    void finishedSaving(bool success);
 
 private slots:
     void finishBackgroundLoad();
+    void finishBackgroundSave();
 
 private:
     bool sourceReady;
@@ -158,6 +161,7 @@ private:
     SourceMode sourceMode;
     LdDecodeMetaData ldDecodeMetaData;
     QString currentSourceFilename;
+    QString currentJsonFilename;
     QString lastIOError;
 
     // Chroma decoder objects
@@ -207,6 +211,7 @@ private:
     QImage generateQImage();
     void generateData();
     bool startBackgroundLoad(QString sourceFilename);
+    bool startBackgroundSave(QString jsonFilename);
 };
 
 #endif // TBCSOURCE_H

--- a/tools/ld-analyse/tbcsource.h
+++ b/tools/ld-analyse/tbcsource.h
@@ -109,8 +109,11 @@ public:
     qint32 getGraphDataSize();
 
     bool getIsDropoutPresent();
-    const ComponentFrame &getComponentFrame();
+
     const LdDecodeMetaData::VideoParameters &getVideoParameters();
+    void setVideoParameters(const LdDecodeMetaData::VideoParameters &videoParameters);
+
+    const ComponentFrame &getComponentFrame();
     ScanLineData getScanLineData(qint32 scanLine);
 
     qint32 getFirstFieldNumber();
@@ -198,6 +201,7 @@ private:
 
     void resetState();
     void invalidateFrameCache();
+    void configureChromaDecoder();
     void loadInputFields();
     void decodeFrame();
     QImage generateQImage();

--- a/tools/ld-analyse/tbcsource.h
+++ b/tools/ld-analyse/tbcsource.h
@@ -70,7 +70,7 @@ public:
     void unloadSource();
     bool getIsSourceLoaded();
     QString getCurrentSourceFilename();
-    QString getLastLoadError();
+    QString getLastIOError();
 
     void setHighlightDropouts(bool _state);
     void setChromaDecoder(bool _state);
@@ -132,8 +132,8 @@ public:
     qint32 startOfChapter(qint32 currentFrameNumber);
 
 signals:
-    void busyLoading(QString information);
-    void finishedLoading();
+    void busy(QString information);
+    void finishedLoading(bool success);
 
 private slots:
     void finishBackgroundLoad();
@@ -158,7 +158,7 @@ private:
     SourceMode sourceMode;
     LdDecodeMetaData ldDecodeMetaData;
     QString currentSourceFilename;
-    QString lastLoadError;
+    QString lastIOError;
 
     // Chroma decoder objects
     PalColour palColour;
@@ -169,8 +169,8 @@ private:
     VbiDecoder vbiDecoder;
 
     // Background loader globals
-    QFutureWatcher<void> watcher;
-    QFuture<void> future;
+    QFutureWatcher<bool> watcher;
+    QFuture<bool> future;
 
     // Metadata for the loaded frame
     qint32 firstFieldNumber, secondFieldNumber;
@@ -206,7 +206,7 @@ private:
     void decodeFrame();
     QImage generateQImage();
     void generateData();
-    void startBackgroundLoad(QString sourceFilename);
+    bool startBackgroundLoad(QString sourceFilename);
 };
 
 #endif // TBCSOURCE_H

--- a/tools/ld-analyse/vbidialog.ui
+++ b/tools/ld-analyse/vbidialog.ui
@@ -25,741 +25,538 @@
   <property name="windowTitle">
    <string>Decoded VBI</string>
   </property>
-  <widget class="QLabel" name="label">
-   <property name="geometry">
-    <rect>
-     <x>10</x>
-     <y>10</y>
-     <width>141</width>
-     <height>21</height>
-    </rect>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <property name="sizeConstraint">
+    <enum>QLayout::SetFixedSize</enum>
    </property>
-   <property name="text">
-    <string>Disc type:</string>
-   </property>
-   <property name="alignment">
-    <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-   </property>
-  </widget>
-  <widget class="QLabel" name="label_2">
-   <property name="geometry">
-    <rect>
-     <x>10</x>
-     <y>110</y>
-     <width>141</width>
-     <height>21</height>
-    </rect>
-   </property>
-   <property name="text">
-    <string>Lead in:</string>
-   </property>
-   <property name="alignment">
-    <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-   </property>
-  </widget>
-  <widget class="QLabel" name="label_3">
-   <property name="geometry">
-    <rect>
-     <x>10</x>
-     <y>130</y>
-     <width>141</width>
-     <height>21</height>
-    </rect>
-   </property>
-   <property name="text">
-    <string>Lead out:</string>
-   </property>
-   <property name="alignment">
-    <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-   </property>
-  </widget>
-  <widget class="QLabel" name="label_4">
-   <property name="geometry">
-    <rect>
-     <x>10</x>
-     <y>150</y>
-     <width>141</width>
-     <height>21</height>
-    </rect>
-   </property>
-   <property name="text">
-    <string>User code:</string>
-   </property>
-   <property name="alignment">
-    <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-   </property>
-  </widget>
-  <widget class="QLabel" name="label_5">
-   <property name="geometry">
-    <rect>
-     <x>10</x>
-     <y>30</y>
-     <width>141</width>
-     <height>21</height>
-    </rect>
-   </property>
-   <property name="text">
-    <string>Picture number:</string>
-   </property>
-   <property name="alignment">
-    <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-   </property>
-  </widget>
-  <widget class="QLabel" name="label_6">
-   <property name="geometry">
-    <rect>
-     <x>10</x>
-     <y>170</y>
-     <width>141</width>
-     <height>21</height>
-    </rect>
-   </property>
-   <property name="text">
-    <string>Picture stop code:</string>
-   </property>
-   <property name="alignment">
-    <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-   </property>
-  </widget>
-  <widget class="QLabel" name="label_7">
-   <property name="geometry">
-    <rect>
-     <x>10</x>
-     <y>50</y>
-     <width>141</width>
-     <height>21</height>
-    </rect>
-   </property>
-   <property name="text">
-    <string>CLV time code:</string>
-   </property>
-   <property name="alignment">
-    <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-   </property>
-  </widget>
-  <widget class="QLabel" name="discTypeLabel">
-   <property name="geometry">
-    <rect>
-     <x>160</x>
-     <y>10</y>
-     <width>161</width>
-     <height>21</height>
-    </rect>
-   </property>
-   <property name="text">
-    <string>TextLabel</string>
-   </property>
-  </widget>
-  <widget class="QLabel" name="pictureNumberLabel">
-   <property name="geometry">
-    <rect>
-     <x>160</x>
-     <y>30</y>
-     <width>161</width>
-     <height>21</height>
-    </rect>
-   </property>
-   <property name="text">
-    <string>TextLabel</string>
-   </property>
-  </widget>
-  <widget class="QLabel" name="clvTimeCodeLabel">
-   <property name="geometry">
-    <rect>
-     <x>160</x>
-     <y>50</y>
-     <width>161</width>
-     <height>21</height>
-    </rect>
-   </property>
-   <property name="text">
-    <string>TextLabel</string>
-   </property>
-  </widget>
-  <widget class="QLabel" name="leadInLabel">
-   <property name="geometry">
-    <rect>
-     <x>160</x>
-     <y>110</y>
-     <width>161</width>
-     <height>21</height>
-    </rect>
-   </property>
-   <property name="text">
-    <string>TextLabel</string>
-   </property>
-  </widget>
-  <widget class="QLabel" name="leadOutLabel">
-   <property name="geometry">
-    <rect>
-     <x>160</x>
-     <y>130</y>
-     <width>161</width>
-     <height>21</height>
-    </rect>
-   </property>
-   <property name="text">
-    <string>TextLabel</string>
-   </property>
-  </widget>
-  <widget class="QLabel" name="userCodeLabel">
-   <property name="geometry">
-    <rect>
-     <x>160</x>
-     <y>150</y>
-     <width>161</width>
-     <height>21</height>
-    </rect>
-   </property>
-   <property name="text">
-    <string>TextLabel</string>
-   </property>
-  </widget>
-  <widget class="QLabel" name="pictureStopCodeLabel">
-   <property name="geometry">
-    <rect>
-     <x>160</x>
-     <y>170</y>
-     <width>161</width>
-     <height>21</height>
-    </rect>
-   </property>
-   <property name="text">
-    <string>TextLabel</string>
-   </property>
-  </widget>
-  <widget class="QLabel" name="label_8">
-   <property name="geometry">
-    <rect>
-     <x>10</x>
-     <y>70</y>
-     <width>141</width>
-     <height>21</height>
-    </rect>
-   </property>
-   <property name="text">
-    <string>Chapter number:</string>
-   </property>
-   <property name="alignment">
-    <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-   </property>
-  </widget>
-  <widget class="QLabel" name="chapterNumberLabel">
-   <property name="geometry">
-    <rect>
-     <x>160</x>
-     <y>70</y>
-     <width>161</width>
-     <height>21</height>
-    </rect>
-   </property>
-   <property name="text">
-    <string>TextLabel</string>
-   </property>
-  </widget>
-  <widget class="QTabWidget" name="tabWidget">
-   <property name="geometry">
-    <rect>
-     <x>10</x>
-     <y>230</y>
-     <width>341</width>
-     <height>231</height>
-    </rect>
-   </property>
-   <property name="currentIndex">
-    <number>1</number>
-   </property>
-   <widget class="QWidget" name="tab">
-    <attribute name="title">
-     <string>Original</string>
-    </attribute>
-    <widget class="QLabel" name="parityCorrectLabel">
-     <property name="geometry">
-      <rect>
-       <x>160</x>
-       <y>170</y>
-       <width>171</width>
-       <height>21</height>
-      </rect>
-     </property>
-     <property name="text">
-      <string>TextLabel</string>
-     </property>
+   <item>
+    <widget class="QWidget" name="widget" native="true">
+     <layout class="QGridLayout" name="gridLayout">
+      <property name="leftMargin">
+       <number>0</number>
+      </property>
+      <property name="topMargin">
+       <number>0</number>
+      </property>
+      <property name="rightMargin">
+       <number>0</number>
+      </property>
+      <property name="bottomMargin">
+       <number>0</number>
+      </property>
+      <item row="5" column="1">
+       <widget class="QLabel" name="leadInLabel">
+        <property name="text">
+         <string>TextLabel</string>
+        </property>
+       </widget>
+      </item>
+      <item row="9" column="1">
+       <widget class="QLabel" name="userCodeLabel">
+        <property name="text">
+         <string>TextLabel</string>
+        </property>
+       </widget>
+      </item>
+      <item row="8" column="1">
+       <widget class="QLabel" name="leadOutLabel">
+        <property name="text">
+         <string>TextLabel</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="0">
+       <widget class="QLabel" name="label_7">
+        <property name="text">
+         <string>CLV time code:</string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="0">
+       <widget class="QLabel" name="label">
+        <property name="text">
+         <string>Disc type:</string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="QLabel" name="discTypeLabel">
+        <property name="text">
+         <string>TextLabel</string>
+        </property>
+       </widget>
+      </item>
+      <item row="10" column="0">
+       <widget class="QLabel" name="label_6">
+        <property name="text">
+         <string>Picture stop code:</string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="QLabel" name="pictureNumberLabel">
+        <property name="text">
+         <string>TextLabel</string>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="1">
+       <widget class="QLabel" name="chapterNumberLabel">
+        <property name="text">
+         <string>TextLabel</string>
+        </property>
+       </widget>
+      </item>
+      <item row="5" column="0">
+       <widget class="QLabel" name="label_2">
+        <property name="text">
+         <string>Lead in:</string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="label_5">
+        <property name="text">
+         <string>Picture number:</string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="0">
+       <widget class="QLabel" name="label_8">
+        <property name="text">
+         <string>Chapter number:</string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+        </property>
+       </widget>
+      </item>
+      <item row="9" column="0">
+       <widget class="QLabel" name="label_4">
+        <property name="text">
+         <string>User code:</string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+        </property>
+       </widget>
+      </item>
+      <item row="8" column="0">
+       <widget class="QLabel" name="label_3">
+        <property name="text">
+         <string>Lead out:</string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="1">
+       <widget class="QLabel" name="clvTimeCodeLabel">
+        <property name="text">
+         <string>TextLabel</string>
+        </property>
+       </widget>
+      </item>
+      <item row="10" column="1">
+       <widget class="QLabel" name="pictureStopCodeLabel">
+        <property name="text">
+         <string>TextLabel</string>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="0">
+       <spacer name="verticalSpacer">
+        <property name="orientation">
+         <enum>Qt::Vertical</enum>
+        </property>
+        <property name="sizeType">
+         <enum>QSizePolicy::Minimum</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>20</width>
+          <height>15</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+     </layout>
     </widget>
-    <widget class="QLabel" name="cxLabel">
-     <property name="geometry">
-      <rect>
-       <x>160</x>
-       <y>10</y>
-       <width>171</width>
-       <height>21</height>
-      </rect>
+   </item>
+   <item>
+    <spacer name="verticalSpacer_2">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeType">
+      <enum>QSizePolicy::Minimum</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>15</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item>
+    <widget class="QLabel" name="label_19">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="MinimumExpanding" vsizetype="Preferred">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="minimumSize">
+      <size>
+       <width>400</width>
+       <height>0</height>
+      </size>
      </property>
      <property name="text">
-      <string>TextLabel</string>
-     </property>
-    </widget>
-    <widget class="QLabel" name="programmeDumpLabel">
-     <property name="geometry">
-      <rect>
-       <x>160</x>
-       <y>90</y>
-       <width>171</width>
-       <height>21</height>
-      </rect>
-     </property>
-     <property name="text">
-      <string>TextLabel</string>
-     </property>
-    </widget>
-    <widget class="QLabel" name="discSizeLabel">
-     <property name="geometry">
-      <rect>
-       <x>160</x>
-       <y>30</y>
-       <width>171</width>
-       <height>21</height>
-      </rect>
-     </property>
-     <property name="text">
-      <string>TextLabel</string>
-     </property>
-    </widget>
-    <widget class="QLabel" name="label_15">
-     <property name="geometry">
-      <rect>
-       <x>10</x>
-       <y>110</y>
-       <width>141</width>
-       <height>21</height>
-      </rect>
-     </property>
-     <property name="text">
-      <string>FM/FM Multiplex:</string>
+      <string>Programme Status:</string>
      </property>
      <property name="alignment">
-      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+      <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
      </property>
     </widget>
-    <widget class="QLabel" name="label_13">
-     <property name="geometry">
-      <rect>
-       <x>10</x>
-       <y>70</y>
-       <width>141</width>
-       <height>21</height>
-      </rect>
+   </item>
+   <item>
+    <widget class="QTabWidget" name="tabWidget">
+     <property name="currentIndex">
+      <number>0</number>
      </property>
-     <property name="text">
-      <string>Teletext:</string>
-     </property>
-     <property name="alignment">
-      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-     </property>
+     <widget class="QWidget" name="tab">
+      <attribute name="title">
+       <string>Original</string>
+      </attribute>
+      <layout class="QGridLayout" name="gridLayout_2">
+       <item row="0" column="0">
+        <widget class="QLabel" name="label_10">
+         <property name="text">
+          <string>CX:</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+         </property>
+        </widget>
+       </item>
+       <item row="3" column="0">
+        <widget class="QLabel" name="label_13">
+         <property name="text">
+          <string>Teletext:</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+         </property>
+        </widget>
+       </item>
+       <item row="7" column="0">
+        <widget class="QLabel" name="label_17">
+         <property name="text">
+          <string>Sound mode:</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="1">
+        <widget class="QLabel" name="discSizeLabel">
+         <property name="text">
+          <string>TextLabel</string>
+         </property>
+        </widget>
+       </item>
+       <item row="5" column="0">
+        <widget class="QLabel" name="label_15">
+         <property name="text">
+          <string>FM/FM Multiplex:</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+         </property>
+        </widget>
+       </item>
+       <item row="3" column="1">
+        <widget class="QLabel" name="teletextLabel">
+         <property name="text">
+          <string>TextLabel</string>
+         </property>
+        </widget>
+       </item>
+       <item row="6" column="1">
+        <widget class="QLabel" name="digitalLabel">
+         <property name="text">
+          <string>TextLabel</string>
+         </property>
+        </widget>
+       </item>
+       <item row="2" column="0">
+        <widget class="QLabel" name="label_12">
+         <property name="text">
+          <string>Disc side:</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="1">
+        <widget class="QLabel" name="cxLabel">
+         <property name="text">
+          <string>TextLabel</string>
+         </property>
+        </widget>
+       </item>
+       <item row="7" column="1">
+        <widget class="QLabel" name="soundModeLabel">
+         <property name="text">
+          <string>TextLabel</string>
+         </property>
+        </widget>
+       </item>
+       <item row="9" column="0">
+        <widget class="QLabel" name="label_18">
+         <property name="text">
+          <string>Parity correct:</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+         </property>
+        </widget>
+       </item>
+       <item row="4" column="1">
+        <widget class="QLabel" name="programmeDumpLabel">
+         <property name="text">
+          <string>TextLabel</string>
+         </property>
+        </widget>
+       </item>
+       <item row="2" column="1">
+        <widget class="QLabel" name="discSideLabel">
+         <property name="text">
+          <string>TextLabel</string>
+         </property>
+        </widget>
+       </item>
+       <item row="5" column="1">
+        <widget class="QLabel" name="fmFmMultiplexLabel">
+         <property name="text">
+          <string>TextLabel</string>
+         </property>
+        </widget>
+       </item>
+       <item row="9" column="1">
+        <widget class="QLabel" name="parityCorrectLabel">
+         <property name="text">
+          <string>TextLabel</string>
+         </property>
+        </widget>
+       </item>
+       <item row="4" column="0">
+        <widget class="QLabel" name="label_14">
+         <property name="text">
+          <string>Programme dump:</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+         </property>
+        </widget>
+       </item>
+       <item row="6" column="0">
+        <widget class="QLabel" name="label_16">
+         <property name="text">
+          <string>Digital:</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="0">
+        <widget class="QLabel" name="label_11">
+         <property name="text">
+          <string>Disc size:</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+         </property>
+        </widget>
+       </item>
+       <item row="10" column="0">
+        <spacer name="verticalSpacer_4">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>0</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+      </layout>
+     </widget>
+     <widget class="QWidget" name="tab_2">
+      <attribute name="title">
+       <string>Amendment 2</string>
+      </attribute>
+      <layout class="QGridLayout" name="gridLayout_3">
+       <item row="0" column="0">
+        <widget class="QLabel" name="label_23">
+         <property name="text">
+          <string>CX:</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="1">
+        <widget class="QLabel" name="cxLabelAm2">
+         <property name="text">
+          <string>TextLabel</string>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="0">
+        <widget class="QLabel" name="label_26">
+         <property name="text">
+          <string>Disc size:</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="1">
+        <widget class="QLabel" name="discSizeLabelAm2">
+         <property name="text">
+          <string>TextLabel</string>
+         </property>
+        </widget>
+       </item>
+       <item row="2" column="0">
+        <widget class="QLabel" name="label_24">
+         <property name="text">
+          <string>Disc side:</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+         </property>
+        </widget>
+       </item>
+       <item row="2" column="1">
+        <widget class="QLabel" name="discSideLabelAm2">
+         <property name="text">
+          <string>TextLabel</string>
+         </property>
+        </widget>
+       </item>
+       <item row="3" column="0">
+        <widget class="QLabel" name="label_25">
+         <property name="text">
+          <string>Teletext:</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+         </property>
+        </widget>
+       </item>
+       <item row="3" column="1">
+        <widget class="QLabel" name="teletextLabelAm2">
+         <property name="text">
+          <string>TextLabel</string>
+         </property>
+        </widget>
+       </item>
+       <item row="4" column="0">
+        <widget class="QLabel" name="label_22">
+         <property name="text">
+          <string>Copy allowed:</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+         </property>
+        </widget>
+       </item>
+       <item row="4" column="1">
+        <widget class="QLabel" name="copyAllowedLabelAm2">
+         <property name="text">
+          <string>TextLabel</string>
+         </property>
+        </widget>
+       </item>
+       <item row="5" column="0">
+        <widget class="QLabel" name="label_27">
+         <property name="text">
+          <string>Standard Video:</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+         </property>
+        </widget>
+       </item>
+       <item row="5" column="1">
+        <widget class="QLabel" name="standardVideoLabelAm2">
+         <property name="text">
+          <string>TextLabel</string>
+         </property>
+        </widget>
+       </item>
+       <item row="6" column="0">
+        <widget class="QLabel" name="label_20">
+         <property name="text">
+          <string>Sound mode:</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+         </property>
+        </widget>
+       </item>
+       <item row="6" column="1">
+        <widget class="QLabel" name="soundModeLabelAm2">
+         <property name="text">
+          <string>TextLabel</string>
+         </property>
+        </widget>
+       </item>
+       <item row="7" column="0">
+        <spacer name="verticalSpacer_3">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>0</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+      </layout>
+     </widget>
     </widget>
-    <widget class="QLabel" name="label_12">
-     <property name="geometry">
-      <rect>
-       <x>10</x>
-       <y>50</y>
-       <width>141</width>
-       <height>21</height>
-      </rect>
-     </property>
-     <property name="text">
-      <string>Disc side:</string>
-     </property>
-     <property name="alignment">
-      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-     </property>
-    </widget>
-    <widget class="QLabel" name="teletextLabel">
-     <property name="geometry">
-      <rect>
-       <x>160</x>
-       <y>70</y>
-       <width>171</width>
-       <height>21</height>
-      </rect>
-     </property>
-     <property name="text">
-      <string>TextLabel</string>
-     </property>
-    </widget>
-    <widget class="QLabel" name="label_11">
-     <property name="geometry">
-      <rect>
-       <x>10</x>
-       <y>30</y>
-       <width>141</width>
-       <height>21</height>
-      </rect>
-     </property>
-     <property name="text">
-      <string>Disc size:</string>
-     </property>
-     <property name="alignment">
-      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-     </property>
-    </widget>
-    <widget class="QLabel" name="soundModeLabel">
-     <property name="geometry">
-      <rect>
-       <x>160</x>
-       <y>150</y>
-       <width>171</width>
-       <height>21</height>
-      </rect>
-     </property>
-     <property name="text">
-      <string>TextLabel</string>
-     </property>
-    </widget>
-    <widget class="QLabel" name="label_10">
-     <property name="geometry">
-      <rect>
-       <x>10</x>
-       <y>10</y>
-       <width>141</width>
-       <height>21</height>
-      </rect>
-     </property>
-     <property name="text">
-      <string>CX:</string>
-     </property>
-     <property name="alignment">
-      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-     </property>
-    </widget>
-    <widget class="QLabel" name="label_14">
-     <property name="geometry">
-      <rect>
-       <x>10</x>
-       <y>90</y>
-       <width>141</width>
-       <height>21</height>
-      </rect>
-     </property>
-     <property name="text">
-      <string>Programme dump:</string>
-     </property>
-     <property name="alignment">
-      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-     </property>
-    </widget>
-    <widget class="QLabel" name="fmFmMultiplexLabel">
-     <property name="geometry">
-      <rect>
-       <x>160</x>
-       <y>110</y>
-       <width>171</width>
-       <height>21</height>
-      </rect>
-     </property>
-     <property name="text">
-      <string>TextLabel</string>
-     </property>
-    </widget>
-    <widget class="QLabel" name="label_16">
-     <property name="geometry">
-      <rect>
-       <x>10</x>
-       <y>130</y>
-       <width>141</width>
-       <height>21</height>
-      </rect>
-     </property>
-     <property name="text">
-      <string>Digital:</string>
-     </property>
-     <property name="alignment">
-      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-     </property>
-    </widget>
-    <widget class="QLabel" name="digitalLabel">
-     <property name="geometry">
-      <rect>
-       <x>160</x>
-       <y>130</y>
-       <width>171</width>
-       <height>21</height>
-      </rect>
-     </property>
-     <property name="text">
-      <string>TextLabel</string>
-     </property>
-    </widget>
-    <widget class="QLabel" name="discSideLabel">
-     <property name="geometry">
-      <rect>
-       <x>160</x>
-       <y>50</y>
-       <width>171</width>
-       <height>21</height>
-      </rect>
-     </property>
-     <property name="text">
-      <string>TextLabel</string>
-     </property>
-    </widget>
-    <widget class="QLabel" name="label_17">
-     <property name="geometry">
-      <rect>
-       <x>10</x>
-       <y>150</y>
-       <width>141</width>
-       <height>21</height>
-      </rect>
-     </property>
-     <property name="text">
-      <string>Sound mode:</string>
-     </property>
-     <property name="alignment">
-      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-     </property>
-    </widget>
-    <widget class="QLabel" name="label_18">
-     <property name="geometry">
-      <rect>
-       <x>10</x>
-       <y>170</y>
-       <width>141</width>
-       <height>21</height>
-      </rect>
-     </property>
-     <property name="text">
-      <string>Parity correct:</string>
-     </property>
-     <property name="alignment">
-      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-     </property>
-    </widget>
-   </widget>
-   <widget class="QWidget" name="tab_2">
-    <attribute name="title">
-     <string>Amendment 2</string>
-    </attribute>
-    <widget class="QLabel" name="label_20">
-     <property name="geometry">
-      <rect>
-       <x>10</x>
-       <y>130</y>
-       <width>141</width>
-       <height>21</height>
-      </rect>
-     </property>
-     <property name="text">
-      <string>Sound mode:</string>
-     </property>
-     <property name="alignment">
-      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-     </property>
-    </widget>
-    <widget class="QLabel" name="copyAllowedLabelAm2">
-     <property name="geometry">
-      <rect>
-       <x>160</x>
-       <y>90</y>
-       <width>171</width>
-       <height>21</height>
-      </rect>
-     </property>
-     <property name="text">
-      <string>TextLabel</string>
-     </property>
-    </widget>
-    <widget class="QLabel" name="soundModeLabelAm2">
-     <property name="geometry">
-      <rect>
-       <x>160</x>
-       <y>130</y>
-       <width>171</width>
-       <height>21</height>
-      </rect>
-     </property>
-     <property name="text">
-      <string>TextLabel</string>
-     </property>
-    </widget>
-    <widget class="QLabel" name="standardVideoLabelAm2">
-     <property name="geometry">
-      <rect>
-       <x>160</x>
-       <y>110</y>
-       <width>171</width>
-       <height>21</height>
-      </rect>
-     </property>
-     <property name="text">
-      <string>TextLabel</string>
-     </property>
-    </widget>
-    <widget class="QLabel" name="cxLabelAm2">
-     <property name="geometry">
-      <rect>
-       <x>160</x>
-       <y>10</y>
-       <width>171</width>
-       <height>21</height>
-      </rect>
-     </property>
-     <property name="text">
-      <string>TextLabel</string>
-     </property>
-    </widget>
-    <widget class="QLabel" name="discSizeLabelAm2">
-     <property name="geometry">
-      <rect>
-       <x>160</x>
-       <y>30</y>
-       <width>171</width>
-       <height>21</height>
-      </rect>
-     </property>
-     <property name="text">
-      <string>TextLabel</string>
-     </property>
-    </widget>
-    <widget class="QLabel" name="label_22">
-     <property name="geometry">
-      <rect>
-       <x>10</x>
-       <y>90</y>
-       <width>141</width>
-       <height>21</height>
-      </rect>
-     </property>
-     <property name="text">
-      <string>Copy allowed:</string>
-     </property>
-     <property name="alignment">
-      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-     </property>
-    </widget>
-    <widget class="QLabel" name="label_23">
-     <property name="geometry">
-      <rect>
-       <x>10</x>
-       <y>10</y>
-       <width>141</width>
-       <height>21</height>
-      </rect>
-     </property>
-     <property name="text">
-      <string>CX:</string>
-     </property>
-     <property name="alignment">
-      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-     </property>
-    </widget>
-    <widget class="QLabel" name="discSideLabelAm2">
-     <property name="geometry">
-      <rect>
-       <x>160</x>
-       <y>50</y>
-       <width>171</width>
-       <height>21</height>
-      </rect>
-     </property>
-     <property name="text">
-      <string>TextLabel</string>
-     </property>
-    </widget>
-    <widget class="QLabel" name="label_24">
-     <property name="geometry">
-      <rect>
-       <x>10</x>
-       <y>50</y>
-       <width>141</width>
-       <height>21</height>
-      </rect>
-     </property>
-     <property name="text">
-      <string>Disc side:</string>
-     </property>
-     <property name="alignment">
-      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-     </property>
-    </widget>
-    <widget class="QLabel" name="teletextLabelAm2">
-     <property name="geometry">
-      <rect>
-       <x>160</x>
-       <y>70</y>
-       <width>171</width>
-       <height>21</height>
-      </rect>
-     </property>
-     <property name="text">
-      <string>TextLabel</string>
-     </property>
-    </widget>
-    <widget class="QLabel" name="label_25">
-     <property name="geometry">
-      <rect>
-       <x>10</x>
-       <y>70</y>
-       <width>141</width>
-       <height>21</height>
-      </rect>
-     </property>
-     <property name="text">
-      <string>Teletext:</string>
-     </property>
-     <property name="alignment">
-      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-     </property>
-    </widget>
-    <widget class="QLabel" name="label_26">
-     <property name="geometry">
-      <rect>
-       <x>10</x>
-       <y>30</y>
-       <width>141</width>
-       <height>21</height>
-      </rect>
-     </property>
-     <property name="text">
-      <string>Disc size:</string>
-     </property>
-     <property name="alignment">
-      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-     </property>
-    </widget>
-    <widget class="QLabel" name="label_27">
-     <property name="geometry">
-      <rect>
-       <x>10</x>
-       <y>110</y>
-       <width>141</width>
-       <height>21</height>
-      </rect>
-     </property>
-     <property name="text">
-      <string>Standard Video:</string>
-     </property>
-     <property name="alignment">
-      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-     </property>
-    </widget>
-   </widget>
-  </widget>
-  <widget class="QLabel" name="label_19">
-   <property name="geometry">
-    <rect>
-     <x>10</x>
-     <y>210</y>
-     <width>221</width>
-     <height>21</height>
-    </rect>
-   </property>
-   <property name="text">
-    <string>Programme Status:</string>
-   </property>
-   <property name="alignment">
-    <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
-   </property>
-  </widget>
+   </item>
+  </layout>
  </widget>
  <resources/>
  <connections/>

--- a/tools/ld-analyse/videoparametersdialog.cpp
+++ b/tools/ld-analyse/videoparametersdialog.cpp
@@ -48,6 +48,8 @@ void VideoParametersDialog::setVideoParameters(const LdDecodeMetaData::VideoPara
     // Transfer values to the dialogue
     ui->blackLevelSpinBox->setValue(videoParameters.black16bIre);
     ui->whiteLevelSpinBox->setValue(videoParameters.white16bIre);
+    if (videoParameters.isWidescreen) ui->aspectRatio169RadioButton->setChecked(true);
+    else ui->aspectRatio43RadioButton->setChecked(true);
 
     // Update the dialogue
     updateDialog();
@@ -118,4 +120,11 @@ void VideoParametersDialog::on_whiteLevelResetButton_clicked()
     } else {
         ui->whiteLevelSpinBox->setValue(0xD300);
     }
+}
+
+void VideoParametersDialog::on_aspectRatioButtonGroup_buttonClicked(QAbstractButton *button)
+{
+    videoParameters.isWidescreen = (button == ui->aspectRatio169RadioButton);
+    updateDialog();
+    emit videoParametersChanged(videoParameters);
 }

--- a/tools/ld-analyse/videoparametersdialog.cpp
+++ b/tools/ld-analyse/videoparametersdialog.cpp
@@ -1,0 +1,121 @@
+/************************************************************************
+
+    videoparametersdialog.cpp
+
+    ld-analyse - TBC output analysis
+    Copyright (C) 2022 Adam Sampson
+
+    This file is part of ld-decode-tools.
+
+    ld-analyse is free software: you can redistribute it and/or
+    modify it under the terms of the GNU General Public License as
+    published by the Free Software Foundation, either version 3 of the
+    License, or (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+************************************************************************/
+
+#include "videoparametersdialog.h"
+#include "ui_videoparametersdialog.h"
+
+VideoParametersDialog::VideoParametersDialog(QWidget *parent) :
+    QDialog(parent),
+    ui(new Ui::VideoParametersDialog)
+{
+    ui->setupUi(this);
+    setWindowFlags(Qt::Window);
+    
+    // Update the dialogue
+    updateDialog();
+}
+
+VideoParametersDialog::~VideoParametersDialog()
+{
+    delete ui;
+}
+
+void VideoParametersDialog::setVideoParameters(const LdDecodeMetaData::VideoParameters &_videoParameters)
+{
+    videoParameters = _videoParameters;
+
+    // Transfer values to the dialogue
+    ui->blackLevelSpinBox->setValue(videoParameters.black16bIre);
+    ui->whiteLevelSpinBox->setValue(videoParameters.white16bIre);
+
+    // Update the dialogue
+    updateDialog();
+}
+
+void VideoParametersDialog::updateDialog()
+{
+    // Adjust the black level reset buttons depending on whether the system is NTSC
+    if (videoParameters.system == NTSC) {
+        ui->blackLevelResetButton->setText("Reset NTSC");
+        ui->blackLevelAltResetButton->setText("Reset NTSC-J");
+        ui->blackLevelAltResetButton->show();
+    } else {
+        ui->blackLevelResetButton->setText("Reset");
+        ui->blackLevelAltResetButton->hide();
+    }
+}
+
+// Public slots
+
+// Set either black or white level, depending on which half of the range the value is in
+void VideoParametersDialog::levelSelected(qint32 level)
+{
+    if (level < 0x8000) {
+        ui->blackLevelSpinBox->setValue(level);
+    } else {
+        ui->whiteLevelSpinBox->setValue(level);
+    }
+}
+
+// Private slots
+
+void VideoParametersDialog::on_blackLevelSpinBox_valueChanged(int value)
+{
+    videoParameters.black16bIre = value;
+    updateDialog();
+    emit videoParametersChanged(videoParameters);
+}
+
+void VideoParametersDialog::on_whiteLevelSpinBox_valueChanged(int value)
+{
+    videoParameters.white16bIre = value;
+    updateDialog();
+    emit videoParametersChanged(videoParameters);
+}
+
+// The reset black and white levels come from EBU Tech 3280 p6 (PAL) and SMPTE
+// 244M p2 (NTSC), and match what ld-decode uses by default.
+
+void VideoParametersDialog::on_blackLevelResetButton_clicked()
+{
+    if (videoParameters.system == NTSC) {
+        ui->blackLevelSpinBox->setValue(0x3C00 + 0x0A80); // including setup
+    } else {
+        ui->blackLevelSpinBox->setValue(0x4000);
+    }
+}
+
+void VideoParametersDialog::on_blackLevelAltResetButton_clicked()
+{
+    ui->blackLevelSpinBox->setValue(0x3C00);
+}
+
+void VideoParametersDialog::on_whiteLevelResetButton_clicked()
+{
+    if (videoParameters.system == NTSC) {
+        ui->whiteLevelSpinBox->setValue(0xC800);
+    } else {
+        ui->whiteLevelSpinBox->setValue(0xD300);
+    }
+}

--- a/tools/ld-analyse/videoparametersdialog.h
+++ b/tools/ld-analyse/videoparametersdialog.h
@@ -58,6 +58,8 @@ private slots:
     void on_blackLevelAltResetButton_clicked();
     void on_whiteLevelResetButton_clicked();
 
+    void on_aspectRatioButtonGroup_buttonClicked(QAbstractButton *button);
+
 private:
     Ui::VideoParametersDialog *ui;
     LdDecodeMetaData::VideoParameters videoParameters;

--- a/tools/ld-analyse/videoparametersdialog.h
+++ b/tools/ld-analyse/videoparametersdialog.h
@@ -1,0 +1,68 @@
+/************************************************************************
+
+    videoparametersdialog.h
+
+    ld-analyse - TBC output analysis
+    Copyright (C) 2022 Adam Sampson
+
+    This file is part of ld-decode-tools.
+
+    ld-analyse is free software: you can redistribute it and/or
+    modify it under the terms of the GNU General Public License as
+    published by the Free Software Foundation, either version 3 of the
+    License, or (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+************************************************************************/
+
+#ifndef VIDEOPARAMETERSDIALOG_H
+#define VIDEOPARAMETERSDIALOG_H
+
+#include <QAbstractButton>
+#include <QDialog>
+
+#include "lddecodemetadata.h"
+
+namespace Ui {
+class VideoParametersDialog;
+}
+
+class VideoParametersDialog : public QDialog
+{
+    Q_OBJECT
+
+public:
+    explicit VideoParametersDialog(QWidget *parent = nullptr);
+    ~VideoParametersDialog();
+
+    void setVideoParameters(const LdDecodeMetaData::VideoParameters &videoParameters);
+
+signals:
+    void videoParametersChanged(const LdDecodeMetaData::VideoParameters &videoParameters);
+
+public slots:
+    void levelSelected(qint32 level);
+
+private slots:
+    void on_blackLevelSpinBox_valueChanged(int value);
+    void on_whiteLevelSpinBox_valueChanged(int value);
+
+    void on_blackLevelResetButton_clicked();
+    void on_blackLevelAltResetButton_clicked();
+    void on_whiteLevelResetButton_clicked();
+
+private:
+    Ui::VideoParametersDialog *ui;
+    LdDecodeMetaData::VideoParameters videoParameters;
+
+    void updateDialog();
+};
+
+#endif // VIDEOPARAMETERSDIALOG_H

--- a/tools/ld-analyse/videoparametersdialog.ui
+++ b/tools/ld-analyse/videoparametersdialog.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>500</width>
-    <height>90</height>
+    <width>452</width>
+    <height>177</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -20,50 +20,6 @@
    <property name="horizontalSpacing">
     <number>12</number>
    </property>
-   <item row="2" column="0">
-    <spacer name="verticalSpacer_1">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>20</width>
-       <height>0</height>
-      </size>
-     </property>
-    </spacer>
-   </item>
-   <item row="0" column="1">
-    <widget class="QSpinBox" name="blackLevelSpinBox">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="minimumSize">
-      <size>
-       <width>70</width>
-       <height>30</height>
-      </size>
-     </property>
-     <property name="prefix">
-      <string>0x</string>
-     </property>
-     <property name="maximum">
-      <number>32767</number>
-     </property>
-     <property name="singleStep">
-      <number>256</number>
-     </property>
-     <property name="value">
-      <number>16384</number>
-     </property>
-     <property name="displayIntegerBase">
-      <number>16</number>
-     </property>
-    </widget>
-   </item>
    <item row="0" column="2">
     <widget class="QPushButton" name="blackLevelResetButton">
      <property name="minimumSize">
@@ -77,26 +33,13 @@
      </property>
     </widget>
    </item>
-   <item row="1" column="0">
-    <widget class="QLabel" name="whiteLevelLabel">
+   <item row="0" column="0">
+    <widget class="QLabel" name="blackLevelLabel">
      <property name="text">
-      <string>White level:</string>
+      <string>Black level:</string>
      </property>
      <property name="alignment">
       <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-     </property>
-    </widget>
-   </item>
-   <item row="1" column="2">
-    <widget class="QPushButton" name="whiteLevelResetButton">
-     <property name="minimumSize">
-      <size>
-       <width>100</width>
-       <height>0</height>
-      </size>
-     </property>
-     <property name="text">
-      <string>Reset</string>
      </property>
     </widget>
    </item>
@@ -134,13 +77,57 @@
      </property>
     </widget>
    </item>
-   <item row="0" column="0">
-    <widget class="QLabel" name="blackLevelLabel">
+   <item row="3" column="0">
+    <widget class="QLabel" name="aspectRatioLabel">
      <property name="text">
-      <string>Black level:</string>
+      <string>Display aspect ratio:</string>
      </property>
      <property name="alignment">
-      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+      <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="1">
+    <widget class="QSpinBox" name="blackLevelSpinBox">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="minimumSize">
+      <size>
+       <width>70</width>
+       <height>30</height>
+      </size>
+     </property>
+     <property name="prefix">
+      <string>0x</string>
+     </property>
+     <property name="maximum">
+      <number>32767</number>
+     </property>
+     <property name="singleStep">
+      <number>256</number>
+     </property>
+     <property name="value">
+      <number>16384</number>
+     </property>
+     <property name="displayIntegerBase">
+      <number>16</number>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="2">
+    <widget class="QPushButton" name="whiteLevelResetButton">
+     <property name="minimumSize">
+      <size>
+       <width>100</width>
+       <height>0</height>
+      </size>
+     </property>
+     <property name="text">
+      <string>Reset</string>
      </property>
     </widget>
    </item>
@@ -157,8 +144,91 @@
      </property>
     </widget>
    </item>
+   <item row="1" column="0">
+    <widget class="QLabel" name="whiteLevelLabel">
+     <property name="text">
+      <string>White level:</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="0">
+    <spacer name="verticalSpacer_1">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeType">
+      <enum>QSizePolicy::MinimumExpanding</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>15</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item row="3" column="1" colspan="3">
+    <widget class="QWidget" name="aspectRatioWidget" native="true">
+     <layout class="QHBoxLayout" name="horizontalLayout">
+      <property name="leftMargin">
+       <number>0</number>
+      </property>
+      <property name="topMargin">
+       <number>0</number>
+      </property>
+      <property name="rightMargin">
+       <number>0</number>
+      </property>
+      <property name="bottomMargin">
+       <number>0</number>
+      </property>
+      <item>
+       <widget class="QRadioButton" name="aspectRatio43RadioButton">
+        <property name="text">
+         <string>4:3</string>
+        </property>
+        <property name="checked">
+         <bool>true</bool>
+        </property>
+        <attribute name="buttonGroup">
+         <string notr="true">aspectRatioButtonGroup</string>
+        </attribute>
+       </widget>
+      </item>
+      <item>
+       <widget class="QRadioButton" name="aspectRatio169RadioButton">
+        <property name="text">
+         <string>16:9</string>
+        </property>
+        <attribute name="buttonGroup">
+         <string notr="true">aspectRatioButtonGroup</string>
+        </attribute>
+       </widget>
+      </item>
+      <item>
+       <spacer name="horizontalSpacer">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>0</width>
+          <height>0</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+     </layout>
+    </widget>
+   </item>
   </layout>
  </widget>
  <resources/>
  <connections/>
+ <buttongroups>
+  <buttongroup name="aspectRatioButtonGroup"/>
+ </buttongroups>
 </ui>

--- a/tools/ld-analyse/videoparametersdialog.ui
+++ b/tools/ld-analyse/videoparametersdialog.ui
@@ -1,0 +1,164 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>VideoParametersDialog</class>
+ <widget class="QDialog" name="VideoParametersDialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>500</width>
+    <height>90</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Video Parameters</string>
+  </property>
+  <layout class="QGridLayout" name="gridLayout">
+   <property name="sizeConstraint">
+    <enum>QLayout::SetFixedSize</enum>
+   </property>
+   <property name="horizontalSpacing">
+    <number>12</number>
+   </property>
+   <item row="2" column="0">
+    <spacer name="verticalSpacer_1">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>0</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item row="0" column="1">
+    <widget class="QSpinBox" name="blackLevelSpinBox">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="minimumSize">
+      <size>
+       <width>70</width>
+       <height>30</height>
+      </size>
+     </property>
+     <property name="prefix">
+      <string>0x</string>
+     </property>
+     <property name="maximum">
+      <number>32767</number>
+     </property>
+     <property name="singleStep">
+      <number>256</number>
+     </property>
+     <property name="value">
+      <number>16384</number>
+     </property>
+     <property name="displayIntegerBase">
+      <number>16</number>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="2">
+    <widget class="QPushButton" name="blackLevelResetButton">
+     <property name="minimumSize">
+      <size>
+       <width>100</width>
+       <height>0</height>
+      </size>
+     </property>
+     <property name="text">
+      <string>Reset NTSC</string>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="0">
+    <widget class="QLabel" name="whiteLevelLabel">
+     <property name="text">
+      <string>White level:</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="2">
+    <widget class="QPushButton" name="whiteLevelResetButton">
+     <property name="minimumSize">
+      <size>
+       <width>100</width>
+       <height>0</height>
+      </size>
+     </property>
+     <property name="text">
+      <string>Reset</string>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="1">
+    <widget class="QSpinBox" name="whiteLevelSpinBox">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="minimumSize">
+      <size>
+       <width>70</width>
+       <height>30</height>
+      </size>
+     </property>
+     <property name="prefix">
+      <string>0x</string>
+     </property>
+     <property name="minimum">
+      <number>32768</number>
+     </property>
+     <property name="maximum">
+      <number>65535</number>
+     </property>
+     <property name="singleStep">
+      <number>256</number>
+     </property>
+     <property name="value">
+      <number>54016</number>
+     </property>
+     <property name="displayIntegerBase">
+      <number>16</number>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="0">
+    <widget class="QLabel" name="blackLevelLabel">
+     <property name="text">
+      <string>Black level:</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="3">
+    <widget class="QPushButton" name="blackLevelAltResetButton">
+     <property name="minimumSize">
+      <size>
+       <width>100</width>
+       <height>0</height>
+      </size>
+     </property>
+     <property name="text">
+      <string>Reset NTSC-J</string>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/tools/ld-analyse/visibledropoutanalysisdialog.cpp
+++ b/tools/ld-analyse/visibledropoutanalysisdialog.cpp
@@ -52,7 +52,7 @@ VisibleDropOutAnalysisDialog::VisibleDropOutAnalysisDialog(QWidget *parent) :
     numberOfFrames = 0;
 
     // Connect to scale changed slot
-    connect(((QObject*)plot->axisWidget(QwtPlot::xBottom)) , SIGNAL(scaleDivChanged() ), this, SLOT(scaleDivChangedSlot() ));
+    connect(plot->axisWidget(QwtPlot::xBottom), &QwtScaleWidget::scaleDivChanged, this, &VisibleDropOutAnalysisDialog::scaleDivChangedSlot);
 }
 
 VisibleDropOutAnalysisDialog::~VisibleDropOutAnalysisDialog()

--- a/tools/ld-analyse/whitesnranalysisdialog.cpp
+++ b/tools/ld-analyse/whitesnranalysisdialog.cpp
@@ -54,7 +54,7 @@ WhiteSnrAnalysisDialog::WhiteSnrAnalysisDialog(QWidget *parent) :
     numberOfFrames = 0;
 
     // Connect to scale changed slot
-    connect(((QObject*)plot->axisWidget(QwtPlot::xBottom)) , SIGNAL(scaleDivChanged () ), this, SLOT(scaleDivChangedSlot () ));
+    connect(plot->axisWidget(QwtPlot::xBottom), &QwtScaleWidget::scaleDivChanged, this, &WhiteSnrAnalysisDialog::scaleDivChangedSlot);
 }
 
 WhiteSnrAnalysisDialog::~WhiteSnrAnalysisDialog()


### PR DESCRIPTION
This lets you edit the black/white levels and aspect ratio in ld-analyse, then save them back to the JSON file. You can also set the black/white levels by shift-clicking on the oscilloscope. For NTSC sources, there are buttons to set the black level for both NTSC and NTSC-J (see #744). The aspect ratio button now just toggles SAR/DAR.

![videoparams-ntsc](https://user-images.githubusercontent.com/436317/173170380-fb0b0304-04f0-48e5-ba73-6df43d9c3226.png)
![videoparams-pal](https://user-images.githubusercontent.com/436317/173170383-6b41d836-f6a1-4f6f-9f3b-c4561cbfaef6.png)

When saving, I've made it rename the existing .json to .json.bup if it doesn't already exist, as ld-process-vbi does. I think I've done this in a way that'll work on non-Unixy filesystems.

There's a fair amount of GUI refactoring in here to support this, so apologies if I've broken anything else in the process... It'll need some updates to the manual, but I haven't (non-trivially) changed the appearance of anything that already existed so it should only need a screenshot of the new dialogue.