### PR TITLE
Use completeBaseName in SourceAudio::open

### DIFF
--- a/tools/library/tbc/sourceaudio.cpp
+++ b/tools/library/tbc/sourceaudio.cpp
@@ -40,7 +40,7 @@ SourceAudio::~SourceAudio()
 bool SourceAudio::open(QFileInfo inputFileInfo)
 {
     // Get the input audio fileinfo from the input TBC fileinfo:
-    QFileInfo inputAudioFileInfo(inputFileInfo.absolutePath() + "/" + inputFileInfo.baseName() + ".pcm");
+    QFileInfo inputAudioFileInfo(inputFileInfo.absolutePath() + "/" + inputFileInfo.completeBaseName() + ".pcm");
 
     // Open the audio source data file
     inputAudioFile.setFileName(inputAudioFileInfo.filePath());


### PR DESCRIPTION
A TBC filename like "some 1.1 file.tbc" would otherwise produce the wrong audio filename.

Fixes #810. It's similar to #557 so I've checked for other uses of `baseName` - this was the only one remaining.