### PR TITLE
EFM decoder performance improvements

### DIFF
--- a/tools/ld-process-efm/Datatypes/f3frame.cpp
+++ b/tools/ld-process-efm/Datatypes/f3frame.cpp
@@ -47,7 +47,7 @@ F3Frame::F3Frame()
     }
 }
 
-F3Frame::F3Frame(uchar *tValuesIn, qint32 tLength, bool audioIsDts)
+F3Frame::F3Frame(const uchar *tValuesIn, qint32 tLength, bool audioIsDts)
 {
     validEfmSymbols = 0;
     invalidEfmSymbols = 0;
@@ -61,7 +61,7 @@ F3Frame::F3Frame(uchar *tValuesIn, qint32 tLength, bool audioIsDts)
 }
 
 // This method sets the T-values for the F3 Frame
-void F3Frame::setTValues(uchar* tValuesIn, qint32 tLength, bool audioIsDts)
+void F3Frame::setTValues(const uchar *tValuesIn, qint32 tLength, bool audioIsDts)
 {
     // Does tValuesIn contain values?
     if (tLength == 0) {
@@ -236,7 +236,7 @@ qint16 F3Frame::translateEfm(qint16 efmValue)
 }
 
 // Method to get 'width' bits (max 15) from a byte array starting from bit 'bitIndex'
-inline qint16 F3Frame::getBits(uchar *rawData, qint16 bitIndex, qint16 width)
+inline qint16 F3Frame::getBits(const uchar *rawData, qint16 bitIndex, qint16 width)
 {
     qint16 byteIndex = bitIndex / 8;
     qint16 bitInByteIndex = 7 - (bitIndex % 8);

--- a/tools/ld-process-efm/Datatypes/f3frame.h
+++ b/tools/ld-process-efm/Datatypes/f3frame.h
@@ -33,9 +33,9 @@ class F3Frame
 {
 public:
     F3Frame();
-    F3Frame(uchar *tValuesIn, qint32 tLength, bool audioIsDts);
+    F3Frame(const uchar *tValuesIn, qint32 tLength, bool audioIsDts);
 
-    void setTValues(uchar *tValuesIn, qint32 tLength, bool audioIsDts);
+    void setTValues(const uchar *tValuesIn, qint32 tLength, bool audioIsDts);
     uchar* getDataSymbols();
     uchar* getErrorSymbols();
     uchar getSubcodeSymbol();
@@ -58,7 +58,7 @@ private:
     qint64 correctedEfmSymbols;
 
     qint16 translateEfm(qint16 efmValue);
-    qint16 getBits(uchar *rawData, qint16 bitIndex, qint16 width);
+    qint16 getBits(const uchar *rawData, qint16 bitIndex, qint16 width);
 };
 
 // The following table provides the 10-bit EFM code (padded with leading

--- a/tools/ld-process-efm/Datatypes/f3frame.h
+++ b/tools/ld-process-efm/Datatypes/f3frame.h
@@ -58,7 +58,6 @@ private:
     qint64 correctedEfmSymbols;
 
     qint16 translateEfm(qint16 efmValue);
-    qint16 getBits(const uchar *rawData, qint16 bitIndex, qint16 width);
 };
 
 // The following table provides the 10-bit EFM code (padded with leading


### PR DESCRIPTION
Two changes to `F3Frame` that together make ld-process-efm about 2.5x faster overall:

- Convert T-values directly into EFM symbols, rather than going bit-by-bit via an intermediate buffer. This also fixes a bug where it'd very occasionally write the final bit in the wrong place, so you get very slightly better results.
- Use a little hash table to convert EFM symbols into values, rather than a linear search. The hash function was found using [this script](https://github.com/atsampson/ld-decode-testsuite/blob/master/efm/efm-hash).