### PR TITLE
Add Closed Caption support for PAL

### DIFF
--- a/tools/ld-analyse/closedcaptionsdialog.ui
+++ b/tools/ld-analyse/closedcaptionsdialog.ui
@@ -17,7 +17,7 @@
    </size>
   </property>
   <property name="windowTitle">
-   <string>NTSC Closed Captions</string>
+   <string>Closed Captions</string>
   </property>
   <property name="windowIcon">
    <iconset resource="ld-analyse-resources.qrc">

--- a/tools/ld-analyse/mainwindow.cpp
+++ b/tools/ld-analyse/mainwindow.cpp
@@ -394,9 +394,8 @@ void MainWindow::showFrame()
     updateFrame();
 
     // Update the closed caption dialog
-    if (tbcSource.getSystem() == NTSC) {
-        closedCaptionDialog->addData(currentFrameNumber, tbcSource.getCcData0(), tbcSource.getCcData1());
-    }
+    closedCaptionDialog->addData(currentFrameNumber, tbcSource.getCcData0(), tbcSource.getCcData1());
+
     // QT Bug workaround for some macOS versions
     #if defined(Q_OS_MACOS)
     	repaint();

--- a/tools/ld-analyse/tbcsource.cpp
+++ b/tools/ld-analyse/tbcsource.cpp
@@ -482,16 +482,16 @@ qint32 TbcSource::getCcData0()
 {
     if (loadedFrameNumber == -1) return 0;
 
-    if (firstField.ntsc.ccData0 != -1) return firstField.ntsc.ccData0;
-    return secondField.ntsc.ccData0;
+    if (firstField.closedCaption.data0 != -1) return firstField.closedCaption.data0;
+    return secondField.closedCaption.data0;
 }
 
 qint32 TbcSource::getCcData1()
 {
     if (loadedFrameNumber == -1) return 0;
 
-    if (firstField.ntsc.ccData1 != -1) return firstField.ntsc.ccData1;
-    return secondField.ntsc.ccData1;
+    if (firstField.closedCaption.data1 != -1) return firstField.closedCaption.data1;
+    return secondField.closedCaption.data1;
 }
 
 void TbcSource::setChromaConfiguration(const PalColour::Configuration &_palConfiguration,

--- a/tools/ld-process-vbi/closedcaption.cpp
+++ b/tools/ld-process-vbi/closedcaption.cpp
@@ -4,6 +4,7 @@
 
     ld-process-vbi - VBI and IEC NTSC specific processor for ld-decode
     Copyright (C) 2018-2019 Simon Inns
+    Copyright (C) 2023 Adam Sampson
 
     This file is part of ld-decode-tools.
 
@@ -25,6 +26,18 @@
 #include "closedcaption.h"
 #include "vbiutilities.h"
 
+/*!
+    \class ClosedCaption
+
+    Decoder for EIA/CEA-608 data lines, widely used for closed
+    captioning in NTSC, and occasionally in other standards.
+
+    References:
+
+    [CTA] "Line 21 Data Services", (https://shop.cta.tech/products/line-21-data-services)
+    ANSI/CTA-608-E S-2019, April 2008.
+*/
+
 // Public method to read CEA-608 Closed Captioning data.
 // Return true if CC data was decoded successfully, false otherwise.
 bool ClosedCaption::decodeLine(const SourceVideo::Data& lineData,
@@ -36,47 +49,56 @@ bool ClosedCaption::decodeLine(const SourceVideo::Data& lineData,
     fieldMetadata.closedCaption.data0 = -1;
     fieldMetadata.closedCaption.data1 = -1;
 
-    // Determine the 16-bit zero-crossing point
+    // The zero-crossing point is 25 IRE [CTA p13]
     qint32 zcPoint = ((videoParameters.white16bIre - videoParameters.black16bIre) / 4) + videoParameters.black16bIre;
 
     // Get the transition map for the line
     QVector<bool> transitionMap = getTransitionMap(lineData, zcPoint);
 
-    // Set the number of samples to the expected start of the start bit transition
-    qint32 expectedStart = videoParameters.activeVideoStart + 262;
+    // Bit clock is 32 x fH [CTA p14, note 1]
+    double samplesPerBit = static_cast<double>(videoParameters.fieldWidth) / 32.0;
 
-    // Set the width of 1 bit
-    qint32 samplesPerBit = 28;
+    // Following the colourburst, the line starts with 2-7 (but usually 7)
+    // cycles of sine wave at the bit clock rate, then start bits 001, then 16
+    // bits of data. [CTA p14] ("21.4 D" in the standard is a typo; it should
+    // be "2.14 D" from the time given.)
 
-    // Find the first transition
-    qint32 x = expectedStart - samplesPerBit;
-    while (x < transitionMap.size() && transitionMap[x] == false) {
-        x++;
+    // Find the 00 by looking for a 1.5-bit low period
+    double x = static_cast<double>(videoParameters.colourBurstEnd) + (2.0 * samplesPerBit);
+    double xLimit = static_cast<double>(videoParameters.fieldWidth) - (17.0 * samplesPerBit);
+    double lastOne = x;
+    while ((x - lastOne) < (1.5 * samplesPerBit)) {
+        if (x >= xLimit) {
+            qDebug() << "ClosedCaption::decodeLine(): No start bits found (00)";
+            return false;
+        }
+        if (transitionMap[static_cast<qint32>(x)] == true) lastOne = x;
+        x += 1.0;
     }
 
-    // Check that the first transition is where it should be
-    if (abs(x - expectedStart) > 16) {
-        qDebug() << "ClosedCaption::getData(): Expected" << expectedStart << "but got" << x << "- invalid CC line";
+    // Resynchronise on the 1 transition
+    if (!findTransition(transitionMap, true, x, xLimit)) {
+        qDebug() << "ClosedCaption::decodeLine(): No start bits found (1)";
         return false;
-    } else {
-        qDebug() << "ClosedCaption::getData(): Found start bit transition at" << x << "(expected" << expectedStart << ")";
     }
+
+    qDebug() << "ClosedCaption::decodeLine(): Found start bit transition at" << x;
 
     // Skip the the start bit and move to the centre of the first payload bit
-    x += samplesPerBit + (samplesPerBit / 2);
+    x += 1.5 * samplesPerBit;
 
     // Get the first 7 bit code
     uchar byte0 = 0;
     for (qint32 i = 0; i < 7; i++)
     {
         byte0 >>= 1;
-        if (transitionMap[x]) byte0 += 64;
+        if (transitionMap[static_cast<qint32>(x)]) byte0 += 64;
         x += samplesPerBit;
     }
 
     // Get the first 7 bit parity
     uchar byte0Parity = 0;
-    if (transitionMap[x]) byte0Parity = 1;
+    if (transitionMap[static_cast<qint32>(x)]) byte0Parity = 1;
     x += samplesPerBit;
 
     // Get the second byte
@@ -84,27 +106,27 @@ bool ClosedCaption::decodeLine(const SourceVideo::Data& lineData,
     for (qint32 i = 0; i < 7; i++)
     {
         byte1 >>= 1;
-        if (transitionMap[x]) byte1 += 64;
+        if (transitionMap[static_cast<qint32>(x)]) byte1 += 64;
         x += samplesPerBit;
     }
 
     // Get the second 7 bit parity
     uchar byte1Parity = 0;
-    if (transitionMap[x]) byte1Parity = 1;
+    if (transitionMap[static_cast<qint32>(x)]) byte1Parity = 1;
     x += samplesPerBit;
 
-    qDebug().nospace() << "ClosedCaption::getData(): Bytes are: " << byte0 << " (" << byte0Parity << ") - "
+    qDebug().nospace() << "ClosedCaption::decodeLine(): Bytes are: " << byte0 << " (" << byte0Parity << ") - "
                        << byte1 << " (" << byte1Parity << ")";
 
     if (isEvenParity(byte0) && byte0Parity != 1) {
-        qDebug() << "ClosedCaption::getData(): First byte failed parity check!";
+        qDebug() << "ClosedCaption::decodeLine(): First byte failed parity check!";
     } else {
         fieldMetadata.closedCaption.data0 = byte0;
         fieldMetadata.closedCaption.inUse = true;
     }
 
     if (isEvenParity(byte1) && byte1Parity != 1) {
-        qDebug() << "ClosedCaption::getData(): Second byte failed parity check!";
+        qDebug() << "ClosedCaption::decodeLine(): Second byte failed parity check!";
     } else {
         fieldMetadata.closedCaption.data1 = byte1;
         fieldMetadata.closedCaption.inUse = true;

--- a/tools/ld-process-vbi/closedcaption.cpp
+++ b/tools/ld-process-vbi/closedcaption.cpp
@@ -25,15 +25,16 @@
 #include "closedcaption.h"
 #include "vbiutilities.h"
 
-// Public method to read CEA-608 Closed Captioning data (NTSC only).
+// Public method to read CEA-608 Closed Captioning data.
 // Return true if CC data was decoded successfully, false otherwise.
 bool ClosedCaption::decodeLine(const SourceVideo::Data& lineData,
                                const LdDecodeMetaData::VideoParameters& videoParameters,
                                LdDecodeMetaData::Field& fieldMetadata)
 {
     // Reset data to invalid
-    fieldMetadata.ntsc.ccData0 = -1;
-    fieldMetadata.ntsc.ccData1 = -1;
+    fieldMetadata.closedCaption.inUse = false;
+    fieldMetadata.closedCaption.data0 = -1;
+    fieldMetadata.closedCaption.data1 = -1;
 
     // Determine the 16-bit zero-crossing point
     qint32 zcPoint = ((videoParameters.white16bIre - videoParameters.black16bIre) / 4) + videoParameters.black16bIre;
@@ -98,13 +99,15 @@ bool ClosedCaption::decodeLine(const SourceVideo::Data& lineData,
     if (isEvenParity(byte0) && byte0Parity != 1) {
         qDebug() << "ClosedCaption::getData(): First byte failed parity check!";
     } else {
-        fieldMetadata.ntsc.ccData0 = byte0;
+        fieldMetadata.closedCaption.data0 = byte0;
+        fieldMetadata.closedCaption.inUse = true;
     }
 
     if (isEvenParity(byte1) && byte1Parity != 1) {
         qDebug() << "ClosedCaption::getData(): Second byte failed parity check!";
     } else {
-        fieldMetadata.ntsc.ccData1 = byte1;
+        fieldMetadata.closedCaption.data1 = byte1;
+        fieldMetadata.closedCaption.inUse = true;
     }
 
     return true;

--- a/tools/ld-process-vbi/decoderpool.cpp
+++ b/tools/ld-process-vbi/decoderpool.cpp
@@ -135,6 +135,7 @@ bool DecoderPool::setOutputField(qint32 fieldNumber, const LdDecodeMetaData::Fie
     ldDecodeMetaData.updateFieldVbi(fieldMetadata.vbi, fieldNumber);
     ldDecodeMetaData.updateFieldNtsc(fieldMetadata.ntsc, fieldNumber);
     ldDecodeMetaData.updateFieldVitc(fieldMetadata.vitc, fieldNumber);
+    ldDecodeMetaData.updateFieldClosedCaption(fieldMetadata.closedCaption, fieldNumber);
 
     return true;
 }

--- a/tools/ld-process-vbi/vbilinedecoder.cpp
+++ b/tools/ld-process-vbi/vbilinedecoder.cpp
@@ -78,10 +78,6 @@ void VbiLineDecoder::run()
             WhiteFlag whiteFlag;
             whiteFlag.decodeLine(getFieldLine(sourceFieldData, 11, videoParameters), videoParameters, fieldMetadata);
 
-            // Get the closed captioning from field line 21
-            ClosedCaption closedCaption;
-            closedCaption.decodeLine(getFieldLine(sourceFieldData, 21, videoParameters), videoParameters, fieldMetadata);
-
             fieldMetadata.ntsc.inUse = true;
         }
 
@@ -93,6 +89,11 @@ void VbiLineDecoder::run()
                 break;
             }
         }
+
+        // Get Closed Caption data from line 21 (525-line) or 22 (625-line)
+        ClosedCaption closedCaption;
+        closedCaption.decodeLine(getFieldLine(sourceFieldData, (videoParameters.system == PAL) ? 22 : 21, videoParameters),
+                                 videoParameters, fieldMetadata);
 
         // Write the result to the output metadata
         if (!decoderPool.setOutputField(fieldNumber, fieldMetadata)) {

--- a/tools/library/tbc/lddecodemetadata.h
+++ b/tools/library/tbc/lddecodemetadata.h
@@ -5,7 +5,7 @@
     ld-decode-tools TBC library
     Copyright (C) 2018-2020 Simon Inns
     Copyright (C) 2022 Ryan Holtz
-    Copyright (C) 2022 Adam Sampson
+    Copyright (C) 2022-2023 Adam Sampson
 
     This file is part of ld-decode-tools.
 
@@ -134,16 +134,15 @@ public:
     };
 
     // NTSC Specific metadata definition
+    struct ClosedCaption;
     struct Ntsc {
         bool inUse = false;
         bool isFmCodeDataValid = false;
         qint32 fmCodeData = 0;
         bool fieldFlag = false;
         bool whiteFlag = false;
-        qint32 ccData0 = -1;
-        qint32 ccData1 = -1;
 
-        void read(JsonReader &reader);
+        void read(JsonReader &reader, ClosedCaption &closedCaption);
         void write(JsonWriter &writer) const;
     };
 
@@ -154,6 +153,17 @@ public:
         // Just the VITC data, without the sync bits or CRC.
         // vitcData[0]'s LSB is bit 2; vitcData[7]'s MSB is bit 79.
         std::array<qint32, 8> vitcData;
+
+        void read(JsonReader &reader);
+        void write(JsonWriter &writer) const;
+    };
+
+    // Closed Caption definition
+    struct ClosedCaption {
+        bool inUse = false;
+
+        qint32 data0 = -1;
+        qint32 data1 = -1;
 
         void read(JsonReader &reader);
         void write(JsonWriter &writer) const;
@@ -186,6 +196,7 @@ public:
         Vbi vbi;
         Ntsc ntsc;
         Vitc vitc;
+        ClosedCaption closedCaption;
         DropOuts dropOuts;
         bool pad = false;
 
@@ -233,6 +244,7 @@ public:
     const Vbi &getFieldVbi(qint32 sequentialFieldNumber);
     const Ntsc &getFieldNtsc(qint32 sequentialFieldNumber);
     const Vitc &getFieldVitc(qint32 sequentialFieldNumber);
+    const ClosedCaption &getFieldClosedCaption(qint32 sequentialFieldNumber);
     const DropOuts &getFieldDropOuts(qint32 sequentialFieldNumber);
 
     // Set field metadata
@@ -241,6 +253,7 @@ public:
     void updateFieldVbi(const LdDecodeMetaData::Vbi &vbi, qint32 sequentialFieldNumber);
     void updateFieldNtsc(const LdDecodeMetaData::Ntsc &ntsc, qint32 sequentialFieldNumber);
     void updateFieldVitc(const LdDecodeMetaData::Vitc &vitc, qint32 sequentialFieldNumber);
+    void updateFieldClosedCaption(const LdDecodeMetaData::ClosedCaption &closedCaption, qint32 sequentialFieldNumber);
     void updateFieldDropOuts(const DropOuts &dropOuts, qint32 sequentialFieldNumber);
     void clearFieldDropOuts(qint32 sequentialFieldNumber);
 


### PR DESCRIPTION
We haven't found any examples of PAL CC on LaserDisc yet, but it certainly exists on commercial VHS tapes - the format is the same, with 32 bit times per line, but it's on field line 22 rather than 21.

This will need an update to the JSON spec once merged, since it moves `ntsc.ccData[01]` to `cc.data[01]`. The parser understands the old location as well when reading existing JSON files.