### PR TITLE
Remove the mode option from the Transform decoders

### DIFF
--- a/tools/ld-analyse/chromadecoderconfigdialog.cpp
+++ b/tools/ld-analyse/chromadecoderconfigdialog.cpp
@@ -177,16 +177,13 @@ void ChromaDecoderConfigDialog::updateDialog()
     }
 
     const bool isTransform = (palConfiguration.chromaFilter != PalColour::palColourFilter);
-    const bool isThresholdMode = (palConfiguration.transformMode == TransformPal::thresholdMode);
-    ui->thresholdModeCheckBox->setEnabled(isSourcePal && isTransform);
-    ui->thresholdModeCheckBox->setChecked(isThresholdMode);
 
-    ui->thresholdLabel->setEnabled(isSourcePal && isTransform && isThresholdMode);
+    ui->thresholdLabel->setEnabled(isSourcePal && isTransform);
 
-    ui->thresholdHorizontalSlider->setEnabled(isSourcePal && isTransform && isThresholdMode);
+    ui->thresholdHorizontalSlider->setEnabled(isSourcePal && isTransform);
     ui->thresholdHorizontalSlider->setValue(static_cast<qint32>(palConfiguration.transformThreshold * 100));
 
-    ui->thresholdValueLabel->setEnabled(isSourcePal && isTransform && isThresholdMode);
+    ui->thresholdValueLabel->setEnabled(isSourcePal && isTransform);
     ui->thresholdValueLabel->setText(QString::number(palConfiguration.transformThreshold, 'f', 2));
 
     ui->showFFTsCheckBox->setEnabled(isSourcePal && isTransform);
@@ -256,17 +253,6 @@ void ChromaDecoderConfigDialog::on_palFilterButtonGroup_buttonClicked(QAbstractB
         palConfiguration.chromaFilter = PalColour::transform2DFilter;
     } else {
         palConfiguration.chromaFilter = PalColour::transform3DFilter;
-    }
-    updateDialog();
-    emit chromaDecoderConfigChanged();
-}
-
-void ChromaDecoderConfigDialog::on_thresholdModeCheckBox_clicked()
-{
-    if (ui->thresholdModeCheckBox->isChecked()) {
-        palConfiguration.transformMode = TransformPal::thresholdMode;
-    } else {
-        palConfiguration.transformMode = TransformPal::levelMode;
     }
     updateDialog();
     emit chromaDecoderConfigChanged();

--- a/tools/ld-analyse/chromadecoderconfigdialog.h
+++ b/tools/ld-analyse/chromadecoderconfigdialog.h
@@ -59,7 +59,6 @@ private slots:
     void on_chromaPhaseHorizontalSlider_valueChanged(int value);
 
     void on_palFilterButtonGroup_buttonClicked(QAbstractButton *button);
-    void on_thresholdModeCheckBox_clicked();
     void on_thresholdHorizontalSlider_valueChanged(int value);
     void on_showFFTsCheckBox_clicked();
     void on_simplePALCheckBox_clicked();

--- a/tools/ld-analyse/chromadecoderconfigdialog.ui
+++ b/tools/ld-analyse/chromadecoderconfigdialog.ui
@@ -181,13 +181,6 @@
         </spacer>
        </item>
        <item>
-        <widget class="QCheckBox" name="thresholdModeCheckBox">
-         <property name="text">
-          <string>Use threshold comparison mode</string>
-         </property>
-        </widget>
-       </item>
-       <item>
         <spacer name="verticalSpacer_2">
          <property name="orientation">
           <enum>Qt::Vertical</enum>

--- a/tools/ld-chroma-decoder/main.cpp
+++ b/tools/ld-chroma-decoder/main.cpp
@@ -247,21 +247,15 @@ int main(int argc, char *argv[])
                                            QCoreApplication::translate("main", "Transform: Use 1D UV filter (default 2D)"));
     parser.addOption(simplePALOption);
 
-    // Option to select the Transform PAL filter mode
-    QCommandLineOption transformModeOption(QStringList() << "transform-mode",
-                                           QCoreApplication::translate("main", "Transform: Filter mode to use (level, threshold; default threshold)"),
-                                           QCoreApplication::translate("main", "mode"));
-    parser.addOption(transformModeOption);
-
     // Option to select the Transform PAL threshold
     QCommandLineOption transformThresholdOption(QStringList() << "transform-threshold",
-                                                QCoreApplication::translate("main", "Transform: Uniform similarity threshold in 'threshold' mode (default 0.4)"),
+                                                QCoreApplication::translate("main", "Transform: Uniform similarity threshold (default 0.4)"),
                                                 QCoreApplication::translate("main", "number"));
     parser.addOption(transformThresholdOption);
 
     // Option to select the Transform PAL thresholds file
     QCommandLineOption transformThresholdsOption(QStringList() << "transform-thresholds",
-                                                 QCoreApplication::translate("main", "Transform: File containing per-bin similarity thresholds in 'threshold' mode"),
+                                                 QCoreApplication::translate("main", "Transform: File containing per-bin similarity thresholds"),
                                                  QCoreApplication::translate("main", "file"));
     parser.addOption(transformThresholdsOption);
 
