### PR TITLE
Workaround for weird linker issue with connect/qtw on windows

### DIFF
--- a/tools/ld-analyse/blacksnranalysisdialog.cpp
+++ b/tools/ld-analyse/blacksnranalysisdialog.cpp
@@ -54,7 +54,10 @@ BlackSnrAnalysisDialog::BlackSnrAnalysisDialog(QWidget *parent) :
     numberOfFrames = 0;
 
     // Connect to scale changed slot
-    connect(plot->axisWidget(QwtPlot::xBottom), &QwtScaleWidget::scaleDivChanged, this, &BlackSnrAnalysisDialog::scaleDivChangedSlot);
+    connect(
+        plot->axisWidget(QwtPlot::xBottom), SIGNAL( scaleDivChanged() ),
+        this, SLOT( scaleDivChangedSlot() )
+    );
 }
 
 BlackSnrAnalysisDialog::~BlackSnrAnalysisDialog()

--- a/tools/ld-analyse/blacksnranalysisdialog.cpp
+++ b/tools/ld-analyse/blacksnranalysisdialog.cpp
@@ -54,10 +54,15 @@ BlackSnrAnalysisDialog::BlackSnrAnalysisDialog(QWidget *parent) :
     numberOfFrames = 0;
 
     // Connect to scale changed slot
+#ifdef Q_OS_WIN32
+    // Workaround for linker issue with Qwt on windows
     connect(
         plot->axisWidget(QwtPlot::xBottom), SIGNAL( scaleDivChanged() ),
         this, SLOT( scaleDivChangedSlot() )
     );
+#else
+    connect(plot->axisWidget(QwtPlot::xBottom), &QwtScaleWidget::scaleDivChanged, this, &BlackSnrAnalysisDialog::scaleDivChangedSlot);
+#endif
 }
 
 BlackSnrAnalysisDialog::~BlackSnrAnalysisDialog()

--- a/tools/ld-analyse/dropoutanalysisdialog.cpp
+++ b/tools/ld-analyse/dropoutanalysisdialog.cpp
@@ -52,10 +52,15 @@ DropoutAnalysisDialog::DropoutAnalysisDialog(QWidget *parent) :
     numberOfFrames = 0;
 
     // Connect to scale changed slot
+#ifdef Q_OS_WIN32
+    // Workaround for linker issue with Qwt on windows
     connect(
         plot->axisWidget(QwtPlot::xBottom), SIGNAL( scaleDivChanged() ),
         this, SLOT( scaleDivChangedSlot() )
     );
+#else
+    connect(plot->axisWidget(QwtPlot::xBottom), &QwtScaleWidget::scaleDivChanged, this, &DropoutAnalysisDialog::scaleDivChangedSlot);
+#endif
 }
 
 DropoutAnalysisDialog::~DropoutAnalysisDialog()

--- a/tools/ld-analyse/dropoutanalysisdialog.cpp
+++ b/tools/ld-analyse/dropoutanalysisdialog.cpp
@@ -52,7 +52,10 @@ DropoutAnalysisDialog::DropoutAnalysisDialog(QWidget *parent) :
     numberOfFrames = 0;
 
     // Connect to scale changed slot
-    connect(plot->axisWidget(QwtPlot::xBottom), &QwtScaleWidget::scaleDivChanged, this, &DropoutAnalysisDialog::scaleDivChangedSlot);
+    connect(
+        plot->axisWidget(QwtPlot::xBottom), SIGNAL( scaleDivChanged() ),
+        this, SLOT( scaleDivChangedSlot() )
+    );
 }
 
 DropoutAnalysisDialog::~DropoutAnalysisDialog()

