### PR TITLE
Convert asserts to exceptions in ld-ac3-decode

### DIFF
--- a/tools/ld-process-ac3/decode/AC3Framer.hpp
+++ b/tools/ld-process-ac3/decode/AC3Framer.hpp
@@ -101,7 +101,8 @@ struct AC3Framer {
                 ac3Buffer.insert(ac3Buffer.end(), buffer[bytePosition]);
                 if (static_cast<int>(ac3Buffer.size()) == currentAc3Size) {
                     currentAc3Size = 0;
-                    // assert(ac3Buffer[4] == 0x1c); // fscod and frmsizecod fixed until lookup above implemented
+                    // XXX fscod and frmsizecod fixed until lookup above implemented;
+                    // for now, SyncFrame::check_crc will check the equivalent of assert(ac3Buffer[4] == 0x1c)
                     return ac3Buffer;
                 }
             }

--- a/tools/ld-process-ac3/decode/AC3Framer.hpp
+++ b/tools/ld-process-ac3/decode/AC3Framer.hpp
@@ -99,7 +99,7 @@ struct AC3Framer {
             if (currentAc3Size != 0) { // append to the ac3 block
                 // ac3Buffer.emplace_back(buffer[i]); // todo
                 ac3Buffer.insert(ac3Buffer.end(), buffer[bytePosition]);
-                if (ac3Buffer.size() == currentAc3Size) {
+                if (static_cast<int>(ac3Buffer.size()) == currentAc3Size) {
                     currentAc3Size = 0;
                     // assert(ac3Buffer[4] == 0x1c); // fscod and frmsizecod fixed until lookup above implemented
                     return ac3Buffer;

--- a/tools/ld-process-ac3/decode/main.cpp
+++ b/tools/ld-process-ac3/decode/main.cpp
@@ -126,14 +126,19 @@ int main(int argc, char *argv[]) {
         while (true) {
             auto frame = ac3Framer.next();
 
-            // partial decode of AC3 frame
-            auto sf = SyncFrame(frame);
-            auto crc_status = sf.check_crc();
+            try {
+                // partial decode of AC3 frame
+                auto sf = SyncFrame(frame);
+                auto crc_status = sf.check_crc();
 
-            if (!(crc_status & 1))
-                Logger(INFO, "CRC1") << "frame " << ac3_frames;
-            if (!(crc_status >> 1)) // note; data covered by crc2 is useless without crc1
-                Logger(INFO, "CRC2") << "frame " << ac3_frames;
+                if (!(crc_status & 1))
+                    Logger(INFO, "CRC1") << "frame " << ac3_frames;
+                if (!(crc_status >> 1)) // note; data covered by crc2 is useless without crc1
+                    Logger(INFO, "CRC2") << "frame " << ac3_frames;
+            } catch (InvalidFrameError &e) {
+                // Frame data is not valid enough to check the CRCs
+                Logger(INFO, "SyncFrame") << "frame " << ac3_frames;
+            }
 
             for (auto &b: frame)
                 *output << b;

--- a/tools/ld-process-ac3/decode/main.cpp
+++ b/tools/ld-process-ac3/decode/main.cpp
@@ -26,6 +26,7 @@
 
 #include <getopt.h>
 #include <cassert>
+#include <cstring>
 
 #include "../logger.hpp"
 #include "AC3Framer.hpp"
@@ -82,7 +83,7 @@ int main(int argc, char *argv[]) {
 
     // prep input file (if not piped)
     std::ifstream inputFile;
-    if (memcmp(posArgv[0], "-\x00", 2) != 0) {
+    if (std::strcmp(posArgv[0], "-") != 0) {
         fprintf(stderr, "using input file: %s\n", posArgv[0]);
         char fileBuffer[8196]; // 8K
         inputFile.rdbuf()->pubsetbuf(fileBuffer, sizeof fileBuffer);
@@ -93,7 +94,7 @@ int main(int argc, char *argv[]) {
 
     // prep output file (if not piped)
     std::ofstream outputFile;
-    if (memcmp(posArgv[1], "-\x00", 2) != 0) {
+    if (std::strcmp(posArgv[1], "-") != 0) {
         fprintf(stderr, "using output file: %s\n", posArgv[1]);
         outputFile.open(posArgv[1], std::ifstream::binary);
         assert(outputFile.good());
@@ -102,7 +103,7 @@ int main(int argc, char *argv[]) {
 
     // prep logger file (if not piped)
     std::ofstream loggerFile;
-    if (posArgc > 2 && memcmp(posArgv[2], "-\x00", 2) != 0) {
+    if (posArgc > 2 && std::strcmp(posArgv[2], "-") != 0) {
         fprintf(stderr, "using logger file: %s\n", posArgv[2]);
         loggerFile.open(posArgv[2], std::ifstream::binary);
         assert(loggerFile.good());

--- a/tools/ld-process-ac3/demodulate/main.cpp
+++ b/tools/ld-process-ac3/demodulate/main.cpp
@@ -98,7 +98,7 @@ int main(int argc, char *argv[]) {
 
     // prep input file (if not piped)
     std::ifstream inputFile;
-    if (memcmp(posArgv[0], "-\x00", 2) != 0) {
+    if (std::strcmp(posArgv[0], "-") != 0) {
         fprintf(stderr, "using input file: %s\n", posArgv[0]);
         char fileBuffer[8196]; // 8K
         inputFile.rdbuf()->pubsetbuf(fileBuffer, sizeof fileBuffer);
@@ -109,7 +109,7 @@ int main(int argc, char *argv[]) {
 
     // prep output file (if not piped)
     std::ofstream outputFile;
-    if (memcmp(posArgv[1], "-\x00", 2) != 0) {
+    if (std::strcmp(posArgv[1], "-") != 0) {
         fprintf(stderr, "using output file: %s\n", posArgv[1]);
         outputFile.open(posArgv[1], std::ostream::binary);
         assert(outputFile.good());
@@ -118,7 +118,7 @@ int main(int argc, char *argv[]) {
 
     // prep logger file (if not piped)
     std::ofstream loggerFile;
-    if (posArgc > 2 && memcmp(posArgv[2], "-\x00", 2) != 0) {
+    if (posArgc > 2 && std::strcmp(posArgv[2], "-") != 0) {
         fprintf(stderr, "using logger file: %s\n", posArgv[2]);
         loggerFile.open(posArgv[2], std::ifstream::binary);
         assert(loggerFile.good());

--- a/tools/ld-process-efm/Datatypes/f3frame.cpp
+++ b/tools/ld-process-efm/Datatypes/f3frame.cpp
@@ -227,9 +227,9 @@ public:
 
         // If present, the symbol must be in this bucket or the next one
         const quint32 thisBucket = buckets[bucket];
-        if ((thisBucket & 0xFFFF) == symbol) return thisBucket >> 16;
+        if ((thisBucket & 0xFFFF) == static_cast<quint32>(symbol)) return thisBucket >> 16;
         const quint32 nextBucket = buckets[bucket + 1];
-        if ((nextBucket & 0xFFFF) == symbol) return nextBucket >> 16;
+        if ((nextBucket & 0xFFFF) == static_cast<quint32>(symbol)) return nextBucket >> 16;
 
         // Not found
         return -1;


### PR DESCRIPTION
Some asserts were previously disabled in 1500999ef3d5ce867532f346578b8f8108d045b3. This converts them (including the disabled ones) into exceptions, so the main loop can detect that parsing the frame has failed rather than exiting, allowing the decode to continue.

I've also included fixes for some new warnings produced by GCC 12.2.