@@ -399,20 +393,6 @@ int main(int argc, char *argv[])
 
     if (parser.isSet(ntscPhaseCompOption)) {
         combConfig.phaseCompensation = true;
-    }
-
-    if (parser.isSet(transformModeOption)) {
-        const QString name = parser.value(transformModeOption);
-
-        if (name == "level") {
-            palConfig.transformMode = TransformPal::levelMode;
-        } else if (name == "threshold") {
-            palConfig.transformMode = TransformPal::thresholdMode;
-        } else {
-            // Quit with error
-            qCritical() << "Unknown Transform mode" << name;
-            return -1;
-        }
     }
 
     if (parser.isSet(simplePALOption)) {

--- a/tools/ld-chroma-decoder/palcolour.cpp
+++ b/tools/ld-chroma-decoder/palcolour.cpp
@@ -124,7 +124,7 @@ void PalColour::updateConfiguration(const LdDecodeMetaData::VideoParameters &_vi
         }
 
         // Configure the filter
-        transformPal->updateConfiguration(videoParameters, configuration.transformMode, configuration.transformThreshold,
+        transformPal->updateConfiguration(videoParameters, configuration.transformThreshold,
                                           configuration.transformThresholds);
     }
 

--- a/tools/ld-chroma-decoder/palcolour.h
+++ b/tools/ld-chroma-decoder/palcolour.h
@@ -60,7 +60,6 @@ public:
         double yNRLevel = 0.5;
         bool simplePAL = false;
         ChromaFilterMode chromaFilter = palColourFilter;
-        TransformPal::TransformMode transformMode = TransformPal::thresholdMode;
         double transformThreshold = 0.4;
         QVector<double> transformThresholds;
         bool showFFTs = false;

--- a/tools/ld-chroma-decoder/transformpal.cpp
+++ b/tools/ld-chroma-decoder/transformpal.cpp
@@ -40,11 +40,9 @@ TransformPal::~TransformPal()
 }
 
 void TransformPal::updateConfiguration(const LdDecodeMetaData::VideoParameters &_videoParameters,
-                                       TransformPal::TransformMode _mode, double threshold,
-                                       const QVector<double> &_thresholds)
+                                       double threshold, const QVector<double> &_thresholds)
 {
     videoParameters = _videoParameters;
-    mode = _mode;
 
     // Resize thresholds to match the number of FFT bins we will consider in
     // applyFilter. The x loop there doesn't need to look at every bin.

--- a/tools/ld-chroma-decoder/transformpal.h
+++ b/tools/ld-chroma-decoder/transformpal.h
@@ -44,25 +44,13 @@ public:
     TransformPal(qint32 xComplex, qint32 yComplex, qint32 zComplex);
     virtual ~TransformPal();
 
-    // Specify what the frequency-domain filter should do to each pair of
-    // bins that should be symmetrical around the carriers.
-    enum TransformMode {
-        // Adjust the amplitudes of the two bins to be equal
-        levelMode = 0,
-        // If the amplitudes aren't within a threshold of each other, zero both bins
-        thresholdMode
-    };
-
     // Configure TransformPal.
     //
-    // mode selects an operation mode for the filter.
-    //
-    // threshold is the similarity threshold for the filter in thresholdMode.
-    // Values from 0-1 are meaningful, with higher values requiring signals to
-    // be more similar to be considered chroma. 0.6 is pyctools-pal's default.
+    // threshold is the similarity threshold for the filter. Values from 0-1
+    // are meaningful, with higher values requiring signals to be more similar
+    // to be considered chroma.
     void updateConfiguration(const LdDecodeMetaData::VideoParameters &videoParameters,
-                             TransformMode mode, double threshold,
-                             const QVector<double> &thresholds);
+                             double threshold, const QVector<double> &thresholds);
 
     // Filter input fields.
     //
@@ -100,7 +88,6 @@ protected:
     bool configurationSet;
     LdDecodeMetaData::VideoParameters videoParameters;
     QVector<double> thresholds;
-    TransformMode mode;
 };
 
 #endif

