### PR TITLE
adding a .s8 extention to utils.py for signed 8 bit.  

### DIFF
--- a/lddecode/utils.py
+++ b/lddecode/utils.py
@@ -104,6 +104,8 @@ def make_loader(filename, inputfreq=None):
             input_args = ["-f", "u16le"]
         elif filename.endswith(".rf"):
             input_args = ["-f", "f32le"]
+        elif filename.endswith(".s8"):
+            input_args = ["-f", "s8"]
         elif filename.endswith(".r8") or filename.endswith(".u8"):
             input_args = ["-f", "u8"]
         elif filename.endswith(".u16"):


### PR DESCRIPTION
the fl2k_file (from osmo-fl2k package) uses signed 8 bit input files.  When generating files for use with osmo-fl2k, it is nice to be able to test them with cvbs-decode.  So this is mostly for use with cvbs-decode, but seems like might as well add it here for global support.

