### PR TITLE
Don't write invalid JSON when no valid burst is found

### DIFF
--- a/lddecode/core.py
+++ b/lddecode/core.py
@@ -2886,6 +2886,9 @@ class FieldPAL(Field):
             if lineburst is not None:
                 burstlevel.append(lineburst)
 
+        if burstlevel == []:
+            return 0.0
+
         return np.median(burstlevel) / self.rf.SysParams["hz_ire"]
 
     def get_following_field_number(self):

--- a/lddecode/utils.py
+++ b/lddecode/utils.py
@@ -1052,6 +1052,7 @@ def write_json(ldd, jsondict, outname):
     json.dump(
         jsondict,
         fp,
+        allow_nan=False,
         indent=4 if ldd.verboseVITS else None,
         separators=(",", ":") if not ldd.verboseVITS else None,
     )


### PR DESCRIPTION
On the SFTP, in `adamsampson/Faults/issue809`, there's the first few frames of [Easy Rider (LD10005)](https://www.lddb.com/laserdisc/35115/LD-10005/Easy-Rider) side 2.

Decoding this causes `FieldPAL.calc_burstmedian` to return NaN. This appears to be because the disc's mastered a bit hot - in the first field, all the lines trip the test for excessive burst amplitude in `get_burstlevel`.

The NaN eventually gets written to `burstMedianIre` in the JSON file... but Python's `json.dump` writes it as `NaN`, which isn't permitted by the JSON spec.

These two commits pass `allow_nan=False` to `json.dump`, and fix the test in `calc_burstmedian` so it returns 0 when no burst is found. It might be worth looking at the `get_burstlevel` heuristic to see if there's a better way of handling discs like this, though?