### PR TITLE
Fix unpack_data_4_40's return type

### DIFF
--- a/lddecode/utils.py
+++ b/lddecode/utils.py
@@ -269,7 +269,7 @@ def unpack_data_4_40(indata, readlen, offset):
 
     # convert back to original DdD 16-bit format (signed 16-bit, left shifted)
     rv_unsigned = unpacked[offset : offset + readlen]
-    rv_signed = np.left_shift(rv_unsigned.astype(np.int16) - 512, 6)
+    rv_signed = np.left_shift(rv_unsigned - 512, 6).astype(np.int16)
 
     # # Original implementation.
     #  unpacked = np.zeros(readlen + 4, dtype=np.uint16)


### PR DESCRIPTION
It's intending to return an np.ndarray of int16s, but the final shift was converting to int64. The numpy documentation warns that the typing rules for left_shift "can lead to unexpected results".

Found while looking at #815 - I've confirmed that this now produces the same output as the .ldf reader by hashing the returned array.