--- a/tools/ld-chroma-decoder/transformpal2d.cpp
+++ b/tools/ld-chroma-decoder/transformpal2d.cpp
@@ -133,12 +133,8 @@ void TransformPal2D::filterField(const SourceField& inputField, qint32 outputInd
             // Compute the forward FFT
             forwardFFTTile(tileX, tileY, startY, endY, inputField);
 
-            // Apply the frequency-domain filter in the appropriate mode
-            if (mode == levelMode) {
-                applyFilter<levelMode>();
-            } else {
-                applyFilter<thresholdMode>();
-            }
+            // Apply the frequency-domain filter
+            applyFilter();
 
             // Compute the inverse FFT
             inverseFFTTile(tileX, tileY, startY, endY, outputIndex);
@@ -198,8 +194,6 @@ static inline double fftwAbsSq(const fftw_complex &value)
 }
 
 // Apply the frequency-domain filter.
-// (Templated so that the inner loop gets specialised for each mode.)
-template <TransformPal::TransformMode MODE>
 void TransformPal2D::applyFilter()
 {
     // Get pointer to squared threshold values
@@ -261,37 +255,17 @@ void TransformPal2D::applyFilter()
             const double m_in_sq = fftwAbsSq(in_val);
             const double m_ref_sq = fftwAbsSq(ref_val);
 
-            if (MODE == levelMode) {
-                // Compare the magnitudes of the two values, and scale the
-                // larger one down so its magnitude is the same as the
-                // smaller one.
-                const double factor = sqrt(m_in_sq / m_ref_sq);
-                if (m_in_sq > m_ref_sq) {
-                    // Reduce in_val, keep ref_val as is
-                    bo[x][0] = in_val[0] / factor;
-                    bo[x][1] = in_val[1] / factor;
-                    bo_ref[x_ref][0] = ref_val[0];
-                    bo_ref[x_ref][1] = ref_val[1];
-                } else {
-                    // Reduce ref_val, keep in_val as is
-                    bo[x][0] = in_val[0];
-                    bo[x][1] = in_val[1];
-                    bo_ref[x_ref][0] = ref_val[0] * factor;
-                    bo_ref[x_ref][1] = ref_val[1] * factor;
-                }
+            // Compare the magnitudes of the two values, and discard both
+            // if they are more different than the threshold for this
+            // bin.
+            if (m_in_sq < m_ref_sq * threshold_sq || m_ref_sq < m_in_sq * threshold_sq) {
+                // Probably not a chroma signal; throw it away.
             } else {
-                // Compare the magnitudes of the two values, and discard both
-                // if they are more different than the threshold for this
-                // bin.
-                if (m_in_sq < m_ref_sq * threshold_sq || m_ref_sq < m_in_sq * threshold_sq) {
-                    // Probably not a chroma signal; throw it away.
-                } else {
-                    // They're similar. Keep it!
-                    bo[x][0] = in_val[0];
-                    bo[x][1] = in_val[1];
-                    bo_ref[x_ref][0] = ref_val[0];
-                    bo_ref[x_ref][1] = ref_val[1];
-                }
+                // They're similar. Keep it!
+                bo[x][0] = in_val[0];
+                bo[x][1] = in_val[1];
+                bo_ref[x_ref][0] = ref_val[0];
+                bo_ref[x_ref][1] = ref_val[1];
             }
         }
     }
