### PR TITLE
Have a single definition of the SyncPulseType enum

### DIFF
--- a/tools/ld-chroma-decoder/encoder/encoder.h
+++ b/tools/ld-chroma-decoder/encoder/encoder.h
@@ -52,6 +52,14 @@ static constexpr double kR = 0.87728321993817866838972487283129;
 static constexpr double cbScale = ONE_MINUS_Kb * kB / C_SCALE;
 static constexpr double crScale = ONE_MINUS_Kr * kR / C_SCALE;
 
+// Types of sync pulse [Poynton p521 for PAL, p502 for NTSC]
+enum SyncPulseType {
+    NONE = 0,
+    NORMAL,
+    EQUALIZATION,
+    BROAD
+};
+
 class Encoder
 {
 public:

--- a/tools/ld-chroma-decoder/encoder/ntscencoder.cpp
+++ b/tools/ld-chroma-decoder/encoder/ntscencoder.cpp
@@ -120,14 +120,6 @@ void NTSCEncoder::getFieldMetadata(qint32 fieldNo, LdDecodeMetaData::Field &fiel
     fieldData.audioSamples = 0;
 }
 
-// Types of sync pulse [Poynton p502]
-enum SyncPulseType {
-    NONE = 0,
-    NORMAL,
-    EQUALIZATION,
-    BROAD
-};
-
 // Generate a gate waveform for a sync pulse in one half of a line
 static double syncPulseGate(double t, double startTime, SyncPulseType type)
 {

--- a/tools/ld-chroma-decoder/encoder/palencoder.cpp
+++ b/tools/ld-chroma-decoder/encoder/palencoder.cpp
@@ -136,14 +136,6 @@ void PALEncoder::getFieldMetadata(qint32 fieldNo, LdDecodeMetaData::Field &field
     fieldData.audioSamples = 0;
 }
 
-// Types of sync pulse [Poynton p521]
-enum SyncPulseType {
-    NONE = 0,
-    NORMAL,
-    EQUALISATION,
-    BROAD
-};
-
 // Generate a gate waveform for a sync pulse in one half of a line
 static double syncPulseGate(double t, double startTime, SyncPulseType type)
 {
@@ -155,7 +147,7 @@ static double syncPulseGate(double t, double startTime, SyncPulseType type)
     case NORMAL:
         length = 4.7e-6;
         break;
-    case EQUALISATION:
+    case EQUALIZATION:
         length = 4.7e-6 / 2.0;
         break;
     case BROAD:
@@ -241,17 +233,17 @@ void PALEncoder::encodeLine(qint32 fieldNo, qint32 frameLine, const quint16 *inp
     if (frameLine < 5) {
         leftSyncType = BROAD;
     } else if (frameLine >= 5 && frameLine < 10) {
-        leftSyncType = EQUALISATION;
+        leftSyncType = EQUALIZATION;
     } else if (frameLine >= 620) {
-        leftSyncType = EQUALISATION;
+        leftSyncType = EQUALIZATION;
     }
     SyncPulseType rightSyncType = NONE;
     if (frameLine < 4) {
         rightSyncType = BROAD;
     } else if (frameLine >= 4 && frameLine < 9) {
-        rightSyncType = EQUALISATION;
+        rightSyncType = EQUALIZATION;
     } else if (frameLine >= 619 && frameLine < 624) {
-        rightSyncType = EQUALISATION;
+        rightSyncType = EQUALIZATION;
     } else if (frameLine == 624) {
         rightSyncType = BROAD;
     }


### PR DESCRIPTION
GCC 12.2 warns (correctly) that the previous definitions violate the One Definition Rule, since the values were named differently.