### PR TITLE
CMake support for Python installation

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,7 +32,7 @@ jobs:
 
     - name: Configure
       timeout-minutes: 5
-      run: cd obj && cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo ..
+      run: cd obj && cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo -DUSE_QT_VERSION=5 ..
 
     - name: Build
       timeout-minutes: 15
@@ -73,7 +73,7 @@ jobs:
 
     - name: Configure
       timeout-minutes: 5
-      run: cd obj && cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo -DUSE_QWT=OFF ..
+      run: cd obj && cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo -DUSE_QT_VERSION=6 -DUSE_QWT=OFF ..
 
     - name: Build
       timeout-minutes: 15

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,10 @@ option(USE_QWT
     ON
 )
 
+set(USE_QT_VERSION "" CACHE STRING
+    "Version of Qt to use (by default, try Qt 6 then Qt 5)"
+)
+
 # Not working on Windows as of yet. The decoders are able to use ffmpeg binaries instead if needed.
 if(NOT $WIN32)
     option(BUILD_LDF_READER
@@ -22,11 +26,6 @@ if(NOT $WIN32)
         ON
     )
 endif()
-
-option(SEARCH_QT5_ONLY
-    "Only search for Qt5 (use e.g if qwt is not packaged for qt6 but both qt5 and qt6 are installed)"
-    OFF
-)
 
 option(BUILD_PYTHON
     "Build and install ld-decode's Python library and tools"
@@ -40,11 +39,11 @@ set(CMAKE_AUTOMOC ON)
 include(GNUInstallDirs)
 set(CMAKE_AUTOUIC ON)
 
-if(SEARCH_QT5_ONLY)
-    find_package(QT NAMES Qt5 REQUIRED COMPONENTS Core)
-else()
-    find_package(QT NAMES Qt5 Qt6 REQUIRED COMPONENTS Core)
+set(QT_PACKAGE_NAMES Qt5 Qt6)
+if(USE_QT_VERSION)
+    set(QT_PACKAGE_NAMES Qt${USE_QT_VERSION})
 endif()
+find_package(QT NAMES ${QT_PACKAGE_NAMES} REQUIRED COMPONENTS Core)
 find_package(Qt${QT_VERSION_MAJOR} REQUIRED COMPONENTS Gui Widgets)
 message(STATUS "Qt Version: ${QT_VERSION}")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,11 @@ option(SEARCH_QT5_ONLY
     OFF
 )
 
+option(BUILD_PYTHON
+    "Build and install ld-decode's Python library and tools"
+    ON
+)
+
 # Check for dependencies
 
 # When using Qt 6.3, you can replace the code block below with qt_standard_project_setup()
@@ -129,22 +134,29 @@ endif()
 
 # Python library and tools
 
-find_package(Python3 3.6 REQUIRED COMPONENTS Interpreter)
+if(BUILD_PYTHON)
+    find_package(Python3 3.6 REQUIRED COMPONENTS Interpreter)
 
-set(OUTPUT ${CMAKE_CURRENT_BINARY_DIR})
-set(DEPS ${CMAKE_CURRENT_SOURCE_DIR}/lddecode/__init__.py)
+    set(PYTHON_BUILD_DIR ${CMAKE_CURRENT_BINARY_DIR}/python-build)
 
-if(0)
-    # XXX There must be a better way to do this!
-    # XXX This doesn't work when building in a separate object directory
-    add_custom_command(
-        OUTPUT ${OUTPUT}/timestamp
-        COMMAND ${PYTHON} ./setup.py build
-        COMMAND ${CMAKE_COMMAND} -E touch ${OUTPUT}/timestamp
-        DEPENDS ${DEPS}
+    add_custom_target(python-build ALL
+        COMMAND ${PYTHON} ./setup.py --quiet
+            build --build-base ${PYTHON_BUILD_DIR}
+        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
     )
 
-    add_custom_target(target ALL DEPENDS ${OUTPUT}/timestamp)
+    # We must run build/egg_info here to specify the directories.
+    install(CODE "
+        if(NOT DEFINED ENV{DESTDIR})
+            set(ENV{DESTDIR} /)
+        endif()
+        execute_process(
+            COMMAND ${PYTHON} ./setup.py --quiet
+                build --build-base ${PYTHON_BUILD_DIR}
+                egg_info --egg-base ${CMAKE_CURRENT_BINARY_DIR}
+                install --prefix ${CMAKE_INSTALL_PREFIX}
+                        --root \$ENV{DESTDIR}
+            WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+        )
+    ")
 endif()
-
-# XXX Install rule for Python

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,15 +15,15 @@ option(USE_QWT
     ON
 )
 
-#Not working on windows as of yet. The decoders are able to use ffmpeg binaries instead if needed.
+# Not working on Windows as of yet. The decoders are able to use ffmpeg binaries instead if needed.
 if(NOT $WIN32)
-  option(BUILD_LDF_READER
-    "build ld_ldf_reader"
-    ON
-  )
+    option(BUILD_LDF_READER
+        "build ld_ldf_reader"
+        ON
+    )
 endif()
 
-option(SEACRH_QT5_ONLY
+option(SEARCH_QT5_ONLY
     "Only search for Qt5 (use e.g if qwt is not packaged for qt6 but both qt5 and qt6 are installed)"
     OFF
 )

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python3
 
-from distutils.core import setup
+from setuptools import setup
 
 setup(
     name='ld-decode',


### PR DESCRIPTION
CMake now builds and installs the Python code in the same way that the old Makefile did, with some additional options to make it work with a separate object directory. This means it's now at parity with the old build system. As packagers may prefer to handle `setup.py` through their own Python mechanism, there's a `BUILD_PYTHON` option to skip this.

I've switched `setup.py` from distutils to setuptools. We tried this previously and it didn't work on older versions of Ubuntu. It's OK now, maybe because the CMake code is a bit more careful about always setting `DESTDIR` - setuptools interprets an empty `--root` as the current directory, which is wrong.

I've added a `USE_QT_VERSION` option, replacing `SEARCH_QT5_ONLY`, so that you can specify either version of Qt explicitly. The CI now uses this to avoid accidentally falling back to the wrong version.

CC @oyvindln.