### PR TITLE
Speed up AC3 demodulator

### DIFF
--- a/tools/ld-process-ac3/decode/main.cpp
+++ b/tools/ld-process-ac3/decode/main.cpp
@@ -77,6 +77,9 @@ int main(int argc, char *argv[]) {
     std::ostream *output = &std::cout;
     Logger::LOG_STREAM = &std::cerr;
 
+    // Don't force a .flush() on cout when reading from cin
+    std::cin.tie(nullptr);
+
     // prep input file (if not piped)
     std::ifstream inputFile;
     if (memcmp(posArgv[0], "-\x00", 2) != 0) {

--- a/tools/ld-process-ac3/demodulate/Demodulator.hpp
+++ b/tools/ld-process-ac3/demodulate/Demodulator.hpp
@@ -28,50 +28,55 @@
 
 #include "Resampler.hpp"
 
+#include <algorithm>
 
 template<class DATA_SRC>
 struct Demodulator {
     static constexpr int compareIntervalSize = 16;
     static constexpr int cyclesPerSymbol = 10;
     static constexpr int samplesBetweenSymbols = compareIntervalSize * cyclesPerSymbol;
-    static constexpr short buffer_size = (compareIntervalSize + samplesBetweenSymbols + samplesPerCarrierCycle) * 2;
 
-    bool buffer[buffer_size]{};
-    short buffer_pos = 0;
+    static constexpr int buffer_size = 1024;
+    static constexpr int bufferPreload = samplesBetweenSymbols * 2;
+    static_assert(buffer_size > bufferPreload, "buffer_size too small");
+
+    int buffer[buffer_size];
+    int buffer_pos;
     DATA_SRC &source;
 
     explicit Demodulator(DATA_SRC &source) : source(source) {
-        for (bool &i: buffer)
-            i = source.next();
+        // Load bufferPreload samples into buffer
+        for (int i = 0; i < bufferPreload; i++)
+            buffer[i] = source.next();
+        buffer_pos = bufferPreload;
     }
-
-    // ~90% of runtime spent here
-    // __attribute__((optimize("unroll-loops")))
 
     // Votes on the value of a symbol from a window of samples
     char next() {
-        int votes[2]{0, 0};
         buffer[buffer_pos] = source.next();
-        buffer_pos = (buffer_pos + 1) % buffer_size;
 
-        for (int j = 0; j < compareIntervalSize; ++j) {
-            int ptmp = 320 - 1 + buffer_pos - j;
-            const int p0 = ptmp % buffer_size;
-            ptmp -= samplesBetweenSymbols;
-            const int p1 = (ptmp - +0) % buffer_size;
-            const int p2 = (ptmp - +4) % buffer_size;
-            const int p3 = (ptmp - +8) % buffer_size;
-            const int p4 = (ptmp - 12) % buffer_size;
-
-            auto d0 = buffer[p0];
-            votes[0] -= d0 ^ buffer[p1];
-            votes[1] -= d0 ^ buffer[p2];
-            votes[0] += d0 ^ buffer[p3];
-            votes[1] += d0 ^ buffer[p4];
+        int sums[4] {0, 0, 0, 0};
+        for (int ph = 0; ph < 4; ph++) {
+            const int phase = ph * (samplesPerCarrierCycle / 4);
+            int sum = 0;
+            for (int j = 0; j < compareIntervalSize; j++) {
+                sum += buffer[buffer_pos - j] ^ buffer[buffer_pos - j - samplesBetweenSymbols - phase];
+            }
+            sums[ph] = sum;
         }
-        int &a = votes[0], &b = votes[1];
 
-        char winner = (abs(a) > abs(b)) ? (a > 0 ? 0 : 3) : (b > 0 ? 1 : 2);
+        const int a = sums[2] - sums[0];
+        const int b = sums[3] - sums[1];
+        const char winner = (abs(a) > abs(b)) ? (a > 0 ? 0 : 3) : (b > 0 ? 1 : 2);
+
+        buffer_pos++;
+
+        // If the buffer is full, throw away all but the last bufferPreload samples
+        if (buffer_pos == buffer_size) {
+            std::copy(&buffer[buffer_size - bufferPreload], &buffer[buffer_size], buffer);
+            buffer_pos = bufferPreload;
+        }
+
         return winner;
     }
 };

--- a/tools/ld-process-ac3/demodulate/main.cpp
+++ b/tools/ld-process-ac3/demodulate/main.cpp
@@ -93,6 +93,9 @@ int main(int argc, char *argv[]) {
     std::ostream *output = &std::cout;
     Logger::LOG_STREAM = &std::cerr;
 
+    // Don't force a .flush() on cout when reading from cin
+    std::cin.tie(nullptr);
+
     // prep input file (if not piped)
     std::ifstream inputFile;
     if (memcmp(posArgv[0], "-\x00", 2) != 0) {


### PR DESCRIPTION
CC @LeightonSmallshire.

These changes to `Demodulator` make the program as a whole about five times faster with `-O3 -march=native` - here's the time taken for the original and the three commits on a 10s sample:
![Figure_1](https://user-images.githubusercontent.com/436317/196045086-5ab31e19-2c33-4235-a4fa-a81bb49f5dd0.png)

The bottleneck now is reading the contents of the buffer for each output bit - since the buffer's only 3 words there's not much that can be done to improve this within this code, but you could get around it by reworking `Reclocker` to accept multiple input bits at once...