### PR TITLE
Fix building with cmake on windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,7 @@ set(USE_QT_VERSION "" CACHE STRING
 )
 
 # Not working on Windows and macos as of yet. The decoders are able to use ffmpeg binaries instead if needed.
-if(LINUX)
+if((NOT WIN32) AND (NOT APPLE))
     option(BUILD_LDF_READER
         "build ld_ldf_reader"
         ON
@@ -64,13 +64,17 @@ endif()
 
 find_package(PkgConfig REQUIRED)
 if(USE_QWT)
-    find_package(Qwt REQUIRED)
+    # try pkg-config first
+    pkg_check_modules(QWT Qt${QT_VERSION_MAJOR}Qwt6)
+    if(QWT_FOUND)
+        # .....
+        set(QWT_INCLUDE_DIR ${QWT_INCLUDE_DIRS})
+        set(QWT_LIBRARY ${QWT_LIBRARIES})
+    else()
+        find_package(Qwt REQUIRED)
+    endif()
 endif()
-pkg_check_modules(LIBAV REQUIRED IMPORTED_TARGET
-    libavcodec
-    libavformat
-    libavutil
-)
+
 pkg_check_modules(FFTW REQUIRED IMPORTED_TARGET
     fftw3
 )
@@ -122,6 +126,12 @@ endif()
 # ld-ldf-reader
 
 if(BUILD_LDF_READER)
+    pkg_check_modules(LIBAV REQUIRED IMPORTED_TARGET
+        libavcodec
+        libavformat
+        libavutil
+    )
+
     add_executable(ld-ldf-reader
       ld-ldf-reader.c)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,7 @@ project(ld-decode-tools)
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake_modules")
 include(CTest)
 
+set(CMAKE_CXX_EXTENSIONS OFF)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
@@ -16,11 +17,11 @@ option(USE_QWT
 )
 
 set(USE_QT_VERSION "" CACHE STRING
-    "Version of Qt to use (by default, try Qt 6 then Qt 5)"
+    "Version of Qt to use, 5 or 6 (Which is used by default can vary due to how cmake find functions work, but will often default to Qt6)"
 )
 
-# Not working on Windows as of yet. The decoders are able to use ffmpeg binaries instead if needed.
-if(NOT $WIN32)
+# Not working on Windows and macos as of yet. The decoders are able to use ffmpeg binaries instead if needed.
+if(LINUX)
     option(BUILD_LDF_READER
         "build ld_ldf_reader"
         ON
@@ -63,9 +64,7 @@ endif()
 
 find_package(PkgConfig REQUIRED)
 if(USE_QWT)
-    pkg_check_modules(QWT REQUIRED IMPORTED_TARGET
-        Qt${QT_VERSION_MAJOR}Qwt6
-    )
+    find_package(Qwt REQUIRED)
 endif()
 pkg_check_modules(LIBAV REQUIRED IMPORTED_TARGET
     libavcodec

--- a/cmake_modules/COPYING-CMAKE-SCRIPTS_FINDQWT
+++ b/cmake_modules/COPYING-CMAKE-SCRIPTS_FINDQWT
@@ -1,0 +1,22 @@
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1. Redistributions of source code must retain the copyright
+   notice, this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
+3. The name of the author may not be used to endorse or promote products 
+   derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/cmake_modules/FindQwt.cmake
+++ b/cmake_modules/FindQwt.cmake
@@ -1,0 +1,57 @@
+# Find Qwt
+# ~~~~~~~~
+# Copyright (c) 2010, Tim Sutton <tim at linfiniti.com>
+# Redistribution and use is allowed according to the terms of the BSD license.
+# For details see the accompanying COPYING-CMAKE-SCRIPTS file.
+#
+# Once run this will define:
+#
+# QWT_FOUND       = system has QWT lib
+# QWT_LIBRARY     = full path to the QWT library
+# QWT_INCLUDE_DIR = where to find headers
+#
+
+
+set(QWT_LIBRARY_NAMES qwt-qt5 qwt6-qt5 qwt qwt6)
+
+find_library(QWT_LIBRARY
+  NAMES ${QWT_LIBRARY_NAMES}
+  PATHS
+    /usr/lib
+    /usr/local/lib
+    /usr/local/lib/qt5
+    "$ENV{LIB_DIR}/lib"
+    "$ENV{LIB}"
+)
+
+set(_qwt_fw)
+if(QWT_LIBRARY MATCHES "/qwt.*\\.framework")
+  string(REGEX REPLACE "^(.*/qwt.*\\.framework).*$" "\\1" _qwt_fw "${QWT_LIBRARY}")
+endif()
+
+FIND_PATH(QWT_INCLUDE_DIR NAMES qwt.h PATHS
+  "${_qwt_fw}/Headers"
+  /usr/include
+  /usr/include/qt5
+  /usr/local/include
+  /usr/local/include/qt5
+  "$ENV{LIB_DIR}/include"
+  "$ENV{INCLUDE}"
+  PATH_SUFFIXES qwt-qt5 qwt qwt6 qt5/qwt
+)
+
+IF (QWT_INCLUDE_DIR AND QWT_LIBRARY)
+  SET(QWT_FOUND TRUE)
+ENDIF (QWT_INCLUDE_DIR AND QWT_LIBRARY)
+
+IF (QWT_FOUND)
+  FILE(READ ${QWT_INCLUDE_DIR}/qwt_global.h qwt_header)
+  STRING(REGEX REPLACE "^.*QWT_VERSION_STR +\"([^\"]+)\".*$" "\\1" QWT_VERSION_STR "${qwt_header}")
+  IF (NOT QWT_FIND_QUIETLY)
+    MESSAGE(STATUS "Found Qwt: ${QWT_LIBRARY} (${QWT_VERSION_STR})")
+  ENDIF (NOT QWT_FIND_QUIETLY)
+ELSE (QWT_FOUND)
+  IF (QWT_FIND_REQUIRED)
+    MESSAGE(FATAL_ERROR "Could not find Qwt")
+  ENDIF (QWT_FIND_REQUIRED)
+ENDIF (QWT_FOUND)

--- a/tools/ld-analyse/CMakeLists.txt
+++ b/tools/ld-analyse/CMakeLists.txt
@@ -1,3 +1,6 @@
+# For M_PI constant
+add_compile_definitions(_USE_MATH_DEFINES)
+
 set(ld-analyse_SOURCES
     blacksnranalysisdialog.cpp blacksnranalysisdialog.ui
     busydialog.cpp busydialog.ui
@@ -22,9 +25,13 @@ qt_add_resources(ld-analyse_SOURCES ld-analyse-resources.qrc)
 add_executable(ld-analyse MACOSX_BUNDLE
     ${ld-analyse_SOURCES})
 
+target_include_directories(ld-analyse PRIVATE
+    ${QWT_INCLUDE_DIR}
+)
+
 target_link_libraries(ld-analyse PRIVATE
     Qt::Core Qt::Gui Qt::Widgets
-    PkgConfig::QWT
+    ${QWT_LIBRARY}
     lddecode-library lddecode-chroma
 )
 

--- a/tools/ld-chroma-decoder/CMakeLists.txt
+++ b/tools/ld-chroma-decoder/CMakeLists.txt
@@ -1,5 +1,8 @@
 # Library for chroma decoders
 
+# For M_PI constant
+add_compile_definitions(_USE_MATH_DEFINES)
+
 add_library(lddecode-chroma STATIC
     comb.cpp
     componentframe.cpp

--- a/tools/ld-chroma-decoder/encoder/CMakeLists.txt
+++ b/tools/ld-chroma-decoder/encoder/CMakeLists.txt
@@ -1,3 +1,7 @@
+# For M_PI constant
+add_compile_definitions(_USE_MATH_DEFINES)
+
+
 add_executable(ld-chroma-encoder
     main.cpp
     encoder.cpp


### PR DESCRIPTION
Neither qwt nor pkg-config seems to include a .pc file on windows, so this borrows a findQwt script from [QGis](https://github.com/qgis/QGIS/blob/master/cmake/FindQwt.cmake) to make handling it easier.

The other addition needed was to define ```_USE_MATH_DEFINES``` as ```M_PI``` is a non-standard extension and as such not available from ```<cmath>``` when compiling with MSVC otherwise. 

Now builds with cmake+msbuild on windows if the needed packages are installed via vcpkg and using the ms dev environment command line and vcpkg cmake toolchain file. 

ld-ldf-reader is still disabled for windows as it uses some linux/unix-specific functions, also disable it for macos as @kaliohelix on discord reported it didn't build properly there either.