### PR TITLE
Handle more variation in VITC

### DIFF
--- a/tools/ld-process-vbi/biphasecode.cpp
+++ b/tools/ld-process-vbi/biphasecode.cpp
@@ -76,7 +76,7 @@ qint32 BiphaseCode::manchesterDecoder(const SourceVideo::Data &lineData, qint32 
     qint32 decodeCount = 0;
 
     // Find the first transition
-    qint32 x = 0;
+    qint32 x = videoParameters.activeVideoStart;
     while (x < manchesterData.size() && manchesterData[x] == false) {
         x++;
     }

--- a/tools/ld-process-vbi/closedcaption.cpp
+++ b/tools/ld-process-vbi/closedcaption.cpp
@@ -42,7 +42,7 @@ bool ClosedCaption::decodeLine(const SourceVideo::Data& lineData,
     QVector<bool> transitionMap = getTransitionMap(lineData, zcPoint);
 
     // Set the number of samples to the expected start of the start bit transition
-    qint32 expectedStart = 262;
+    qint32 expectedStart = videoParameters.activeVideoStart + 262;
 
     // Set the width of 1 bit
     qint32 samplesPerBit = 28;

--- a/tools/ld-process-vbi/fmcode.cpp
+++ b/tools/ld-process-vbi/fmcode.cpp
@@ -58,7 +58,7 @@ bool FmCode::decodeLine(const SourceVideo::Data &lineData,
     qint32 decodeCount = 0;
 
     // Find the first transition
-    qint32 x = 0;
+    qint32 x = videoParameters.activeVideoStart;
     while (x < fmData.size() && fmData[x] == false) {
         x++;
     }

--- a/tools/ld-process-vbi/vbilinedecoder.h
+++ b/tools/ld-process-vbi/vbilinedecoder.h
@@ -42,8 +42,8 @@ public:
     explicit VbiLineDecoder(QAtomicInt& _abort, DecoderPool& _decoderPool, QObject *parent = nullptr);
 
     // The range of field lines needed from the input file (1-based, inclusive)
-    static constexpr qint32 startFieldLine = 10;
-    static constexpr qint32 endFieldLine = 21;
+    static constexpr qint32 startFieldLine = 6;
+    static constexpr qint32 endFieldLine = 22;
 
 protected:
     void run() override;

--- a/tools/ld-process-vbi/vbilinedecoder.h
+++ b/tools/ld-process-vbi/vbilinedecoder.h
@@ -53,8 +53,8 @@ private:
     QAtomicInt& abort;
     DecoderPool& decoderPool;
 
-    SourceVideo::Data getActiveVideoLine(const SourceVideo::Data& sourceField, qint32 fieldLine,
-                                         const LdDecodeMetaData::VideoParameters& videoParameters);
+    SourceVideo::Data getFieldLine(const SourceVideo::Data& sourceField, qint32 fieldLine,
+                                   const LdDecodeMetaData::VideoParameters& videoParameters);
 };
 
 #endif // VBILINEDECODER_H

--- a/tools/ld-process-vbi/vbiutilities.h
+++ b/tools/ld-process-vbi/vbiutilities.h
@@ -74,4 +74,16 @@ static inline QVector<bool> getTransitionMap(const InputData &lineData, qint32 z
     return transitionMap;
 }
 
+// Find the next sample with a given value in the output of getTransitionMap.
+// Return true if found before the limit, false if not found.
+static inline bool findTransition(const QVector<bool> &transitionMap, bool wantValue,
+                                  double &position, double positionLimit)
+{
+    while (position < positionLimit) {
+        if (transitionMap[static_cast<qint32>(position)] == wantValue) return true;
+        position += 1.0;
+    }
+    return false;
+}
+
 #endif

--- a/tools/ld-process-vbi/vitccode.cpp
+++ b/tools/ld-process-vbi/vitccode.cpp
@@ -133,6 +133,7 @@ bool VitcCode::decodeLine(const SourceVideo::Data &lineData,
     // Everything looks good -- update the metadata
     fieldMetadata.vitc.inUse = true;
     std::copy(vitcData.begin(), vitcData.begin() + 8, fieldMetadata.vitc.vitcData.begin());
+    qDebug() << "VitcCode::decodeLine(): Found VITC";
 
     return true;
 }

--- a/tools/ld-process-vbi/vitccode.cpp
+++ b/tools/ld-process-vbi/vitccode.cpp
@@ -142,13 +142,20 @@ bool VitcCode::decodeLine(const SourceVideo::Data &lineData,
 std::vector<qint32> VitcCode::getLineNumbers(const LdDecodeMetaData::VideoParameters& videoParameters)
 {
     // VITC can be on any line between 10-20 (525-line) or 6-22 (625-line), but
-    // the standards [ITU 6.20, SMPTE 10.6] recommend lines to use. The lists
-    // below try the lines that don't clash with LaserDisc VBI lines first.
+    // the standards [ITU 6.20, SMPTE 10.6] recommend lines to use. Try the
+    // recommended lines first (prioritising those that don't clash with
+    // LaserDisc VBI), then the others.
     if (videoParameters.system == PAL) {
         // 625-line
-        return { 21, 19, 18, 20 };
+        return {
+            21, 19, 18, 20,
+            6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 22,
+        };
     } else {
         // 525-line
-        return { 14, 12, 16, 18 };
+        return {
+            14, 12, 16, 18,
+            10, 11, 13, 15, 17, 19, 20,
+        };
     }
 }

--- a/tools/ld-process-vbi/whiteflag.cpp
+++ b/tools/ld-process-vbi/whiteflag.cpp
@@ -35,7 +35,7 @@ bool WhiteFlag::decodeLine(const SourceVideo::Data& lineData,
 
     qint32 whiteCount = 0;
     for (qint32 x = videoParameters.activeVideoStart; x < videoParameters.activeVideoEnd; x++) {
-        if (lineData[x - videoParameters.activeVideoStart] > zcPoint) whiteCount++;
+        if (lineData[x] > zcPoint) whiteCount++;
     }
 
     // Mark the line as a white flag if at least 50% of the data is above the zc point


### PR DESCRIPTION
@harrypm's Eden Project sample failed to decode for a couple of reasons: it was using VITC lines we weren't looking at, and the time between the sync pulse and VITC start meant the end of VITC was (just) outside the active region.

Fix this by looking at all the possible lines, and giving the decoders the complete composite line to look at rather than just the active region.