@@ -320,12 +294,8 @@ void TransformPal2D::overlayFFTFrame(qint32 positionX, qint32 positionY,
     // Compute the forward FFT
     forwardFFTTile(positionX, tileY, startY, endY, inputField);
 
-    // Apply the frequency-domain filter in the appropriate mode
-    if (mode == levelMode) {
-        applyFilter<levelMode>();
-    } else {
-        applyFilter<thresholdMode>();
-    }
+    // Apply the frequency-domain filter
+    applyFilter();
 
     // Create a canvas
     FrameCanvas canvas(componentFrame, videoParameters);

--- a/tools/ld-chroma-decoder/transformpal2d.h
+++ b/tools/ld-chroma-decoder/transformpal2d.h
@@ -51,7 +51,6 @@ protected:
     void filterField(const SourceField& inputField, qint32 outputIndex);
     void forwardFFTTile(qint32 tileX, qint32 tileY, qint32 startY, qint32 endY, const SourceField &inputField);
     void inverseFFTTile(qint32 tileX, qint32 tileY, qint32 startY, qint32 endY, qint32 outputIndex);
-    template <TransformMode MODE>
     void applyFilter();
     void overlayFFTFrame(qint32 positionX, qint32 positionY,
                          const QVector<SourceField> &inputFields, qint32 fieldIndex,

--- a/tools/ld-chroma-decoder/transformpal3d.cpp
+++ b/tools/ld-chroma-decoder/transformpal3d.cpp
@@ -143,12 +143,8 @@ void TransformPal3D::filterFields(const QVector<SourceField> &inputFields, qint3
                 // Compute the forward FFT
                 forwardFFTTile(tileX, tileY, tileZ, inputFields);
 
-                // Apply the frequency-domain filter in the appropriate mode
-                if (mode == levelMode) {
-                    applyFilter<levelMode>();
-                } else {
-                    applyFilter<thresholdMode>();
-                }
+                // Apply the frequency-domain filter
+                applyFilter();
 
                 // Compute the inverse FFT
                 inverseFFTTile(tileX, tileY, tileZ, startIndex, endIndex);
@@ -234,8 +230,6 @@ static inline double fftwAbsSq(const fftw_complex &value)
 }
 
 // Apply the frequency-domain filter.
-// (Templated so that the inner loop gets specialised for each mode.)
-template <TransformPal::TransformMode MODE>
 void TransformPal3D::applyFilter()
 {
     // Get pointer to squared threshold values
@@ -303,37 +297,17 @@ void TransformPal3D::applyFilter()
                 const double m_in_sq = fftwAbsSq(in_val);
                 const double m_ref_sq = fftwAbsSq(ref_val);
 
-                if (MODE == levelMode) {
-                    // Compare the magnitudes of the two values, and scale the
-                    // larger one down so its magnitude is the same as the
-                    // smaller one.
-                    const double factor = sqrt(m_in_sq / m_ref_sq);
-                    if (m_in_sq > m_ref_sq) {
-                        // Reduce in_val, keep ref_val as is
-                        bo[x][0] = in_val[0] / factor;
-                        bo[x][1] = in_val[1] / factor;
-                        bo_ref[x_ref][0] = ref_val[0];
-                        bo_ref[x_ref][1] = ref_val[1];
-                    } else {
-                        // Reduce ref_val, keep in_val as is
-                        bo[x][0] = in_val[0];
-                        bo[x][1] = in_val[1];
-                        bo_ref[x_ref][0] = ref_val[0] * factor;
-                        bo_ref[x_ref][1] = ref_val[1] * factor;
-                    }
+                // Compare the magnitudes of the two values, and discard
+                // both if they are more different than the threshold for
+                // this bin.
+                if (m_in_sq < m_ref_sq * threshold_sq || m_ref_sq < m_in_sq * threshold_sq) {
+                    // Probably not a chroma signal; throw it away.
                 } else {
-                    // Compare the magnitudes of the two values, and discard
-                    // both if they are more different than the threshold for
-                    // this bin.
-                    if (m_in_sq < m_ref_sq * threshold_sq || m_ref_sq < m_in_sq * threshold_sq) {
-                        // Probably not a chroma signal; throw it away.
-                    } else {
-                        // They're similar. Keep it!
-                        bo[x][0] = in_val[0];
-                        bo[x][1] = in_val[1];
-                        bo_ref[x_ref][0] = ref_val[0];
-                        bo_ref[x_ref][1] = ref_val[1];
-                    }
+                    // They're similar. Keep it!
+                    bo[x][0] = in_val[0];
+                    bo[x][1] = in_val[1];
+                    bo_ref[x_ref][0] = ref_val[0];
+                    bo_ref[x_ref][1] = ref_val[1];
                 }
             }
         }
@@ -355,12 +329,8 @@ void TransformPal3D::overlayFFTFrame(qint32 positionX, qint32 positionY,
     // Compute the forward FFT
     forwardFFTTile(positionX, positionY, fieldIndex, inputFields);
 
-    // Apply the frequency-domain filter in the appropriate mode
-    if (mode == levelMode) {
-        applyFilter<levelMode>();
-    } else {
-        applyFilter<thresholdMode>();
-    }
+    // Apply the frequency-domain filter
+    applyFilter();
 
     // Create a canvas
     FrameCanvas canvas(componentFrame, videoParameters);

--- a/tools/ld-chroma-decoder/transformpal3d.h
+++ b/tools/ld-chroma-decoder/transformpal3d.h
@@ -55,7 +55,6 @@ public:
 protected:
     void forwardFFTTile(qint32 tileX, qint32 tileY, qint32 tileZ, const QVector<SourceField> &inputFields);
     void inverseFFTTile(qint32 tileX, qint32 tileY, qint32 tileZ, qint32 startFieldIndex, qint32 endFieldIndex);
-    template <TransformMode MODE>
     void applyFilter();
     void overlayFFTFrame(qint32 positionX, qint32 positionY,
                          const QVector<SourceField> &inputFields, qint32 fieldIndex,


### PR DESCRIPTION
There doesn't appear to be any reason to use level mode (the BBC hardware decoders use threshold mode), so removing the option simplifies both the code and the interface.

Note to self: update the wiki.