### PR TITLE
Windows and C++17 fixes

### DIFF
--- a/tools/ld-analyse/blacksnranalysisdialog.cpp
+++ b/tools/ld-analyse/blacksnranalysisdialog.cpp
@@ -54,7 +54,15 @@ BlackSnrAnalysisDialog::BlackSnrAnalysisDialog(QWidget *parent) :
     numberOfFrames = 0;
 
     // Connect to scale changed slot
+#ifdef Q_OS_WIN32
+    // Workaround for linker issue with Qwt on windows
+    connect(
+        plot->axisWidget(QwtPlot::xBottom), SIGNAL( scaleDivChanged() ),
+        this, SLOT( scaleDivChangedSlot() )
+    );
+#else
     connect(plot->axisWidget(QwtPlot::xBottom), &QwtScaleWidget::scaleDivChanged, this, &BlackSnrAnalysisDialog::scaleDivChangedSlot);
+#endif
 }
 
 BlackSnrAnalysisDialog::~BlackSnrAnalysisDialog()

--- a/tools/ld-analyse/dropoutanalysisdialog.cpp
+++ b/tools/ld-analyse/dropoutanalysisdialog.cpp
@@ -52,7 +52,15 @@ DropoutAnalysisDialog::DropoutAnalysisDialog(QWidget *parent) :
     numberOfFrames = 0;
 
     // Connect to scale changed slot
+#ifdef Q_OS_WIN32
+    // Workaround for linker issue with Qwt on windows
+    connect(
+        plot->axisWidget(QwtPlot::xBottom), SIGNAL( scaleDivChanged() ),
+        this, SLOT( scaleDivChangedSlot() )
+    );
+#else
     connect(plot->axisWidget(QwtPlot::xBottom), &QwtScaleWidget::scaleDivChanged, this, &DropoutAnalysisDialog::scaleDivChangedSlot);
+#endif
 }
 
 DropoutAnalysisDialog::~DropoutAnalysisDialog()

--- a/tools/ld-analyse/ld-analyse.pro
+++ b/tools/ld-analyse/ld-analyse.pro
@@ -23,7 +23,7 @@ win32:DEFINES += _USE_MATH_DEFINES
 # You can also select to disable deprecated APIs only up to a certain version of Qt.
 #DEFINES += QT_DISABLE_DEPRECATED_BEFORE=0x060000    # disables all the APIs deprecated before Qt 6.0.0
 
-CONFIG += c++11
+CONFIG += c++17
 
 SOURCES += \
     blacksnranalysisdialog.cpp \

--- a/tools/ld-analyse/ld-analyse.pro
+++ b/tools/ld-analyse/ld-analyse.pro
@@ -16,6 +16,7 @@ TEMPLATE = app
 # depend on your compiler). Please consult the documentation of the
 # deprecated API in order to know how to port your code away from it.
 DEFINES += QT_DEPRECATED_WARNINGS
+win32:DEFINES += _USE_MATH_DEFINES
 
 # You can also make your code fail to compile if you use deprecated APIs.
 # In order to do so, uncomment the following line.

--- a/tools/ld-analyse/visibledropoutanalysisdialog.cpp
+++ b/tools/ld-analyse/visibledropoutanalysisdialog.cpp
@@ -52,7 +52,15 @@ VisibleDropOutAnalysisDialog::VisibleDropOutAnalysisDialog(QWidget *parent) :
     numberOfFrames = 0;
 
     // Connect to scale changed slot
+#ifdef Q_OS_WIN32
+    // Workaround for linker issue with Qwt on windows
+    connect(
+        plot->axisWidget(QwtPlot::xBottom), SIGNAL( scaleDivChanged() ),
+        this, SLOT( scaleDivChangedSlot() )
+    );
+#else
     connect(plot->axisWidget(QwtPlot::xBottom), &QwtScaleWidget::scaleDivChanged, this, &VisibleDropOutAnalysisDialog::scaleDivChangedSlot);
+#endif
 }
 
 VisibleDropOutAnalysisDialog::~VisibleDropOutAnalysisDialog()

--- a/tools/ld-analyse/whitesnranalysisdialog.cpp
+++ b/tools/ld-analyse/whitesnranalysisdialog.cpp
@@ -54,7 +54,15 @@ WhiteSnrAnalysisDialog::WhiteSnrAnalysisDialog(QWidget *parent) :
     numberOfFrames = 0;
 
     // Connect to scale changed slot
+#ifdef Q_OS_WIN32
+    // Workaround for linker issue with Qwt on windows
+    connect(
+        plot->axisWidget(QwtPlot::xBottom), SIGNAL( scaleDivChanged() ),
+        this, SLOT( scaleDivChangedSlot() )
+    );
+#else
     connect(plot->axisWidget(QwtPlot::xBottom), &QwtScaleWidget::scaleDivChanged, this, &WhiteSnrAnalysisDialog::scaleDivChangedSlot);
