### PR TITLE
Numba-optimize findpulses and add inputfreq argument to LDDecode

### DIFF
--- a/lddecode/core.py
+++ b/lddecode/core.py
@@ -3190,6 +3190,7 @@ class LDdecode:
         system="NTSC",
         doDOD=True,
         threads=4,
+        inputfreq=40,
         extra_options={},
     ):
         global logger
@@ -3251,6 +3252,7 @@ class LDdecode:
 
         self.system = system
         self.rf = RFDecode(
+            inputfreq=inputfreq,
             system=system,
             decode_analog_audio=analog_audio,
             decode_digital_audio=digital_audio,


### PR DESCRIPTION
  Upstream the optimized version of findpulses used in vhs-decode - the function itself is significantly faster, but it doesn't seem to make a much difference on the overall speed when I tested.
- Not using the lower threshold, not sure what it's purpose would be anyhow since if anything actually hits it it will probably mess up the computation in whichever version. 
- The min/max length args are used in vhs-decode but just set them to not have any effect here, removing the condition didn't seem to have any speed impact anyhow.
 - Benchmarking the func itself indicates it's 3-4x faster than the old one, probably still a lot of room for optimizing it more though. Ideally one would maybe re-use the array buffers between calls, use a vec-type data structure rather than list (not sure what the list in numba actually is implemented as) etc. There are other bottleneck functions that would benefit more from porting to numba/cython or other native code more though, major standout ones from some quick profiling is compute_line_bursts and downscale_audio.
  
  Enable numba on unpack_data_4_40 (probably commented it out by accident when making the PR for that, makes it 2x as fast but the function time is pretty insignificant compared to the rest of the program anyhow.)
  
  add inputfreq argument to LDDecode - mainly to optionally allow decoding at input frequency in vhs-decode rather than resampling to 40mhz which could have some speed benefits since many people capture at lower freqs with cx etc.