### PR TITLE
Fix chroma encoding in NTSCEncoder

### DIFF
--- a/tools/ld-chroma-decoder/comb.cpp
+++ b/tools/ld-chroma-decoder/comb.cpp
@@ -533,9 +533,8 @@ namespace {
 
     // Rotate the burst angle to get the correct values.
     // We do the 33 degree rotation here to avoid computing it for every pixel.
-    // TODO: additionally we need to rotate another ~10 degrees to get the correct hue, find out why.
-    constexpr double ROTATE_SIN = 0.6819983600624985;
-    constexpr double ROTATE_COS = 0.7313537016191705;
+    constexpr double ROTATE_SIN = 0.5446390350150271;
+    constexpr double ROTATE_COS = 0.838670567945424;
 
     BurstInfo detectBurst(const quint16* lineData,
                           const LdDecodeMetaData::VideoParameters& videoParameters)

--- a/tools/ld-chroma-decoder/encoder/palencoder.cpp
+++ b/tools/ld-chroma-decoder/encoder/palencoder.cpp
@@ -62,6 +62,11 @@ PALEncoder::PALEncoder(QFile &_rgbFile, QFile &_tbcFile, QFile &_chromaFile, LdD
         // moves to the right by (4 / 625) samples on each line. The values
         // in this struct represent the sample numbers *on the first line*.
         //
+        // Each line in the output TBC consists of a series of blanking samples
+        // followed by a series of active samples [EBU p9] -- different from
+        // ld-decode, which starts each line with the leading edge of the
+        // horizontal sync pulse (0H).
+        //
         // The first sample in the TBC frame is the first blanking sample of
         // field 1 line 1, sample 948 of 1135. 0H occurs midway between samples
         // 957 and 958. [EBU p7]


### PR DESCRIPTION
This should fix the encoding problem identified in the discussion for #787 - I ended up reworking how it figures out the phase offset for each sample, and fixing how it outputs phaseID to the metadata. This includes @oyvindln's change to Comb from #787 so the tests will pass (but the other change in #787 should rebase cleanly on top of this).

(Note that the output is still offset to the right when compared with ld-decode's output for both PAL and NTSC - this is because it's following SMPTE 244M/EBU Tech 3280 by having each line contain all the blanking samples, then all the active samples, whereas ld-decode starts each line with the sample immediately before 0H.)

CC @oyvindln and @ifb.