+#endif
 }
 
 WhiteSnrAnalysisDialog::~WhiteSnrAnalysisDialog()

--- a/tools/ld-chroma-decoder/comb.cpp
+++ b/tools/ld-chroma-decoder/comb.cpp
@@ -139,10 +139,9 @@ void Comb::decodeFrames(const QVector<SourceField> &inputFields, qint32 startInd
     // Buffers for the next, current and previous frame.
     // Because we only need three of these, we allocate them upfront then
     // rotate the pointers below.
-    std::unique_ptr<FrameBuffer> nextFrameBuffer, currentFrameBuffer, previousFrameBuffer;
-    nextFrameBuffer.reset(new FrameBuffer(videoParameters, configuration));
-    currentFrameBuffer.reset(new FrameBuffer(videoParameters, configuration));
-    previousFrameBuffer.reset(new FrameBuffer(videoParameters, configuration));
+    auto nextFrameBuffer = std::make_unique<FrameBuffer>(videoParameters, configuration);
+    auto currentFrameBuffer = std::make_unique<FrameBuffer>(videoParameters, configuration);
+    auto previousFrameBuffer = std::make_unique<FrameBuffer>(videoParameters, configuration);
 
     // Decode each pair of fields into a frame.
     // To support 3D operation, where we need to see three input frames at a time,

--- a/tools/ld-chroma-decoder/comb.cpp
+++ b/tools/ld-chroma-decoder/comb.cpp
@@ -35,11 +35,6 @@
 #include <memory>
 #include <utility>
 
-// Definitions of static constexpr data members, for compatibility with
-// pre-C++17 compilers
-constexpr qint32 Comb::MAX_WIDTH;
-constexpr qint32 Comb::MAX_HEIGHT;
-
 // Indexes for the candidates considered in 3D adaptive mode
 enum CandidateIndex : qint32 {
     CAND_LEFT,

--- a/tools/ld-chroma-decoder/decoderpool.cpp
+++ b/tools/ld-chroma-decoder/decoderpool.cpp
@@ -26,10 +26,6 @@
 
 #include "decoderpool.h"
 
-// Definitions of static constexpr data members, for compatibility with
-// pre-C++17 compilers
-constexpr qint32 DecoderPool::DEFAULT_BATCH_SIZE;
-
 DecoderPool::DecoderPool(Decoder &_decoder, QString _inputFileName,
                          LdDecodeMetaData &_ldDecodeMetaData,
                          OutputWriter::Configuration &_outputConfig, QString _outputFileName,

--- a/tools/ld-chroma-decoder/encoder/encoder.pro
+++ b/tools/ld-chroma-decoder/encoder/encoder.pro
@@ -1,6 +1,6 @@
 QT -= gui
 
-CONFIG += c++11 console
+CONFIG += c++17 console
 CONFIG -= app_bundle
 
 TARGET = ld-chroma-encoder

--- a/tools/ld-chroma-decoder/ld-chroma-decoder.pro
+++ b/tools/ld-chroma-decoder/ld-chroma-decoder.pro
@@ -1,6 +1,6 @@
 QT -= gui
 
-CONFIG += c++11 console
+CONFIG += c++17 console
 CONFIG -= app_bundle
 
 # The following define makes your compiler emit warnings if you use

--- a/tools/ld-chroma-decoder/main.cpp
+++ b/tools/ld-chroma-decoder/main.cpp
@@ -492,34 +492,34 @@ int main(int argc, char *argv[])
     // Select the decoder
     std::unique_ptr<Decoder> decoder;
     if (decoderName == "pal2d") {
-        decoder.reset(new PalDecoder(palConfig));
+        decoder = std::make_unique<PalDecoder>(palConfig);
     } else if (decoderName == "transform2d") {
         palConfig.chromaFilter = PalColour::transform2DFilter;
         if (!loadTransformThresholds(parser, transformThresholdsOption, palConfig)) {
             return -1;
         }
-        decoder.reset(new PalDecoder(palConfig));
+        decoder = std::make_unique<PalDecoder>(palConfig);
     } else if (decoderName == "transform3d") {
         palConfig.chromaFilter = PalColour::transform3DFilter;
         if (!loadTransformThresholds(parser, transformThresholdsOption, palConfig)) {
             return -1;
         }
-        decoder.reset(new PalDecoder(palConfig));
+        decoder = std::make_unique<PalDecoder>(palConfig);
     } else if (decoderName == "ntsc1d") {
         combConfig.dimensions = 1;
-        decoder.reset(new NtscDecoder(combConfig));
+        decoder = std::make_unique<NtscDecoder>(combConfig);
     } else if (decoderName == "ntsc2d") {
         combConfig.dimensions = 2;
-        decoder.reset(new NtscDecoder(combConfig));
+        decoder = std::make_unique<NtscDecoder>(combConfig);
     } else if (decoderName == "ntsc3d") {
         combConfig.dimensions = 3;
-        decoder.reset(new NtscDecoder(combConfig));
+        decoder = std::make_unique<NtscDecoder>(combConfig);
     } else if (decoderName == "ntsc3dnoadapt") {
         combConfig.dimensions = 3;
         combConfig.adaptive = false;
-        decoder.reset(new NtscDecoder(combConfig));
+        decoder = std::make_unique<NtscDecoder>(combConfig);
     } else if (decoderName == "mono") {
-        decoder.reset(new MonoDecoder);
+        decoder = std::make_unique<MonoDecoder>();
     } else {
         qCritical() << "Unknown decoder" << decoderName;
         return -1;

--- a/tools/ld-chroma-decoder/palcolour.cpp
+++ b/tools/ld-chroma-decoder/palcolour.cpp
@@ -66,11 +66,6 @@
     filters with more complex coefficients than the report describes.
  */
 
-// Definitions of static constexpr data members, for compatibility with
-// pre-C++17 compilers
-constexpr qint32 PalColour::MAX_WIDTH;
-constexpr qint32 PalColour::FILTER_SIZE;
-
 PalColour::PalColour()
     : configurationSet(false)
 {

--- a/tools/ld-chroma-decoder/palcolour.cpp
+++ b/tools/ld-chroma-decoder/palcolour.cpp
@@ -118,9 +118,9 @@ void PalColour::updateConfiguration(const LdDecodeMetaData::VideoParameters &_vi
     if (configuration.chromaFilter == transform2DFilter || configuration.chromaFilter == transform3DFilter) {
         // Create the Transform PAL filter
         if (configuration.chromaFilter == transform2DFilter) {
-            transformPal.reset(new TransformPal2D);
+            transformPal = std::make_unique<TransformPal2D>();
         } else {
-            transformPal.reset(new TransformPal3D);
+            transformPal = std::make_unique<TransformPal3D>();
         }
 
         // Configure the filter

--- a/tools/ld-chroma-decoder/transformpal2d.cpp
+++ b/tools/ld-chroma-decoder/transformpal2d.cpp
@@ -42,15 +42,6 @@
     site (http://www.jim-easterbrook.me.uk/pal/).
  */
 
-// Definitions of static constexpr data members, for compatibility with
-// pre-C++17 compilers
-constexpr qint32 TransformPal2D::YTILE;
-constexpr qint32 TransformPal2D::HALFYTILE;
-constexpr qint32 TransformPal2D::XTILE;
-constexpr qint32 TransformPal2D::HALFXTILE;
-constexpr qint32 TransformPal2D::YCOMPLEX;
-constexpr qint32 TransformPal2D::XCOMPLEX;
-
 // Compute one value of the window function, applied to the data blocks before
 // the FFT to reduce edge effects. This is a symmetrical raised-cosine
 // function, which means that the overlapping inverse-FFT blocks can be summed

--- a/tools/ld-chroma-decoder/transformpal3d.cpp
+++ b/tools/ld-chroma-decoder/transformpal3d.cpp
@@ -45,18 +45,6 @@
     site (http://www.jim-easterbrook.me.uk/pal/).
  */
 
-// Definitions of static constexpr data members, for compatibility with
-// pre-C++17 compilers
-constexpr qint32 TransformPal3D::ZTILE;
-constexpr qint32 TransformPal3D::HALFZTILE;
-constexpr qint32 TransformPal3D::YTILE;
-constexpr qint32 TransformPal3D::HALFYTILE;
-constexpr qint32 TransformPal3D::XTILE;
-constexpr qint32 TransformPal3D::HALFXTILE;
-constexpr qint32 TransformPal3D::ZCOMPLEX;
-constexpr qint32 TransformPal3D::YCOMPLEX;
-constexpr qint32 TransformPal3D::XCOMPLEX;
-
 // Compute one value of the window function, applied to the data blocks before
 // the FFT to reduce edge effects. This is a symmetrical raised-cosine
 // function, which means that the overlapping inverse-FFT blocks can be summed

--- a/tools/ld-disc-stacker/ld-disc-stacker.pro
+++ b/tools/ld-disc-stacker/ld-disc-stacker.pro
@@ -1,6 +1,6 @@
 QT -= gui
 
-CONFIG += c++11 console
+CONFIG += c++17 console
 CONFIG -= app_bundle
 
 # You can make your code fail to compile if it uses deprecated APIs.

--- a/tools/ld-discmap/ld-discmap.pro
+++ b/tools/ld-discmap/ld-discmap.pro
@@ -1,6 +1,6 @@
 QT -= gui
 
-CONFIG += c++11 console
+CONFIG += c++17 console
 CONFIG -= app_bundle
 
 # The following define makes your compiler emit warnings if you use

--- a/tools/ld-dropout-correct/ld-dropout-correct.pro
+++ b/tools/ld-dropout-correct/ld-dropout-correct.pro
@@ -1,6 +1,6 @@
 QT -= gui
 
-CONFIG += c++11 console
+CONFIG += c++17 console
 CONFIG -= app_bundle
 
 # The following define makes your compiler emit warnings if you use

--- a/tools/ld-export-metadata/ld-export-metadata.pro
+++ b/tools/ld-export-metadata/ld-export-metadata.pro
@@ -1,6 +1,6 @@
 QT -= gui
 
-CONFIG += c++11 console
+CONFIG += c++17 console
 CONFIG -= app_bundle
 
 # The following define makes your compiler emit warnings if you use

--- a/tools/ld-lds-converter/ld-lds-converter.pro
+++ b/tools/ld-lds-converter/ld-lds-converter.pro
@@ -1,6 +1,6 @@
 QT -= gui
 
-CONFIG += c++11 console
+CONFIG += c++17 console
 CONFIG -= app_bundle
 
 # The following define makes your compiler emit warnings if you use

--- a/tools/ld-process-efm/ld-process-efm.pro
+++ b/tools/ld-process-efm/ld-process-efm.pro
@@ -1,6 +1,6 @@
 QT -= gui
 
-CONFIG += c++11 console
+CONFIG += c++17 console
 CONFIG -= app_bundle
 
 # The following define makes your compiler emit warnings if you use

--- a/tools/ld-process-vbi/ld-process-vbi.pro
+++ b/tools/ld-process-vbi/ld-process-vbi.pro
@@ -1,6 +1,6 @@
 QT -= gui
 
-CONFIG += c++11 console
+CONFIG += c++17 console
 CONFIG -= app_bundle
 
 # The following define makes your compiler emit warnings if you use

--- a/tools/ld-process-vbi/vbilinedecoder.cpp
+++ b/tools/ld-process-vbi/vbilinedecoder.cpp
@@ -25,11 +25,6 @@
 #include "vbilinedecoder.h"
 #include "decoderpool.h"
 
-// Definitions of static constexpr data members, for compatibility with
-// pre-C++17 compilers
-constexpr qint32 VbiLineDecoder::startFieldLine;
-constexpr qint32 VbiLineDecoder::endFieldLine;
-
 VbiLineDecoder::VbiLineDecoder(QAtomicInt& _abort, DecoderPool& _decoderPool, QObject *parent)
     : QThread(parent), abort(_abort), decoderPool(_decoderPool)
 {

--- a/tools/ld-process-vits/ld-process-vits.pro
+++ b/tools/ld-process-vits/ld-process-vits.pro
@@ -1,6 +1,6 @@
 QT -= gui
 
-CONFIG += c++11 console
+CONFIG += c++17 console
 CONFIG -= app_bundle
 
 # You can make your code fail to compile if it uses deprecated APIs.

--- a/tools/library/filter/testfilter/testfilter.pro
+++ b/tools/library/filter/testfilter/testfilter.pro
@@ -1,4 +1,4 @@
-CONFIG += c++11 testcase
+CONFIG += c++17 testcase
 CONFIG -= app_bundle
 
 SOURCES += \

--- a/tools/library/tbc/testlinenumber/testlinenumber.pro
+++ b/tools/library/tbc/testlinenumber/testlinenumber.pro
@@ -1,4 +1,4 @@
-CONFIG += c++11 testcase
+CONFIG += c++17 testcase
 CONFIG -= app_bundle
 
 SOURCES += \

--- a/tools/library/tbc/testmetadata/testmetadata.pro
+++ b/tools/library/tbc/testmetadata/testmetadata.pro
@@ -1,4 +1,4 @@
-CONFIG += c++11 testcase
+CONFIG += c++17 testcase
 CONFIG -= app_bundle
 
 SOURCES += \

--- a/tools/library/tbc/testvbidecoder/testvbidecoder.pro
+++ b/tools/library/tbc/testvbidecoder/testvbidecoder.pro
@@ -1,4 +1,4 @@
-CONFIG += c++11 testcase
+CONFIG += c++17 testcase
 CONFIG -= app_bundle
 
 SOURCES += \


### PR DESCRIPTION
oyvindln's Windows build fixes from #761, and use C++17 features where we'd previously noted this in the code.

Edit: we can't use std::from_chars in the JSON parser yet because Ubuntu 20.04's GCC doesn't support it.