--- a/tools/ld-analyse/ld-analyse.pro
+++ b/tools/ld-analyse/ld-analyse.pro
@@ -160,7 +160,7 @@ unix:!macx {
 win32: {
     LIBS += qwt.lib
 }
-win32:INCLUDEPATH += "D:\prog\vcpkg\installed\x64-windows\include\qwt"
+
 macx {
 INCLUDEPATH += "/usr/local/lib/qwt.framework/Versions/6/Headers"
 LIBS += -F"/usr/local/lib" -framework qwt

--- a/tools/ld-analyse/ld-analyse.pro
+++ b/tools/ld-analyse/ld-analyse.pro
@@ -16,13 +16,14 @@ TEMPLATE = app
 # depend on your compiler). Please consult the documentation of the
 # deprecated API in order to know how to port your code away from it.
 DEFINES += QT_DEPRECATED_WARNINGS
+win32:DEFINES += _USE_MATH_DEFINES
 
 # You can also make your code fail to compile if you use deprecated APIs.
 # In order to do so, uncomment the following line.
 # You can also select to disable deprecated APIs only up to a certain version of Qt.
 #DEFINES += QT_DISABLE_DEPRECATED_BEFORE=0x060000    # disables all the APIs deprecated before Qt 6.0.0
 
-CONFIG += c++11
+CONFIG += c++17
 
 SOURCES += \
     blacksnranalysisdialog.cpp \
@@ -159,6 +160,7 @@ unix:!macx {
 win32: {
     LIBS += qwt.lib
 }
+win32:INCLUDEPATH += "D:\prog\vcpkg\installed\x64-windows\include\qwt"
 macx {
 INCLUDEPATH += "/usr/local/lib/qwt.framework/Versions/6/Headers"
 LIBS += -F"/usr/local/lib" -framework qwt

--- a/tools/ld-analyse/visibledropoutanalysisdialog.cpp
+++ b/tools/ld-analyse/visibledropoutanalysisdialog.cpp
@@ -52,7 +52,10 @@ VisibleDropOutAnalysisDialog::VisibleDropOutAnalysisDialog(QWidget *parent) :
     numberOfFrames = 0;
 
     // Connect to scale changed slot
-    connect(plot->axisWidget(QwtPlot::xBottom), &QwtScaleWidget::scaleDivChanged, this, &VisibleDropOutAnalysisDialog::scaleDivChangedSlot);
+    connect(
+        plot->axisWidget(QwtPlot::xBottom), SIGNAL( scaleDivChanged() ),
+        this, SLOT( scaleDivChangedSlot() )
+    );
 }
 
 VisibleDropOutAnalysisDialog::~VisibleDropOutAnalysisDialog()

--- a/tools/ld-analyse/visibledropoutanalysisdialog.cpp
+++ b/tools/ld-analyse/visibledropoutanalysisdialog.cpp
@@ -52,10 +52,15 @@ VisibleDropOutAnalysisDialog::VisibleDropOutAnalysisDialog(QWidget *parent) :
     numberOfFrames = 0;
 
     // Connect to scale changed slot
+#ifdef Q_OS_WIN32
+    // Workaround for linker issue with Qwt on windows
     connect(
         plot->axisWidget(QwtPlot::xBottom), SIGNAL( scaleDivChanged() ),
         this, SLOT( scaleDivChangedSlot() )
     );
+#else
+    connect(plot->axisWidget(QwtPlot::xBottom), &QwtScaleWidget::scaleDivChanged, this, &VisibleDropOutAnalysisDialog::scaleDivChangedSlot);
+#endif
 }
 
 VisibleDropOutAnalysisDialog::~VisibleDropOutAnalysisDialog()

--- a/tools/ld-analyse/whitesnranalysisdialog.cpp
+++ b/tools/ld-analyse/whitesnranalysisdialog.cpp
@@ -54,7 +54,11 @@ WhiteSnrAnalysisDialog::WhiteSnrAnalysisDialog(QWidget *parent) :
     numberOfFrames = 0;
 
     // Connect to scale changed slot
-    connect(plot->axisWidget(QwtPlot::xBottom), &QwtScaleWidget::scaleDivChanged, this, &WhiteSnrAnalysisDialog::scaleDivChangedSlot);
+    // connect(plot->axisWidget(QwtPlot::xBottom), &QwtScaleWidget::scaleDivChanged, this, &WhiteSnrAnalysisDialog::scaleDivChangedSlot);
+    connect(
+        plot->axisWidget(QwtPlot::xBottom), SIGNAL( scaleDivChanged() ),
+        this, SLOT( scaleDivChangedSlot() )
+    );
 }
 
 WhiteSnrAnalysisDialog::~WhiteSnrAnalysisDialog()

--- a/tools/ld-analyse/whitesnranalysisdialog.cpp
+++ b/tools/ld-analyse/whitesnranalysisdialog.cpp
@@ -54,11 +54,15 @@ WhiteSnrAnalysisDialog::WhiteSnrAnalysisDialog(QWidget *parent) :
     numberOfFrames = 0;
 
     // Connect to scale changed slot
-    // connect(plot->axisWidget(QwtPlot::xBottom), &QwtScaleWidget::scaleDivChanged, this, &WhiteSnrAnalysisDialog::scaleDivChangedSlot);
+#ifdef Q_OS_WIN32
+    // Workaround for linker issue with Qwt on windows
     connect(
         plot->axisWidget(QwtPlot::xBottom), SIGNAL( scaleDivChanged() ),
         this, SLOT( scaleDivChangedSlot() )
     );
+#else
+    connect(plot->axisWidget(QwtPlot::xBottom), &QwtScaleWidget::scaleDivChanged, this, &WhiteSnrAnalysisDialog::scaleDivChangedSlot);
+#endif
 }
 
 WhiteSnrAnalysisDialog::~WhiteSnrAnalysisDialog()

--- a/tools/ld-chroma-decoder/ld-chroma-decoder.pro
+++ b/tools/ld-chroma-decoder/ld-chroma-decoder.pro
@@ -1,6 +1,6 @@
 QT -= gui
 
-CONFIG += c++11 console
+CONFIG += c++17 console
 CONFIG -= app_bundle
 
 # The following define makes your compiler emit warnings if you use

--- a/tools/ld-dropout-correct/ld-dropout-correct.pro
+++ b/tools/ld-dropout-correct/ld-dropout-correct.pro
@@ -1,6 +1,6 @@
 QT -= gui
 
-CONFIG += c++11 console
+CONFIG += c++17 console
 CONFIG -= app_bundle
 
 # The following define makes your compiler emit warnings if you use


### PR DESCRIPTION
Using connect with scaleDivChanged gives a weird linker error on windows for some reason. I could not figure out why, but using the old-style connect that operates on ```const char*``` works fine.

Add math define to make M_PI available on windows (M_PI is not-standard but a common extension, there is no built-in pi constant in std c++ headers before c++20)

also bump pro files to c++17. C++11 is ancient, c++17 is the default on the system we support I believe.