### PR TITLE
Add field offset option to ld-chroma-encoder

### DIFF
--- a/tools/ld-chroma-decoder/encoder/main.cpp
+++ b/tools/ld-chroma-decoder/encoder/main.cpp
@@ -64,15 +64,10 @@ int main(int argc, char *argv[])
     // Add the standard debug options --debug and --quiet
     addStandardDebugOptions(parser);
 
-    // Option to produce subcarrier-locked output (-c)
-    QCommandLineOption scLockedOption(QStringList() << "c" << "sc-locked",
-                                      QCoreApplication::translate("main", "Output samples are subcarrier-locked. PAL only. (default: line-locked)"));
-    parser.addOption(scLockedOption);
-
-    // Option to select color system (-f)
+    // Option to select video system (-f)
     QCommandLineOption systemOption(QStringList() << "f" << "system",
-                                     QCoreApplication::translate("main", "Select color system, PAL or NTSC. (default PAL)"),
-                                     QCoreApplication::translate("main", "system"));
+                                    QCoreApplication::translate("main", "Video system (PAL, NTSC; default PAL)"),
+                                    QCoreApplication::translate("main", "system"));
     parser.addOption(systemOption);
 
     // Option to specify where to start in the field sequence (--field-offset)
@@ -81,16 +76,25 @@ int main(int argc, char *argv[])
                                          QCoreApplication::translate("main", "offset"));
     parser.addOption(fieldOffsetOption);
 
+    // -- NTSC options --
+
     // Option to select chroma mode (--chroma-mode)
     QCommandLineOption chromaOption(QStringList() << "chroma-mode",
-                                     QCoreApplication::translate("main", "NTSC only. Chroma encoder mode to use (wideband-yuv, wideband-yiq, narrowband-q; default: wideband-yuv)"),
+                                     QCoreApplication::translate("main", "NTSC: Chroma encoder mode to use (wideband-yuv, wideband-yiq, narrowband-q; default: wideband-yuv)"),
                                      QCoreApplication::translate("main", "chroma-mode"));
     parser.addOption(chromaOption);
 
     // Option to disable 7.5 IRE setup, as in NTSC-J (--no-setup)
     QCommandLineOption setupOption(QStringList() << "no-setup",
-                                     QCoreApplication::translate("main", "NTSC only. Do not add 7.5 IRE setup (as in NTSC-J)"));
+                                   QCoreApplication::translate("main", "NTSC: Output NTSC-J, without 7.5 IRE setup"));
     parser.addOption(setupOption);
+
+    // -- PAL options --
+
+    // Option to produce subcarrier-locked output (-c)
+    QCommandLineOption scLockedOption(QStringList() << "c" << "sc-locked",
+                                      QCoreApplication::translate("main", "PAL: Output samples are subcarrier-locked (default: line-locked)"));
+    parser.addOption(scLockedOption);
 
     // -- Positional arguments --
 
@@ -109,32 +113,6 @@ int main(int argc, char *argv[])
 
     // Standard logging options
     processStandardDebugOptions(parser);
-
-    // Get the options from the parser
-    const bool scLocked = parser.isSet(scLockedOption);
-
-    // Get the arguments from the parser
-    QString inputFileName;
-    QString outputFileName;
-    QString chromaFileName;
-    QStringList positionalArguments = parser.positionalArguments();
-    if (positionalArguments.count() == 2 || positionalArguments.count() == 3) {
-        inputFileName = positionalArguments.at(0);
-        outputFileName = positionalArguments.at(1);
-        if (positionalArguments.count() > 2) {
-            chromaFileName = positionalArguments.at(2);
-        }
-    } else {
-        // Quit with error
-        qCritical("You must specify the input RGB and output TBC files");
-        return -1;
-    }
-
-    if (inputFileName == outputFileName) {
-        // Quit with error
-        qCritical("Input and output files cannot be the same");
-        return -1;
-    }
 
     VideoSystem system = PAL;
     QString systemName;
@@ -180,6 +158,32 @@ int main(int argc, char *argv[])
         }
 
     }
