### PR TITLE
Patches for macOS 13 (Ventura)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,8 +20,8 @@ set(USE_QT_VERSION "" CACHE STRING
     "Version of Qt to use, 5 or 6 (Which is used by default can vary due to how cmake find functions work, but will often default to Qt6)"
 )
 
-# Not working on Windows and macos as of yet. The decoders are able to use ffmpeg binaries instead if needed.
-if((NOT WIN32) AND (NOT APPLE))
+# Not working on Windows as of yet. The decoders are able to use ffmpeg binaries instead if needed.
+if(NOT WIN32)
     option(BUILD_LDF_READER
         "build ld_ldf_reader"
         ON

--- a/tools/ld-analyse/CMakeLists.txt
+++ b/tools/ld-analyse/CMakeLists.txt
@@ -42,4 +42,7 @@ if(WIN32)
     )
 endif()
 
-install(TARGETS ld-analyse)
+install(
+        TARGETS ld-analyse
+        BUNDLE DESTINATION bin
+)

--- a/tools/ld-process-ac3/logger.hpp
+++ b/tools/ld-process-ac3/logger.hpp
@@ -31,7 +31,9 @@
 #include <iomanip>
 #include <chrono>
 #include <map>
-
+#ifdef __APPLE__
+#include <sstream>
+#endif
 
 enum LogLevel {
     DEBU = 0,


### PR DESCRIPTION
- Patch up CMake such that it allows macOS to properly compile everything via "cmake .".
- Add a required #include that seems to be required for Xcode 14 (and maybe 13?).

Note that, while this works on my system, either a macOS README file or a wiki update is recommended in order for users to understand the exact requirements (mostly Linux with some minor tweaks).