### PR TITLE
Add YCbCr input support to ld-chroma-encoder

### DIFF
--- a/cmake_modules/LdDecodeTests.cmake
+++ b/cmake_modules/LdDecodeTests.cmake
@@ -9,7 +9,7 @@ set(SCRIPTS_DIR ${CMAKE_SOURCE_DIR}/scripts)
 set(TESTDATA_DIR ${CMAKE_SOURCE_DIR}/testdata)
 
 add_test(
-    NAME chroma-ntsc
+    NAME chroma-ntsc-rgb
     COMMAND ${SCRIPTS_DIR}/test-chroma
         --build ${CMAKE_BINARY_DIR}
         --system ntsc
@@ -18,12 +18,32 @@ add_test(
 )
 
 add_test(
-    NAME chroma-pal
+    NAME chroma-ntsc-ycbcr
+    COMMAND ${SCRIPTS_DIR}/test-chroma
+        --build ${CMAKE_BINARY_DIR}
+        --system ntsc
+        --expect-psnr 25
+        --expect-psnr-range 0.5
+        --input-format yuv
+)
+
+add_test(
+    NAME chroma-pal-rgb
     COMMAND ${SCRIPTS_DIR}/test-chroma
         --build ${CMAKE_BINARY_DIR}
         --system pal
         --expect-psnr 25
         --expect-psnr-range 0.5
+)
+
+add_test(
+    NAME chroma-pal-ycbcr
+    COMMAND ${SCRIPTS_DIR}/test-chroma
+        --build ${CMAKE_BINARY_DIR}
+        --system pal
+        --expect-psnr 25
+        --expect-psnr-range 0.5
+        --input-format yuv
 )
 
 add_test(

--- a/scripts/test-chroma
+++ b/scripts/test-chroma
@@ -55,11 +55,19 @@ def clean(args, suffixes):
 
 FFMPEG_CMD = ['ffmpeg', '-loglevel', 'error']
 RGB_FORMAT = ['-f', 'rawvideo', '-pix_fmt', 'rgb48']
+YUV_FORMAT = ['-f', 'rawvideo', '-pix_fmt', 'yuv444p16']
 
 def test_encode(args, source, sc_locked, png_suffix):
-    """Generate a test video in .rgb form, and encode it to .tbc."""
+    """Generate a test video in .rgb/.yuv form, and encode it to .tbc."""
 
-    clean(args, ['.rgb', png_suffix, '.tbc'])
+    if args.input_format == 'yuv':
+        suffix = '.yuv'
+        PIX_FORMAT = YUV_FORMAT
+    else:
+        suffix = '.rgb'
+        PIX_FORMAT = RGB_FORMAT
+
+    clean(args, [suffix, png_suffix, '.tbc'])
 
     if args.system == 'ntsc':
         FILTER_ARGS = ['-filter:v', 'pad=758:486:-1:-1']
@@ -68,37 +76,38 @@ def test_encode(args, source, sc_locked, png_suffix):
         FILTER_ARGS = ['-filter:v', 'pad=928:576:-1:-1']
         SIZE_ARGS   = ['-s', '928x576', '-r', 'pal']
 
-    # Convert the source video to .rgb using ffmpeg
-    rgb_file = args.output + '.rgb'
+    # Convert the source video to .rgb/.yuv using ffmpeg
+    converted_file = args.output + suffix
     subprocess.check_call(
         FFMPEG_CMD
         + source
         + FILTER_ARGS
         + SIZE_ARGS
-        + RGB_FORMAT + [rgb_file]
+        + PIX_FORMAT + [converted_file]
         )
     if args.png:
-        # Convert .rgb to PNG
+        # Convert .rgb/.yuv to PNG
         subprocess.check_call(
             FFMPEG_CMD
-            + RGB_FORMAT
             + SIZE_ARGS
-            + ['-i', rgb_file]
+            + PIX_FORMAT
+            + ['-i', converted_file]
             + ['-frames:v', '1', args.output + png_suffix]
             )
 
     # Encode the .rgb to .tbc, using ld-chroma-encoder
     tbc_file = args.output + '.tbc'
     cmd = [build_dir + '/tools/ld-chroma-decoder/encoder/ld-chroma-encoder']
+    cmd += ['--input-format', args.input_format]
     if sc_locked:
         cmd += ['--sc-locked']
     if args.system == 'ntsc':
         cmd += ['--system', 'ntsc']
-    cmd += [rgb_file, tbc_file]
+    cmd += [converted_file, tbc_file]
     subprocess.check_call(cmd)
 
 def test_decode(args, decoder, phase_locked, output_format, png_suffix):
-    """Decode a .tbc file, compare it with the original .rgb, and return the
+    """Decode a .tbc file, compare it with the original .rgb/.yuv, and return the
     median pSNR."""
 
     clean(args, ['.decoded', '.psnr', png_suffix])
@@ -144,15 +153,29 @@ def test_decode(args, decoder, phase_locked, output_format, png_suffix):
             + ['-frames:v', '1', args.output + png_suffix]
             )
 
-    # Compare the video from the pipe to the original .rgb using ffmpeg
-    rgb_file = args.output + '.rgb'
+    if args.input_format == 'yuv':
+        suffix = '.yuv'
+        PIX_FORMAT = YUV_FORMAT
+        lavf_format = 'yuv444p16'
+    else:
+        suffix = '.rgb'
+        PIX_FORMAT = RGB_FORMAT
+        lavf_format = 'rgb48'
+
+    if args.system == 'ntsc':
+        SIZE_ARGS = ['-s', '758x486']
+    else:
+        SIZE_ARGS = ['-s', '928x576']
+
+    # Compare the video from the pipe to the original .rgb/.yuv using ffmpeg
+    ref_file = args.output + suffix
     psnr_file = args.output + '.psnr'
     subprocess.check_call(
         FFMPEG_CMD
         + decoded_format + ['-i', decoded_file]
-        + RGB_FORMAT + ['-i', rgb_file]
-        + ['-lavfi', '[0:v] format=pix_fmts=rgb48, split [rgb];'
-                     '[rgb][1:v] psnr=stats_file=%s' % psnr_file,
+        + PIX_FORMAT + SIZE_ARGS + ['-i', ref_file]
+        + ['-lavfi', '[0:v] format=pix_fmts=%s, split [decoded];'
+                     '[decoded][1:v] psnr=stats_file=%s' % (lavf_format, psnr_file),
            '-f', 'null', '-']
         )
 
@@ -173,6 +196,8 @@ def main():
                        help='input video file (default colour bars)')
     group.add_argument('output', metavar='output', nargs='?', default='testout/test',
                        help='base name for output files (default testout/test)')
+    group.add_argument('--input-format', choices=['rgb', 'yuv'], default='rgb',
+                       help='input format is RGB48 or YUV444P16')
     group.add_argument('--build', metavar='DIR',
                        help='build tree to test (default same as this script)')
     group.add_argument('--system', choices=['pal', 'ntsc'], default='pal',

--- a/tools/ld-chroma-decoder/encoder/encoder.cpp
+++ b/tools/ld-chroma-decoder/encoder/encoder.cpp
@@ -48,8 +48,10 @@
 
 #include "encoder.h"
 
-Encoder::Encoder(QFile &_rgbFile, QFile &_tbcFile, QFile &_chromaFile, LdDecodeMetaData &_metaData, int _fieldOffset)
-    : rgbFile(_rgbFile), tbcFile(_tbcFile), chromaFile(_chromaFile), metaData(_metaData), fieldOffset(_fieldOffset)
+Encoder::Encoder(QFile &_inputFile, QFile &_tbcFile, QFile &_chromaFile, LdDecodeMetaData &_metaData,
+                 int _fieldOffset, bool _isComponent)
+    : inputFile(_inputFile), tbcFile(_tbcFile), chromaFile(_chromaFile), metaData(_metaData),
+      fieldOffset(_fieldOffset), isComponent(_isComponent)
 {
 }
 
@@ -78,11 +80,11 @@ bool Encoder::encode()
 qint32 Encoder::encodeFrame(qint32 frameNo)
 {
     // Read the input frame
-    qint64 remainBytes = rgbFrame.size();
+    qint64 remainBytes = inputFrame.size();
     qint64 posBytes = 0;
     while (remainBytes > 0) {
-        qint64 count = rgbFile.read(rgbFrame.data() + posBytes, remainBytes);
-        if (count == 0 && remainBytes == rgbFrame.size()) {
+        qint64 count = inputFile.read(inputFrame.data() + posBytes, remainBytes);
+        if (count == 0 && remainBytes == inputFrame.size()) {
             // EOF at the start of a frame
             return 0;
         } else if (count == 0) {
@@ -109,7 +111,7 @@ qint32 Encoder::encodeFrame(qint32 frameNo)
     return 1;
 }
 
-// Encode one field from rgbFrame to the output.
+// Encode one field from inputFrame to the output.
 // Returns true on success; on failure, prints an error and returns false.
 bool Encoder::encodeField(qint32 fieldNo)
 {
@@ -129,11 +131,15 @@ bool Encoder::encodeField(qint32 fieldNo)
         }
 
         // Encode the line
-        const quint16 *rgbData = nullptr;
+        const quint16 *inputData = nullptr;
         if (frameLine >= activeTop && frameLine < (activeTop + activeHeight)) {
-            rgbData = reinterpret_cast<const quint16 *>(rgbFrame.data()) + ((frameLine - activeTop) * activeWidth * 3);
+            if (isComponent) {
+                inputData = reinterpret_cast<const quint16 *>(inputFrame.data()) + ((frameLine - activeTop) * activeWidth);
+            } else {
+                inputData = reinterpret_cast<const quint16 *>(inputFrame.data()) + ((frameLine - activeTop) * activeWidth * 3);
+            }
         }
-        encodeLine(fieldNo, frameLine, rgbData, outputC, outputVBS);
+        encodeLine(fieldNo, frameLine, inputData, outputC, outputVBS);
 
         if (chromaFile.isOpen()) {
             // Write C and VBS to separate output files

--- a/tools/ld-chroma-decoder/encoder/encoder.cpp
+++ b/tools/ld-chroma-decoder/encoder/encoder.cpp
@@ -48,8 +48,8 @@
 
 #include "encoder.h"
 
-Encoder::Encoder(QFile &_rgbFile, QFile &_tbcFile, QFile &_chromaFile, LdDecodeMetaData &_metaData)
-    : rgbFile(_rgbFile), tbcFile(_tbcFile), chromaFile(_chromaFile), metaData(_metaData)
+Encoder::Encoder(QFile &_rgbFile, QFile &_tbcFile, QFile &_chromaFile, LdDecodeMetaData &_metaData, int _fieldOffset)
+    : rgbFile(_rgbFile), tbcFile(_tbcFile), chromaFile(_chromaFile), metaData(_metaData), fieldOffset(_fieldOffset)
 {
 }
 

--- a/tools/ld-chroma-decoder/encoder/encoder.h
+++ b/tools/ld-chroma-decoder/encoder/encoder.h
@@ -40,7 +40,7 @@ public:
     // This only sets the member variables it takes as parameters; subclasses
     // must initialise the VideoParameters, compute the active region and
     // resize rgbFrame.
-    Encoder(QFile &rgbFile, QFile &tbcFile, QFile &chromaFile, LdDecodeMetaData &metaData);
+    Encoder(QFile &rgbFile, QFile &tbcFile, QFile &chromaFile, LdDecodeMetaData &metaData, int fieldOffset);
 
     // Encode RGB stream to TBC.
     // Returns true on success; on failure, prints an error and returns false.
@@ -67,6 +67,7 @@ protected:
     QFile &tbcFile;
     QFile &chromaFile;
     LdDecodeMetaData &metaData;
+    int fieldOffset;
 
     LdDecodeMetaData::VideoParameters videoParameters;
     qint32 activeWidth;

--- a/tools/ld-chroma-decoder/encoder/main.cpp
+++ b/tools/ld-chroma-decoder/encoder/main.cpp
@@ -156,7 +156,6 @@ int main(int argc, char *argv[])
             qCritical("Unsupported chroma encoder mode");
             return -1;
         }
-
     }
 
     const bool scLocked = parser.isSet(scLockedOption);

--- a/tools/ld-chroma-decoder/encoder/main.cpp
+++ b/tools/ld-chroma-decoder/encoder/main.cpp
@@ -70,6 +70,12 @@ int main(int argc, char *argv[])
                                     QCoreApplication::translate("main", "system"));
     parser.addOption(systemOption);
 
+    // Option to select the input format (-p)
+    QCommandLineOption inputFormatOption(QStringList() << "p" << "input-format",
+                                       QCoreApplication::translate("main", "Input format (rgb, yuv; default rgb); RGB48, YUV444P16 formats are supported"),
+                                       QCoreApplication::translate("main", "input-format"));
+    parser.addOption(inputFormatOption);
+
     // Option to specify where to start in the field sequence (--field-offset)
     QCommandLineOption fieldOffsetOption(QStringList() << "field-offset",
                                          QCoreApplication::translate("main", "Offset of the first output field within the field sequence (0, 2 for NTSC; 0, 2, 4, 6 for PAL; default: 0)"),
@@ -141,6 +147,23 @@ int main(int argc, char *argv[])
 
     bool addSetup = !parser.isSet(setupOption);
 
+    // Select the input format
+    bool isComponent = false;
+    QString inputFormatName;
+    if (parser.isSet(inputFormatOption)) {
+        inputFormatName = parser.value(inputFormatOption);
+    } else {
+        inputFormatName = "rgb";
+    }
+    if (inputFormatName == "yuv") {
+        isComponent = true;
+    } else if (inputFormatName == "rgb") {
+        isComponent = false;
+    } else {
+        qCritical() << "Unknown input format" << inputFormatName;
+        return -1;
+    }
+
     ChromaMode chromaMode = WIDEBAND_YUV;
     QString chromaName;
     if (parser.isSet(chromaOption)) {
@@ -173,7 +196,7 @@ int main(int argc, char *argv[])
         }
     } else {
         // Quit with error
-        qCritical("You must specify the input RGB and output TBC files");
+        qCritical("You must specify the input RGB/YCbCr and output TBC files");
         return -1;
     }
 
@@ -184,14 +207,14 @@ int main(int argc, char *argv[])
     }
 
     // Open the input file
-    QFile rgbFile(inputFileName);
+    QFile inputFile(inputFileName);
     if (inputFileName == "-") {
-        if (!rgbFile.open(stdin, QFile::ReadOnly)) {
+        if (!inputFile.open(stdin, QFile::ReadOnly)) {
             qCritical("Cannot open stdin");
             return -1;
         }
     } else {
-        if (!rgbFile.open(QFile::ReadOnly)) {
+        if (!inputFile.open(QFile::ReadOnly)) {
             qCritical() << "Cannot open input file:" << inputFileName;
             return -1;
         }
@@ -214,12 +237,12 @@ int main(int argc, char *argv[])
     // Encode the data
     LdDecodeMetaData metaData;
     if (system == NTSC) {
-        NTSCEncoder encoder(rgbFile, tbcFile, chromaFile, metaData, fieldOffset, chromaMode, addSetup);
+        NTSCEncoder encoder(inputFile, tbcFile, chromaFile, metaData, fieldOffset, isComponent, chromaMode, addSetup);
         if (!encoder.encode()) {
             return -1;
         }
     } else {
-        PALEncoder encoder(rgbFile, tbcFile, chromaFile, metaData, fieldOffset, scLocked);
+        PALEncoder encoder(inputFile, tbcFile, chromaFile, metaData, fieldOffset, isComponent, scLocked);
         if (!encoder.encode()) {
             return -1;
         }

--- a/tools/ld-chroma-decoder/encoder/ntscencoder.cpp
+++ b/tools/ld-chroma-decoder/encoder/ntscencoder.cpp
@@ -42,8 +42,8 @@
 
 NTSCEncoder::NTSCEncoder(QFile &_rgbFile, QFile &_tbcFile, QFile &_chromaFile, LdDecodeMetaData &_metaData,
                          int _fieldOffset, ChromaMode _chromaMode, bool _addSetup)
-    : Encoder(_rgbFile, _tbcFile, _chromaFile, _metaData),
-      fieldOffset(_fieldOffset), chromaMode(_chromaMode), addSetup(_addSetup)
+    : Encoder(_rgbFile, _tbcFile, _chromaFile, _metaData, _fieldOffset),
+      chromaMode(_chromaMode), addSetup(_addSetup)
 {
     // NTSC subcarrier frequency [Poynton p511]
     videoParameters.fSC = 315.0e6 / 88.0;

--- a/tools/ld-chroma-decoder/encoder/ntscencoder.h
+++ b/tools/ld-chroma-decoder/encoder/ntscencoder.h
@@ -42,12 +42,12 @@ enum ChromaMode {
 class NTSCEncoder : public Encoder
 {
 public:
-    NTSCEncoder(QFile &rgbFile, QFile &tbcFile, QFile &chromaFile, LdDecodeMetaData &metaData,
-                int fieldOffset, ChromaMode chromaMode, bool addSetup);
+    NTSCEncoder(QFile &inputFile, QFile &tbcFile, QFile &chromaFile, LdDecodeMetaData &metaData,
+                int fieldOffset, bool isComponent, ChromaMode chromaMode, bool addSetup);
 
 protected:
     virtual void getFieldMetadata(qint32 fieldNo, LdDecodeMetaData::Field &fieldData);
-    virtual void encodeLine(qint32 fieldNo, qint32 frameLine, const quint16 *rgbData,
+    virtual void encodeLine(qint32 fieldNo, qint32 frameLine, const quint16 *inputData,
                             std::vector<double> &outputC, std::vector<double> &outputVBS);
 
     const qint32 blankingIre = 0x3C00;

--- a/tools/ld-chroma-decoder/encoder/ntscencoder.h
+++ b/tools/ld-chroma-decoder/encoder/ntscencoder.h
@@ -53,7 +53,6 @@ protected:
     const qint32 blankingIre = 0x3C00;
     const qint32 setupIreOffset = 0x0A80; // 10.5 * 256
 
-    int fieldOffset;
     ChromaMode chromaMode;
     bool addSetup;
 

--- a/tools/ld-chroma-decoder/encoder/palencoder.cpp
+++ b/tools/ld-chroma-decoder/encoder/palencoder.cpp
@@ -41,7 +41,7 @@
 
 PALEncoder::PALEncoder(QFile &_rgbFile, QFile &_tbcFile, QFile &_chromaFile, LdDecodeMetaData &_metaData,
                        int _fieldOffset, bool _scLocked)
-    : Encoder(_rgbFile, _tbcFile, _chromaFile, _metaData), fieldOffset(_fieldOffset), scLocked(_scLocked)
+    : Encoder(_rgbFile, _tbcFile, _chromaFile, _metaData, _fieldOffset), scLocked(_scLocked)
 {
     // PAL subcarrier frequency [Poynton p529] [EBU p5]
     videoParameters.fSC = 4433618.75;

--- a/tools/ld-chroma-decoder/encoder/palencoder.h
+++ b/tools/ld-chroma-decoder/encoder/palencoder.h
@@ -35,12 +35,12 @@
 class PALEncoder : public Encoder
 {
 public:
-    PALEncoder(QFile &rgbFile, QFile &tbcFile, QFile &chromaFile, LdDecodeMetaData &metaData,
-               int fieldOffset, bool scLocked);
+    PALEncoder(QFile &inputFile, QFile &tbcFile, QFile &chromaFile, LdDecodeMetaData &metaData,
+               int fieldOffset, bool isComponent, bool scLocked);
 
 private:
     virtual void getFieldMetadata(qint32 fieldNo, LdDecodeMetaData::Field &fieldData);
-    virtual void encodeLine(qint32 fieldNo, qint32 frameLine, const quint16 *rgbData,
+    virtual void encodeLine(qint32 fieldNo, qint32 frameLine, const quint16 *inputData,
                             std::vector<double> &outputC, std::vector<double> &outputVBS);
 
     bool scLocked;

--- a/tools/ld-chroma-decoder/encoder/palencoder.h
+++ b/tools/ld-chroma-decoder/encoder/palencoder.h
@@ -43,7 +43,6 @@ private:
     virtual void encodeLine(qint32 fieldNo, qint32 frameLine, const quint16 *rgbData,
                             std::vector<double> &outputC, std::vector<double> &outputVBS);
 
-    int fieldOffset;
     bool scLocked;
 
     std::vector<double> Y;


### PR DESCRIPTION
Adds the -p/--input-format options.  Below-black (pluge) patterns are possible now.

There's about a 6 dB bump in PSNR for YUV which makes me distrust the test a bit.  The difference is visible, though.

NTSC bars line 420    https://imgsli.com/MTM0NjYx
NTSC bars vectorscope https://imgsli.com/MTM0NjYy
mobcal frame 3        https://imgsli.com/MTM0NjU2

```
../scripts/test-chroma --build ./ --system ntsc  ../mobcal.y4m --input-format yuv
Phase-Comp (Dec)   Decoder         Format   PSNR (dB)
False              ntsc1d          rgb         24.54
False              ntsc1d          yuv         24.19
False              ntsc1d          y4m         24.19
False              ntsc2d          rgb         29.20
False              ntsc2d          yuv         29.00
False              ntsc2d          y4m         29.00
False              ntsc3d          rgb         29.99
False              ntsc3d          yuv         29.78
False              ntsc3d          y4m         29.78
True               ntsc1d          rgb         24.36
True               ntsc1d          yuv         23.97
True               ntsc1d          y4m         23.97
True               ntsc2d          rgb         28.87
True               ntsc2d          yuv         28.64
True               ntsc2d          y4m         28.64
True               ntsc3d          rgb         29.61
True               ntsc3d          yuv         29.39
True               ntsc3d          y4m         29.39

../scripts/test-chroma --build ./ --system ntsc  ../mobcal.y4m --input-format rgb
Phase-Comp (Dec)   Decoder         Format   PSNR (dB)
False              ntsc1d          rgb         18.73
False              ntsc1d          yuv         18.73
False              ntsc1d          y4m         18.73
False              ntsc2d          rgb         23.38
False              ntsc2d          yuv         23.37
False              ntsc2d          y4m         23.37
False              ntsc3d          rgb         23.99
False              ntsc3d          yuv         23.99
False              ntsc3d          y4m         23.99
True               ntsc1d          rgb         18.56
True               ntsc1d          yuv         18.56
True               ntsc1d          y4m         18.56
True               ntsc2d          rgb         23.09
True               ntsc2d          yuv         23.08
True               ntsc2d          y4m         23.08
True               ntsc3d          rgb         23.68
True               ntsc3d          yuv         23.67
True               ntsc3d          y4m         23.67
```