### PR TITLE
Optimize downscale including using numba

### DIFF
--- a/lddecode/utils.py
+++ b/lddecode/utils.py
@@ -995,10 +995,11 @@ def lev_to_db(rlev):
     return 20 * np.log10(rlev)
 
 
-# moved from core.py - this rescales analog audio output levels
 @njit(cache=True)
-def dsa_rescale(infloat):
-    return int(np.round(infloat * 32767.0 / 371081.0))
+def dsa_rescale_and_clip(infloat):
+    """rescales input value to output levels and clips to fit into signed 16-bit"""
+    value = int(np.round(infloat * 32767.0 / 371081.0))
+    return min(max(value, -32766), 32766)
 
 
 # Hotspot subroutines in FieldNTSC's compute_line_bursts function,


### PR DESCRIPTION
Informal test using timeit indicates it's like 100x faster (doing loops in python directly is VERY inefficient). It was one of the functions identified via the profiler.

Should give a small speedup on samples with analog audio.

was a little unsure about what some of the arrays represent so the function docs needs looking over

Also, noted that the 16-bit PCM values are limited to +/- 32766 rather than the typical -32,768 to 32,767, wasn't sure if this is intentional and maybe required by the format or if it's an oversight.