+
+    const bool scLocked = parser.isSet(scLockedOption);
+
+    // Get the arguments from the parser
+    QString inputFileName;
+    QString outputFileName;
+    QString chromaFileName;
+    QStringList positionalArguments = parser.positionalArguments();
+    if (positionalArguments.count() == 2 || positionalArguments.count() == 3) {
+        inputFileName = positionalArguments.at(0);
+        outputFileName = positionalArguments.at(1);
+        if (positionalArguments.count() > 2) {
+            chromaFileName = positionalArguments.at(2);
+        }
+    } else {
+        // Quit with error
+        qCritical("You must specify the input RGB and output TBC files");
+        return -1;
+    }
+
+    if (inputFileName == outputFileName) {
+        // Quit with error
+        qCritical("Input and output files cannot be the same");
+        return -1;
+    }
+
     // Open the input file
     QFile rgbFile(inputFileName);
     if (inputFileName == "-") {

--- a/tools/ld-chroma-decoder/encoder/ntscencoder.h
+++ b/tools/ld-chroma-decoder/encoder/ntscencoder.h
@@ -43,7 +43,7 @@ class NTSCEncoder : public Encoder
 {
 public:
     NTSCEncoder(QFile &rgbFile, QFile &tbcFile, QFile &chromaFile, LdDecodeMetaData &metaData,
-                ChromaMode chromaMode, bool addSetup);
+                int fieldOffset, ChromaMode chromaMode, bool addSetup);
 
 protected:
     virtual void getFieldMetadata(qint32 fieldNo, LdDecodeMetaData::Field &fieldData);
@@ -53,6 +53,7 @@ protected:
     const qint32 blankingIre = 0x3C00;
     const qint32 setupIreOffset = 0x0A80; // 10.5 * 256
 
+    int fieldOffset;
     ChromaMode chromaMode;
     bool addSetup;
 

--- a/tools/ld-chroma-decoder/encoder/palencoder.cpp
+++ b/tools/ld-chroma-decoder/encoder/palencoder.cpp
@@ -39,8 +39,9 @@
 #include <array>
 #include <cmath>
 
-PALEncoder::PALEncoder(QFile &_rgbFile, QFile &_tbcFile, QFile &_chromaFile, LdDecodeMetaData &_metaData, bool _scLocked)
-    : Encoder(_rgbFile, _tbcFile, _chromaFile, _metaData), scLocked(_scLocked)
+PALEncoder::PALEncoder(QFile &_rgbFile, QFile &_tbcFile, QFile &_chromaFile, LdDecodeMetaData &_metaData,
+                       int _fieldOffset, bool _scLocked)
+    : Encoder(_rgbFile, _tbcFile, _chromaFile, _metaData), fieldOffset(_fieldOffset), scLocked(_scLocked)
 {
     // PAL subcarrier frequency [Poynton p529] [EBU p5]
     videoParameters.fSC = 4433618.75;
@@ -184,7 +185,7 @@ void PALEncoder::encodeLine(qint32 fieldNo, qint32 frameLine, const quint16 *rgb
     }
 
     // How many complete lines have gone by since the start of the 4-frame sequence?
-    const qint32 fieldID = fieldNo % 8; 
+    const qint32 fieldID = (fieldNo + fieldOffset) % 8;
     const qint32 prevLines = ((fieldID / 2) * 625) + ((fieldID % 2) * 313) + (frameLine / 2);
 
     // Compute the time at which 0H occurs within the line (see above)

--- a/tools/ld-chroma-decoder/encoder/palencoder.h
+++ b/tools/ld-chroma-decoder/encoder/palencoder.h
@@ -35,13 +35,15 @@
 class PALEncoder : public Encoder
 {
 public:
-    PALEncoder(QFile &rgbFile, QFile &tbcFile, QFile &chromaFile, LdDecodeMetaData &metaData, bool scLocked);
+    PALEncoder(QFile &rgbFile, QFile &tbcFile, QFile &chromaFile, LdDecodeMetaData &metaData,
+               int fieldOffset, bool scLocked);
 
 private:
     virtual void getFieldMetadata(qint32 fieldNo, LdDecodeMetaData::Field &fieldData);
     virtual void encodeLine(qint32 fieldNo, qint32 frameLine, const quint16 *rgbData,
                             std::vector<double> &outputC, std::vector<double> &outputVBS);
 
+    int fieldOffset;
     bool scLocked;
 
     std::vector<double> Y;


### PR DESCRIPTION
This lets you start the encoder's output at an arbitrary point in the NTSC/PAL field sequence, which is useful if you're trying to match the encoding of an existing video. (I'm using it to calibrate Transform PAL.)

Also tidy up the help for the encoder to match the decoder - I'll need to update the wiki.

CC @ifb.