### PR TITLE
Fix pcmAudioField map contents and access

### DIFF
--- a/tools/library/tbc/lddecodemetadata.cpp
+++ b/tools/library/tbc/lddecodemetadata.cpp
@@ -1080,12 +1080,14 @@ void LdDecodeMetaData::generatePcmAudioMap()
 qint32 LdDecodeMetaData::getFieldPcmAudioStart(qint32 sequentialFieldNumber)
 {
     if (pcmAudioFieldStartSampleMap.size() < sequentialFieldNumber) return -1;
-    return pcmAudioFieldStartSampleMap[sequentialFieldNumber];
+    // Field numbers are 1 indexed, but our map is 0 indexed
+    return pcmAudioFieldStartSampleMap[sequentialFieldNumber - 1];
 }
 
 // Method to get the sample length of the specified sequential field number
 qint32 LdDecodeMetaData::getFieldPcmAudioLength(qint32 sequentialFieldNumber)
 {
     if (pcmAudioFieldLengthMap.size() < sequentialFieldNumber) return -1;
-    return pcmAudioFieldLengthMap[sequentialFieldNumber];
+    // Field numbers are 1 indexed, but our map is 0 indexed
+    return pcmAudioFieldLengthMap[sequentialFieldNumber - 1];
 }

--- a/tools/library/tbc/lddecodemetadata.cpp
+++ b/tools/library/tbc/lddecodemetadata.cpp
@@ -1071,7 +1071,7 @@ void LdDecodeMetaData::generatePcmAudioMap()
             pcmAudioFieldStartSampleMap[fieldNo] = 0;
         } else {
             // Every following field's start position is the start+length of the previous
-            pcmAudioFieldStartSampleMap[fieldNo] = pcmAudioFieldStartSampleMap[fieldNo - 1] + pcmAudioFieldLengthMap[fieldNo];
+            pcmAudioFieldStartSampleMap[fieldNo] = pcmAudioFieldStartSampleMap[fieldNo - 1] + pcmAudioFieldLengthMap[fieldNo - 1];
         }
     }
 }

--- a/tools/library/tbc/sourceaudio.cpp
+++ b/tools/library/tbc/sourceaudio.cpp
@@ -116,19 +116,19 @@ SourceAudio::Data SourceAudio::getAudioData(qint32 startSample, qint32 numberOfS
     for (qint32 sample = 0; sample < numberOfSamples; sample++) {
         // Left 16 bit sample
         audioData >> x;
+        sampleData.append(x);
         if (audioData.atEnd()) {
-            qFatal("getAudioData hit premature end of file!");
+            qWarning("getAudioData hit end of file!");
             return sampleData;
         }
-        sampleData.append(x);
 
         // Right 16 bit sample
         audioData >> x;
+        sampleData.append(x);
         if (audioData.atEnd()) {
-            qFatal("getAudioData hit premature end of file!");
+            qWarning("getAudioData hit end of file!");
             return sampleData;
         }
-        sampleData.append(x);
     }
 
     return sampleData;


### PR DESCRIPTION
As the existing comment notes, the previous field's start and length should be used to determine the current field's start. Otherwise we may use the wrong offset.

Furthermore the maps for start and length are 0 indexed, but input sequential frame numbers are 1 indexed and should be corrected.

With the map correction it is also now possible for ld-discmap to actually try to read the last field's audio data, which is likely to be the end of the pcm file. Attempting to read the pcm input file completely would not append the last sample and would result in the program crashing. Updated this to be a warning (to avoid crash) while still appending the data since it's valid.