### PR TITLE
Fix chroma rotation for phase comp decoder and make some json values that are integers actually output as int

### DIFF
--- a/lddecode/core.py
+++ b/lddecode/core.py
@@ -3776,7 +3776,7 @@ class LDdecode:
             "syncConf": f.compute_syncconf(),
             "seqNo": len(self.fieldinfo) + 1,
             "diskLoc": np.round((self.fieldloc / self.bytes_per_field) * 10) / 10,
-            "fileLoc": np.floor(self.fieldloc),
+            "fileLoc": int(np.floor(self.fieldloc)),
             "medianBurstIRE": roundfloat(f.burstmedian),
         }
 
@@ -4003,18 +4003,18 @@ class LDdecode:
         # current burst adjustment as of 2/27/19, update when #158 is fixed!
         badj = -1.4
         spu = f.rf.SysParams["outfreq"]
-        vp["colourBurstStart"] = np.round(
+        vp["colourBurstStart"] = int(np.round(
             (f.rf.SysParams["colorBurstUS"][0] * spu) + badj
-        )
-        vp["colourBurstEnd"] = np.round(
+        ))
+        vp["colourBurstEnd"] = int(np.round(
             (f.rf.SysParams["colorBurstUS"][1] * spu) + badj
-        )
-        vp["activeVideoStart"] = np.round(
+        ))
+        vp["activeVideoStart"] = int(np.round(
             (f.rf.SysParams["activeVideoUS"][0] * spu) + badj
-        )
-        vp["activeVideoEnd"] = np.round(
+        ))
+        vp["activeVideoEnd"] = int(np.round(
             (f.rf.SysParams["activeVideoUS"][1] * spu) + badj
-        )
+        ))
 
         jout["videoParameters"] = vp
 


### PR DESCRIPTION
I added a 10 degree offset to the chroma rotation in the phase compensating decoder as that seemed to fix phase offset, but after some digging it seems it was the samples that were off so it now correctly rotates 33 degrees which should give the correct result if the burst/color relationship in the sample is correct.

Also made some values that are supposed to be integers actually be output as integers to the json, round didn't change the datatype apparently so it was still outputting .0 int the json for those values.