### PR TITLE
Add option to skip looking for qt6

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,10 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 # Options that can be specified with -D
 
 set(USE_QWT ON CACHE BOOL
-    "Use the Qwt library; if OFF, ld-analyse will not be built")
+  "Use the Qwt library; if OFF, ld-analyse will not be built")
+
+set(SEACH_QT5_ONLY OFF CACHE BOOL
+  "Only search for Qt5 (use e.g if qwt is not packaged for qt6 but both qt5 and qt6 are installed)")
 
 # Check for dependencies
 
@@ -20,7 +23,11 @@ set(CMAKE_AUTOMOC ON)
 include(GNUInstallDirs)
 set(CMAKE_AUTOUIC ON)
 
-find_package(QT NAMES Qt5 Qt6 REQUIRED COMPONENTS Core)
+if(SEARCH_QT5_ONLY)
+  find_package(QT NAMES Qt5 REQUIRED COMPONENTS Core)
+else()
+  find_package(QT NAMES Qt5 Qt6 REQUIRED COMPONENTS Core)
+endif()
 find_package(Qt${QT_VERSION_MAJOR} REQUIRED COMPONENTS Gui Widgets)
 message(STATUS "Qt Version: ${QT_VERSION}")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,11 +10,23 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 # Options that can be specified with -D
 
-set(USE_QWT ON CACHE BOOL
-  "Use the Qwt library; if OFF, ld-analyse will not be built")
+option(USE_QWT
+    "Use the Qwt library; if OFF, ld-analyse will not be built"
+    ON
+)
 
-set(SEACH_QT5_ONLY OFF CACHE BOOL
-  "Only search for Qt5 (use e.g if qwt is not packaged for qt6 but both qt5 and qt6 are installed)")
+#Not working on windows as of yet. The decoders are able to use ffmpeg binaries instead if needed.
+if(NOT $WIN32)
+  option(BUILD_LDF_READER
+    "build ld_ldf_reader"
+    ON
+  )
+endif()
+
+option(SEACRH_QT5_ONLY
+    "Only search for Qt5 (use e.g if qwt is not packaged for qt6 but both qt5 and qt6 are installed)"
+    OFF
+)
 
 # Check for dependencies
 
@@ -24,9 +36,9 @@ include(GNUInstallDirs)
 set(CMAKE_AUTOUIC ON)
 
 if(SEARCH_QT5_ONLY)
-  find_package(QT NAMES Qt5 REQUIRED COMPONENTS Core)
+    find_package(QT NAMES Qt5 REQUIRED COMPONENTS Core)
 else()
-  find_package(QT NAMES Qt5 Qt6 REQUIRED COMPONENTS Core)
+    find_package(QT NAMES Qt5 Qt6 REQUIRED COMPONENTS Core)
 endif()
 find_package(Qt${QT_VERSION_MAJOR} REQUIRED COMPONENTS Gui Widgets)
 message(STATUS "Qt Version: ${QT_VERSION}")
@@ -106,12 +118,14 @@ endif()
 
 # ld-ldf-reader
 
-add_executable(ld-ldf-reader
-    ld-ldf-reader.c)
+if(BUILD_LDF_READER)
+    add_executable(ld-ldf-reader
+      ld-ldf-reader.c)
 
-target_link_libraries(ld-ldf-reader PkgConfig::LIBAV)
+    target_link_libraries(ld-ldf-reader PkgConfig::LIBAV)
 
-install(TARGETS ld-ldf-reader)
+    install(TARGETS ld-ldf-reader)
+endif()
 
 # Python library and tools
 


### PR DESCRIPTION
This to avoid issues if both qt5 and qt6 is installed on ubuntu and similar, as there is no qwt package for qt6 in 22.04.

Also disable ld-ldf-reader on windows as it doesn't build there as of now (will probably also need some more tweaks to build the tools on windows with cmake but it's a start).