### PR TITLE
Add DTS support to ld-process-efm

### DIFF
--- a/tools/ld-process-efm/Datatypes/f3frame.cpp
+++ b/tools/ld-process-efm/Datatypes/f3frame.cpp
@@ -47,7 +47,7 @@ F3Frame::F3Frame()
     }
 }
 
-F3Frame::F3Frame(uchar *tValuesIn, qint32 tLength)
+F3Frame::F3Frame(uchar *tValuesIn, qint32 tLength, bool audioIsDts)
 {
     validEfmSymbols = 0;
     invalidEfmSymbols = 0;
@@ -57,11 +57,11 @@ F3Frame::F3Frame(uchar *tValuesIn, qint32 tLength)
     isSync1 = false;
     subcodeSymbol = 0;
 
-    setTValues(tValuesIn, tLength);
+    setTValues(tValuesIn, tLength, audioIsDts);
 }
 
 // This method sets the T-values for the F3 Frame
-void F3Frame::setTValues(uchar* tValuesIn, qint32 tLength)
+void F3Frame::setTValues(uchar* tValuesIn, qint32 tLength, bool audioIsDts)
 {
     // Does tValuesIn contain values?
     if (tLength == 0) {
@@ -134,8 +134,9 @@ void F3Frame::setTValues(uchar* tValuesIn, qint32 tLength)
 
     // Step 3:
 
-    // Decode the subcode symbol
-    if (efmValues[0] == 0x801) {
+    // Decode the subcode symbol.
+    // Some (but not all) DTS LaserDiscs use a non-standard Sync 0 value.
+    if (efmValues[0] == 0x801 || (audioIsDts && efmValues[0] == 0x812)) {
         // Sync 0
         subcodeSymbol = 0;
         isSync0 = true;

--- a/tools/ld-process-efm/Datatypes/f3frame.h
+++ b/tools/ld-process-efm/Datatypes/f3frame.h
@@ -33,9 +33,9 @@ class F3Frame
 {
 public:
     F3Frame();
-    F3Frame(uchar *tValuesIn, qint32 tLength);
+    F3Frame(uchar *tValuesIn, qint32 tLength, bool audioIsDts);
 
-    void setTValues(uchar *tValuesIn, qint32 tLength);
+    void setTValues(uchar *tValuesIn, qint32 tLength, bool audioIsDts);
     uchar* getDataSymbols();
     uchar* getErrorSymbols();
     uchar getSubcodeSymbol();

--- a/tools/ld-process-efm/Decoders/efmtof3frames.cpp
+++ b/tools/ld-process-efm/Decoders/efmtof3frames.cpp
@@ -33,9 +33,10 @@ EfmToF3Frames::EfmToF3Frames()
 // Public methods -----------------------------------------------------------------------------------------------------
 
 // Main processing method
-QVector<F3Frame> EfmToF3Frames::process(QByteArray efmDataIn, bool debugState)
+QVector<F3Frame> EfmToF3Frames::process(QByteArray efmDataIn, bool debugState, bool _audioIsDts)
 {
     debugOn = debugState;
+    audioIsDts = _audioIsDts;
 
     // Clear the output buffer
     f3FramesOut.clear();
@@ -382,7 +383,7 @@ EfmToF3Frames::StateMachine EfmToF3Frames::sm_state_processFrame()
 
     // Now we hand the data over to the F3 frame class which converts the data
     // into a F3 frame and save the F3 frame to our output data buffer
-    f3FramesOut.append(F3Frame(frameT, tLength));
+    f3FramesOut.append(F3Frame(frameT, tLength, audioIsDts));
 
     statistics.validEfmSymbols += f3FramesOut.last().getNumberOfValidEfmSymbols();
     statistics.invalidEfmSymbols += f3FramesOut.last().getNumberOfInvalidEfmSymbols();

--- a/tools/ld-process-efm/Decoders/efmtof3frames.h
+++ b/tools/ld-process-efm/Decoders/efmtof3frames.h
@@ -54,13 +54,14 @@ public:
         qint64 correctedEfmSymbols;
     };
 
-    QVector<F3Frame> process(QByteArray efmDataIn, bool debugState);
+    QVector<F3Frame> process(QByteArray efmDataIn, bool debugState, bool _audioIsDts);
     Statistics getStatistics();
     void reportStatistics();
     void reset();
 
 private:
     bool debugOn;
+    bool audioIsDts;
     Statistics statistics;
     QByteArray efmDataBuffer;
     QVector<F3Frame> f3FramesOut;

--- a/tools/ld-process-efm/efmprocess.cpp
+++ b/tools/ld-process-efm/efmprocess.cpp
@@ -67,9 +67,10 @@ void EfmProcess::setAudioErrorTreatment(EfmProcess::ErrorTreatment _errorTreatme
 }
 
 // Set the decoder options
-void EfmProcess::setDecoderOptions(bool _padInitialDiscTime, bool _decodeAsData, bool _noTimeStamp)
+void EfmProcess::setDecoderOptions(bool _padInitialDiscTime, bool _decodeAsData, bool _audioIsDts, bool _noTimeStamp)
 {
     qDebug() << "EfmProcess::setDecoderOptions(): Pad initial disc time is" << _padInitialDiscTime;
+    qDebug() << "EfmProcess::setDecoderOptions(): Audio-is-DTS is" << _audioIsDts;
     qDebug() << "EfmProcess::setDecoderOptions(): No time-stamp is" << _noTimeStamp;
     padInitialDiscTime = _padInitialDiscTime;
 
@@ -84,6 +85,7 @@ void EfmProcess::setDecoderOptions(bool _padInitialDiscTime, bool _decodeAsData,
         qDebug() << "EfmProcess::setDecoderOptions(): Decoding F1 frames as audio";
     }
 
+    audioIsDts = _audioIsDts;
     noTimeStamp = _noTimeStamp;
 }
 
@@ -153,7 +155,7 @@ bool EfmProcess::process(QString inputFilename, QString outputFilename)
         if (bytesRead != bufferSize) inputEfmBuffer.resize(static_cast<qint32>(bytesRead));
 
         // Perform EFM processing
-        QVector<F3Frame> initialF3Frames = efmToF3Frames.process(inputEfmBuffer, debug_efmToF3Frames);
+        QVector<F3Frame> initialF3Frames = efmToF3Frames.process(inputEfmBuffer, debug_efmToF3Frames, audioIsDts);
         QVector<F3Frame> syncedF3Frames = syncF3Frames.process(initialF3Frames, debug_syncF3Frames);
         QVector<F2Frame> f2Frames = f3ToF2Frames.process(syncedF3Frames, debug_f3ToF2Frames, noTimeStamp);
         QVector<F1Frame> f1Frames = f2ToF1Frames.process(f2Frames, debug_f2ToF1Frame, noTimeStamp);

--- a/tools/ld-process-efm/efmprocess.cpp
+++ b/tools/ld-process-efm/efmprocess.cpp
@@ -55,17 +55,12 @@ void EfmProcess::setDebug(bool _debug_efmToF3Frames, bool _debug_syncF3Frames,
 }
 
 // Set the audio error treatment type
-void EfmProcess::setAudioErrorTreatment(bool concealAudio, bool silenceAudio, bool passThroughAudio)
+void EfmProcess::setAudioErrorTreatment(EfmProcess::ErrorTreatment _errorTreatment)
 {
-    qDebug() << "EfmProcess::setAudioErrorTreatment(): Conceal audio =" << concealAudio;
-    qDebug() << "EfmProcess::setAudioErrorTreatment(): Silence audio =" << silenceAudio;
-    qDebug() << "EfmProcess::setAudioErrorTreatment(): Pass through audio =" << passThroughAudio;
+    qDebug() << "EfmProcess::setAudioErrorTreatment(): Error treatment =" << _errorTreatment;
 
     // Set the audio error treatment option
-    errorTreatment = F1ToAudio::ErrorTreatment::conceal; // Default
-    if (concealAudio) errorTreatment = F1ToAudio::ErrorTreatment::conceal;
-    if (silenceAudio) errorTreatment = F1ToAudio::ErrorTreatment::silence;
-    if (passThroughAudio) errorTreatment = F1ToAudio::ErrorTreatment::passThrough;
+    errorTreatment = _errorTreatment;
 
     // Set the conceal type option (THIS SHOULD BE REMOVED)
     concealType = F1ToAudio::ConcealType::linear;

--- a/tools/ld-process-efm/efmprocess.h
+++ b/tools/ld-process-efm/efmprocess.h
@@ -41,6 +41,8 @@ class EfmProcess
 public:
     EfmProcess();
 
+    using ErrorTreatment = F1ToAudio::ErrorTreatment;
+
     struct Statistics {
         EfmToF3Frames::Statistics efmToF3Frames;
         SyncF3Frames::Statistics syncF3Frames;
@@ -53,8 +55,7 @@ public:
     void setDebug(bool _debug_efmToF3Frames, bool _debug_syncF3Frames,
                   bool _debug_f3ToF2Frames, bool _debug_f2ToF1Frames,
                   bool _debug_f1ToAudio, bool _debug_f1ToData);
-    void setAudioErrorTreatment(bool concealAudio,
-                                            bool silenceAudio, bool passThroughAudio);
+    void setAudioErrorTreatment(ErrorTreatment _errorTreatment);
     void setDecoderOptions(bool _padInitialDiscTime, bool _decodeAsData, bool _noTimeStamp);
     void reportStatistics();
     bool process(QString inputFilename, QString outputFilename);

--- a/tools/ld-process-efm/efmprocess.h
+++ b/tools/ld-process-efm/efmprocess.h
@@ -56,7 +56,7 @@ public:
                   bool _debug_f3ToF2Frames, bool _debug_f2ToF1Frames,
                   bool _debug_f1ToAudio, bool _debug_f1ToData);
     void setAudioErrorTreatment(ErrorTreatment _errorTreatment);
-    void setDecoderOptions(bool _padInitialDiscTime, bool _decodeAsData, bool _noTimeStamp);
+    void setDecoderOptions(bool _padInitialDiscTime, bool _decodeAsData, bool _audioIsDts, bool _noTimeStamp);
     void reportStatistics();
     bool process(QString inputFilename, QString outputFilename);
     Statistics getStatistics();
@@ -85,6 +85,7 @@ private:
     bool padInitialDiscTime;
     bool decodeAsAudio;
     bool decodeAsData;
+    bool audioIsDts;
     bool noTimeStamp;
 
     Statistics statistics;

--- a/tools/ld-process-efm/main.cpp
+++ b/tools/ld-process-efm/main.cpp
@@ -79,6 +79,10 @@ int main(int argc, char *argv[])
                                        QCoreApplication::translate("main", "Decode F1 frames as data instead of audio"));
     parser.addOption(decodeAsDataOption);
 
+    QCommandLineOption audioIsDtsOption(QStringList() << "D" << "dts",
+                                        QCoreApplication::translate("main", "Audio is DTS rather than PCM (allow non-standard F3 syncs)"));
+    parser.addOption(audioIsDtsOption);
+
     QCommandLineOption noTimeStampOption(QStringList() << "t" << "time",
                                        QCoreApplication::translate("main", "Non-standard audio decode (no time-stamp information)"));
     parser.addOption(noTimeStampOption);
@@ -121,8 +125,10 @@ int main(int argc, char *argv[])
     // Standard logging options
     processStandardDebugOptions(parser);
 
-    // Get the audio options from the parser
-    EfmProcess::ErrorTreatment errorTreatment = EfmProcess::ErrorTreatment::conceal;
+    // Get the audio options from the parser.
+    // Default to conceal for PCM audio, and passThrough for DTS audio.
+    EfmProcess::ErrorTreatment errorTreatment = parser.isSet(audioIsDtsOption) ? EfmProcess::ErrorTreatment::passThrough
+                                                                               : EfmProcess::ErrorTreatment::conceal;
     int numTreatments = 0;
     if (parser.isSet(concealAudioOption)) {
         errorTreatment = EfmProcess::ErrorTreatment::conceal;
@@ -144,6 +150,7 @@ int main(int argc, char *argv[])
     // Get the decoding options from the parser
     bool pad = parser.isSet(padOption);
     bool decodeAsData = parser.isSet(decodeAsDataOption);
+    bool audioIsDts = parser.isSet(audioIsDtsOption);
     bool noTimeStamp = parser.isSet(noTimeStampOption);
 
     // Get the additional debug options from the parser
@@ -171,7 +178,7 @@ int main(int argc, char *argv[])
     EfmProcess efmProcess;
     efmProcess.setDebug(debug_efmToF3Frames, debug_syncF3Frames, debug_f3ToF2Frames,
                         debug_f2ToF1Frame, debug_f1ToAudio, debug_f1ToData);
-    efmProcess.setDecoderOptions(pad, decodeAsData, noTimeStamp);
+    efmProcess.setDecoderOptions(pad, decodeAsData, audioIsDts, noTimeStamp);
     efmProcess.setAudioErrorTreatment(errorTreatment);
 
     if (!efmProcess.process(inputFilename, outputFilename)) return 1;

--- a/tools/ld-process-efm/main.cpp
+++ b/tools/ld-process-efm/main.cpp
@@ -122,9 +122,24 @@ int main(int argc, char *argv[])
     processStandardDebugOptions(parser);
 
     // Get the audio options from the parser
-    bool concealAudio = parser.isSet(concealAudioOption);
-    bool silenceAudio = parser.isSet(silenceAudioOption);
-    bool passThroughAudio = parser.isSet(passThroughAudioOption);
+    EfmProcess::ErrorTreatment errorTreatment = EfmProcess::ErrorTreatment::conceal;
+    int numTreatments = 0;
+    if (parser.isSet(concealAudioOption)) {
+        errorTreatment = EfmProcess::ErrorTreatment::conceal;
+        numTreatments++;
+    }
+    if (parser.isSet(silenceAudioOption)) {
+        errorTreatment = EfmProcess::ErrorTreatment::silence;
+        numTreatments++;
+    }
+    if (parser.isSet(passThroughAudioOption)) {
+        errorTreatment = EfmProcess::ErrorTreatment::passThrough;
+        numTreatments++;
+    }
+    if (numTreatments > 1) {
+        qCritical() << "You may only specify one error treatment option (-c, -s or -g)";
+        return 1;
+    }
 
     // Get the decoding options from the parser
     bool pad = parser.isSet(padOption);
@@ -157,7 +172,7 @@ int main(int argc, char *argv[])
     efmProcess.setDebug(debug_efmToF3Frames, debug_syncF3Frames, debug_f3ToF2Frames,
                         debug_f2ToF1Frame, debug_f1ToAudio, debug_f1ToData);
     efmProcess.setDecoderOptions(pad, decodeAsData, noTimeStamp);
-    efmProcess.setAudioErrorTreatment(concealAudio, silenceAudio, passThroughAudio);
+    efmProcess.setAudioErrorTreatment(errorTreatment);
 
     if (!efmProcess.process(inputFilename, outputFilename)) return 1;
 


### PR DESCRIPTION
This is based on @DreckSoft's work in #527. It adds a `--dts` option to accept the alternative Sync 0 value that some DTS LaserDiscs use. Since audio error concealment doesn't make sense for DTS, it also changes the default error treatment when the option is used (and checks that you haven't specified multiple treatment options).

It's been tested on clips from the following [DTS discs](https://www.lddb.com/list.php?format=ld&list=dts):
- Armageddon - decodes as normal
- Goldeneye - needs `--dts --time`
- Jurassic Park - needs `--dts --time`
- Jurassic Park: The Lost World - decodes as normal

Fixes #527.

Note to self: will need to add the new option, and some advice on using it, to the wiki.