### PR TITLE
Add fftw3 to ld-chroma-decoder include directories.

### DIFF
--- a/tools/ld-chroma-decoder/CMakeLists.txt
+++ b/tools/ld-chroma-decoder/CMakeLists.txt
@@ -30,6 +30,8 @@ add_executable(ld-chroma-decoder
     paldecoder.cpp
 )
 
+target_include_directories(ld-chroma-decoder PRIVATE ${FFTW_INCLUDE_DIRS})
+
 target_link_libraries(ld-chroma-decoder PRIVATE Qt::Core lddecode-library lddecode-chroma)
 
 install(TARGETS ld-chroma-decoder)


### PR DESCRIPTION
ld-chroma-decoder's headers eventually require `fftw3.h`. In OS/compiler toolchains where 3rd party libraries are installed in the default system include dirs, this bug isn't as obvious. In systems like macOS where system includes are typically left untouched, the build fails:
```
% cd tools/ld-chroma-decoder && make
[  4%] Automatic MOC and UIC for target lddecode-library
[  4%] Built target lddecode-library_autogen
[ 33%] Built target lddecode-library
[ 38%] Automatic MOC and UIC for target lddecode-chroma
[ 38%] Built target lddecode-chroma_autogen
[ 42%] Building CXX object tools/ld-chroma-decoder/CMakeFiles/lddecode-chroma.dir/lddecode-chroma_autogen/mocs_compilation.cpp.o
[ 42%] Building CXX object tools/ld-chroma-decoder/CMakeFiles/lddecode-chroma.dir/comb.cpp.o
[ 47%] Building CXX object tools/ld-chroma-decoder/CMakeFiles/lddecode-chroma.dir/componentframe.cpp.o
[ 47%] Building CXX object tools/ld-chroma-decoder/CMakeFiles/lddecode-chroma.dir/framecanvas.cpp.o
[ 52%] Building CXX object tools/ld-chroma-decoder/CMakeFiles/lddecode-chroma.dir/outputwriter.cpp.o
[ 57%] Building CXX object tools/ld-chroma-decoder/CMakeFiles/lddecode-chroma.dir/palcolour.cpp.o
[ 57%] Building CXX object tools/ld-chroma-decoder/CMakeFiles/lddecode-chroma.dir/sourcefield.cpp.o
[ 61%] Building CXX object tools/ld-chroma-decoder/CMakeFiles/lddecode-chroma.dir/transformpal.cpp.o
[ 66%] Building CXX object tools/ld-chroma-decoder/CMakeFiles/lddecode-chroma.dir/transformpal2d.cpp.o
[ 66%] Building CXX object tools/ld-chroma-decoder/CMakeFiles/lddecode-chroma.dir/transformpal3d.cpp.o
[ 71%] Linking CXX static library liblddecode-chroma.a
/Library/Developer/CommandLineTools/usr/bin/ranlib: file: liblddecode-chroma.a(mocs_compilation.cpp.o) has no symbols
/Library/Developer/CommandLineTools/usr/bin/ranlib: file: liblddecode-chroma.a(mocs_compilation.cpp.o) has no symbols
[ 71%] Built target lddecode-chroma
[ 71%] Automatic MOC and UIC for target ld-chroma-decoder
[ 71%] Built target ld-chroma-decoder_autogen
[ 76%] Building CXX object tools/ld-chroma-decoder/CMakeFiles/ld-chroma-decoder.dir/ld-chroma-decoder_autogen/mocs_compilation.cpp.o
In file included from ~/Repos/ld-decode/tools/ld-chroma-decoder/ld-chroma-decoder_autogen/mocs_compilation.cpp:5:
In file included from ~/Repos/ld-decode/tools/ld-chroma-decoder/ld-chroma-decoder_autogen/EWIEGA46WW/moc_paldecoder.cpp:10:
In file included from ~/Repos/ld-decode/tools/ld-chroma-decoder/ld-chroma-decoder_autogen/EWIEGA46WW/../../paldecoder.h:39:
In file included from ~/Repos/ld-decode/tools/ld-chroma-decoder/palcolour.h:40:
/Users/jarthur/Repos/ld-decode/tools/ld-chroma-decoder/transformpal.h:32:10: fatal error: 'fftw3.h' file not found
#include <fftw3.h>
         ^~~~~~~~~
1 error generated.
make[2]: *** [tools/ld-chroma-decoder/CMakeFiles/ld-chroma-decoder.dir/ld-chroma-decoder_autogen/mocs_compilation.cpp.o] Error 1
make[1]: *** [tools/ld-chroma-decoder/CMakeFiles/ld-chroma-decoder.dir/all] Error 2
make: *** [all] Error 2
```