### PR TITLE
Add fftw to ld-analyse include dirs

### DIFF
--- a/tools/ld-analyse/CMakeLists.txt
+++ b/tools/ld-analyse/CMakeLists.txt
@@ -26,7 +26,7 @@ add_executable(ld-analyse MACOSX_BUNDLE
     ${ld-analyse_SOURCES})
 
 target_include_directories(ld-analyse PRIVATE
-    ${QWT_INCLUDE_DIR}
+    ${QWT_INCLUDE_DIR}  ${FFTW_INCLUDE_DIRS}
 )
 
 target_link_libraries(ld-analyse PRIVATE


### PR DESCRIPTION
Not sure why missing this didn't cause errors in the windows build before but hit it now. fftw is used by something in ld-analyse so if it's not included it won't be found if it's not in a standard location like on linux.