### PR TITLE
Fix ld-ac3-demodulate and ld-process-efm for 32-bit architectures

### DIFF
--- a/tools/ld-process-ac3/demodulate/Reclocker.hpp
+++ b/tools/ld-process-ac3/demodulate/Reclocker.hpp
@@ -40,7 +40,7 @@ struct Reclocker {
     static constexpr int counterBits = 16;
     static constexpr int nominalFrequency = 288000; // 2.88KHz QPSK eye pattern clock. PD4606A Pin 85 EPCK.
     static constexpr int sampleRate = 2.88e6 * samplesPerCarrierCycle; // PD4606A Pin 4, XIN 46.08MHz
-    static constexpr int nominalAdd = int((long) (1 << counterBits) * (long) nominalFrequency / (long) sampleRate);
+    static constexpr int nominalAdd = int(((1LL << counterBits) * nominalFrequency) / sampleRate);
 
     DATA_SRC &source;
     int totalBitsIn = 0;

--- a/tools/ld-process-efm/Datatypes/audio.cpp
+++ b/tools/ld-process-efm/Datatypes/audio.cpp
@@ -34,7 +34,7 @@ Audio::Audio()
 }
 
 // Method to set the audio sample frame data from a F2 Frame
-Audio::Audio(uchar* _sampleFrame)
+Audio::Audio(const uchar *_sampleFrame)
 {
     for (qint32 i = 0; i < 24; i++) sample.sampleFrame[i] = _sampleFrame[i];
 
@@ -43,13 +43,13 @@ Audio::Audio(uchar* _sampleFrame)
 }
 
 // Method to get the audio data as a sample frame (of 24 bytes)
-uchar* Audio::getSampleFrame()
+const uchar *Audio::getSampleFrame() const
 {
     return sample.sampleFrame;
 }
 
 // Method to set the signed 16-bit sample values
-void Audio::setSampleValues(Audio::SampleValues _sampleValues)
+void Audio::setSampleValues(const Audio::SampleValues &_sampleValues)
 {
     sample.sampleValues = _sampleValues;
 
@@ -58,7 +58,7 @@ void Audio::setSampleValues(Audio::SampleValues _sampleValues)
 }
 
 // Method to get the signed 16-bit sample values
-Audio::SampleValues Audio::getSampleValues()
+const Audio::SampleValues &Audio::getSampleValues() const
 {
     return sample.sampleValues;
 }

--- a/tools/ld-process-efm/Datatypes/audio.h
+++ b/tools/ld-process-efm/Datatypes/audio.h
@@ -42,11 +42,11 @@ public:
     };
 
     Audio();
-    Audio(uchar *_sampleFrame);
+    Audio(const uchar *_sampleFrame);
 
-    uchar* getSampleFrame();
-    void setSampleValues(Audio::SampleValues _sampleValues);
-    SampleValues getSampleValues();
+    const uchar *getSampleFrame() const;
+    void setSampleValues(const Audio::SampleValues &_sampleValues);
+    const SampleValues &getSampleValues() const;
     void setSampleToSilence();
 
 private:

--- a/tools/ld-process-efm/Datatypes/f1frame.cpp
+++ b/tools/ld-process-efm/Datatypes/f1frame.cpp
@@ -36,7 +36,7 @@ F1Frame::F1Frame()
     trackNumber = 0;
 }
 
-void F1Frame::setData(uchar *dataParam, bool _isCorrupt, bool _isEncoderOn, bool _isMissing,
+void F1Frame::setData(const uchar *dataParam, bool _isCorrupt, bool _isEncoderOn, bool _isMissing,
                       TrackTime _discTime, TrackTime _trackTime, qint32 _trackNumber)
 {
     // Add the F1 frame data to the F1 data buffer and swap the byte
@@ -60,37 +60,37 @@ void F1Frame::setData(uchar *dataParam, bool _isCorrupt, bool _isEncoderOn, bool
     // to perform the swapping twice (in the audio and data processing)
 }
 
-uchar* F1Frame::getDataSymbols()
+const uchar *F1Frame::getDataSymbols() const
 {
     return dataSymbols;
 }
 
-bool F1Frame::isCorrupt()
+bool F1Frame::isCorrupt() const
 {
     return isCorruptFlag;
 }
 
-bool F1Frame::isEncoderOn()
+bool F1Frame::isEncoderOn() const
 {
     return isEncoderOnFlag;
 }
 
-bool F1Frame::isMissing()
+bool F1Frame::isMissing() const
 {
     return isMissingFlag;
 }
 
-TrackTime F1Frame::getDiscTime()
+TrackTime F1Frame::getDiscTime() const
 {
     return discTime;
 }
 
-TrackTime F1Frame::getTrackTime()
+TrackTime F1Frame::getTrackTime() const
 {
     return trackTime;
 }
 
-qint32 F1Frame::getTrackNumber()
+qint32 F1Frame::getTrackNumber() const
 {
     return trackNumber;
 }

--- a/tools/ld-process-efm/Datatypes/f1frame.h
+++ b/tools/ld-process-efm/Datatypes/f1frame.h
@@ -35,17 +35,17 @@ class F1Frame
 public:
     F1Frame();
 
-    void setData(uchar *dataParam, bool _isCorrupt, bool _isEncoderOn, bool _isMissing,
+    void setData(const uchar *dataParam, bool _isCorrupt, bool _isEncoderOn, bool _isMissing,
                  TrackTime _discTime, TrackTime _trackTime, qint32 _trackNumber);
-    uchar* getDataSymbols(void);
+    const uchar *getDataSymbols() const;
 
-    bool isCorrupt();
-    bool isEncoderOn();
-    bool isMissing();
+    bool isCorrupt() const;
+    bool isEncoderOn() const;
+    bool isMissing() const;
 
-    TrackTime getDiscTime();
-    TrackTime getTrackTime();
-    qint32 getTrackNumber();
+    TrackTime getDiscTime() const;
+    TrackTime getTrackTime() const;
+    qint32 getTrackNumber() const;
 
 private:
     bool isCorruptFlag;

--- a/tools/ld-process-efm/Datatypes/f2frame.cpp
+++ b/tools/ld-process-efm/Datatypes/f2frame.cpp
@@ -35,7 +35,7 @@ F2Frame::F2Frame()
     trackNumber = 0;
 }
 
-void F2Frame::setData(uchar* dataParam, uchar* erasuresParam)
+void F2Frame::setData(const uchar *dataParam, const uchar *erasuresParam)
 {
     errorState = false;
 
@@ -47,14 +47,14 @@ void F2Frame::setData(uchar* dataParam, uchar* erasuresParam)
 }
 
 // This method returns the 24 data symbols for the F2 Frame
-uchar *F2Frame::getDataSymbols()
+const uchar *F2Frame::getDataSymbols() const
 {
     return dataSymbols;
 }
 
 // This method returns true if the data in the F2 Frame
 // is marked with erasures (i.e. it's corrupt)
-bool F2Frame::isFrameCorrupt()
+bool F2Frame::isFrameCorrupt() const
 {
     return errorState;
 }
@@ -71,12 +71,12 @@ void F2Frame::setTrackTime(TrackTime _trackTime)
     trackTime = _trackTime;
 }
 
-TrackTime F2Frame::getDiscTime()
+TrackTime F2Frame::getDiscTime() const
 {
     return discTime;
 }
 
-TrackTime F2Frame::getTrackTime()
+TrackTime F2Frame::getTrackTime() const
 {
     return trackTime;
 }
@@ -86,7 +86,7 @@ void F2Frame::setTrackNumber(qint32 _trackNumber)
     trackNumber = _trackNumber;
 }
 
-qint32 F2Frame::getTrackNumber()
+qint32 F2Frame::getTrackNumber() const
 {
     return trackNumber;
 }
@@ -96,7 +96,7 @@ void F2Frame::setIsEncoderRunning(bool _isEncoderRunning)
     isEncoderRunning = _isEncoderRunning;
 }
 
-bool F2Frame::getIsEncoderRunning()
+bool F2Frame::getIsEncoderRunning() const
 {
     return isEncoderRunning;
 }

--- a/tools/ld-process-efm/Datatypes/f2frame.h
+++ b/tools/ld-process-efm/Datatypes/f2frame.h
@@ -36,18 +36,18 @@ class F2Frame
 public:
     F2Frame();
 
-    void setData(uchar *dataParam, uchar *erasuresParam);
-    uchar* getDataSymbols();
-    bool isFrameCorrupt();
+    void setData(const uchar *dataParam, const uchar *erasuresParam);
+    const uchar *getDataSymbols() const;
+    bool isFrameCorrupt() const;
 
     void setDiscTime(TrackTime _discTime);
     void setTrackTime(TrackTime _trackTime);
-    TrackTime getDiscTime();
-    TrackTime getTrackTime();
+    TrackTime getDiscTime() const;
+    TrackTime getTrackTime() const;
     void setTrackNumber(qint32 _trackNumber);
-    qint32 getTrackNumber();
+    qint32 getTrackNumber() const;
     void setIsEncoderRunning(bool _isEncoderRunning);
-    bool getIsEncoderRunning();
+    bool getIsEncoderRunning() const;
 
 private:
     uchar dataSymbols[24];

--- a/tools/ld-process-efm/Datatypes/f3frame.cpp
+++ b/tools/ld-process-efm/Datatypes/f3frame.cpp
@@ -147,49 +147,49 @@ void F3Frame::setTValues(const uchar *tValuesIn, qint32 tLength, bool audioIsDts
 }
 
 // Return the number of valid EFM symbols in the frame
-qint64 F3Frame::getNumberOfValidEfmSymbols()
+qint64 F3Frame::getNumberOfValidEfmSymbols() const
 {
     return validEfmSymbols;
 }
 
 // Return the number of invalid EFM symbols in the frame
-qint64 F3Frame::getNumberOfInvalidEfmSymbols()
+qint64 F3Frame::getNumberOfInvalidEfmSymbols() const
 {
     return invalidEfmSymbols;
 }
 
 // Return the number of corrected EFM symbols in the frame
-qint64 F3Frame::getNumberOfCorrectedEfmSymbols()
+qint64 F3Frame::getNumberOfCorrectedEfmSymbols() const
 {
     return correctedEfmSymbols;
 }
 
 // This method returns the 32 data symbols for the F3 Frame
-uchar *F3Frame::getDataSymbols()
+const uchar *F3Frame::getDataSymbols() const
 {
     return dataSymbols;
 }
 
 // This method returns the 32 error symbols for the F3 Frame
-uchar *F3Frame::getErrorSymbols()
+const uchar *F3Frame::getErrorSymbols() const
 {
     return errorSymbols;
 }
 
 // This method returns the subcode symbol for the F3 frame
-uchar F3Frame::getSubcodeSymbol()
+uchar F3Frame::getSubcodeSymbol() const
 {
     return subcodeSymbol;
 }
 
 // This method returns true if the subcode symbol is a SYNC0 pattern
-bool F3Frame::isSubcodeSync0()
+bool F3Frame::isSubcodeSync0() const
 {
     return isSync0;
 }
 
 // This method returns true if the subcode symbol is a SYNC1 pattern
-bool F3Frame::isSubcodeSync1()
+bool F3Frame::isSubcodeSync1() const
 {
     return isSync1;
 }

--- a/tools/ld-process-efm/Datatypes/f3frame.h
+++ b/tools/ld-process-efm/Datatypes/f3frame.h
@@ -36,15 +36,15 @@ public:
     F3Frame(const uchar *tValuesIn, qint32 tLength, bool audioIsDts);
 
     void setTValues(const uchar *tValuesIn, qint32 tLength, bool audioIsDts);
-    uchar* getDataSymbols();
-    uchar* getErrorSymbols();
-    uchar getSubcodeSymbol();
-    bool isSubcodeSync0();
-    bool isSubcodeSync1();
+    const uchar *getDataSymbols() const;
+    const uchar *getErrorSymbols() const;
+    uchar getSubcodeSymbol() const;
+    bool isSubcodeSync0() const;
+    bool isSubcodeSync1() const;
 
-    qint64 getNumberOfValidEfmSymbols();
-    qint64 getNumberOfInvalidEfmSymbols();
-    qint64 getNumberOfCorrectedEfmSymbols();
+    qint64 getNumberOfValidEfmSymbols() const;
+    qint64 getNumberOfInvalidEfmSymbols() const;
+    qint64 getNumberOfCorrectedEfmSymbols() const;
 
 private:
     uchar dataSymbols[32];

--- a/tools/ld-process-efm/Datatypes/section.cpp
+++ b/tools/ld-process-efm/Datatypes/section.cpp
@@ -45,7 +45,7 @@ Section::Section()
     qMetadata.qMode1And4.isEncoderRunning = true;
 }
 
-bool Section::setData(uchar *dataIn)
+bool Section::setData(const uchar *dataIn)
 {
     // Interpret the section data
     qint32 symbolNumber = 2;
@@ -114,13 +114,13 @@ bool Section::setData(uchar *dataIn)
 }
 
 // Method to determine the Q mode
-qint32 Section::getQMode()
+qint32 Section::getQMode() const
 {
     return qMode;
 }
 
 // Method to get Q channel metadata
-Section::QMetadata Section::getQMetadata()
+const Section::QMetadata &Section::getQMetadata() const
 {
     return qMetadata;
 }

--- a/tools/ld-process-efm/Datatypes/section.h
+++ b/tools/ld-process-efm/Datatypes/section.h
@@ -67,9 +67,9 @@ public:
         QMode2 qMode2;
     };
 
-    bool setData(uchar* dataIn);
-    qint32 getQMode();
-    QMetadata getQMetadata();
+    bool setData(const uchar *dataIn);
+    qint32 getQMode() const;
+    const QMetadata &getQMetadata() const;
 
 private:
     // Q channel specific data
@@ -87,12 +87,12 @@ private:
     uchar wSubcode[12];
 
     bool verifyQ();
-    quint16 crc16(const uchar *addr, quint16 num);
+    static quint16 crc16(const uchar *addr, quint16 num);
     qint32 decodeQAddress();
     void decodeQControl();
     void decodeQDataMode1And4();
     void decodeQDataMode2();
-    qint32 bcdToInteger(uchar bcd);
+    static qint32 bcdToInteger(uchar bcd);
 };
 
 #endif // SECTION_H

--- a/tools/ld-process-efm/Datatypes/sector.cpp
+++ b/tools/ld-process-efm/Datatypes/sector.cpp
@@ -158,13 +158,13 @@ void Sector::setData(QByteArray _sectorData, bool _isValid)
 }
 
 // Method to get the sector's mode
-qint32 Sector::getMode()
+qint32 Sector::getMode() const
 {
     return mode;
 }
 
 // Method to get the sector's address
-TrackTime Sector::getAddress()
+TrackTime Sector::getAddress() const
 {
     return address;
 }
@@ -185,19 +185,19 @@ void Sector::setAsNull(TrackTime _address)
 }
 
 // Method to get the sector's validity
-bool Sector::isValid()
+bool Sector::isValid() const
 {
     return valid;
 }
 
 // Method to get the sector's missing flag
-bool Sector::isMissing()
+bool Sector::isMissing() const
 {
     return missing;
 }
 
 // Method to get the corrected flag (i.e. sector was invalid, but corrected by ECC)
-bool Sector::isCorrected()
+bool Sector::isCorrected() const
 {
     if (qCorrected && pCorrected) return true;
     return false;

--- a/tools/ld-process-efm/Datatypes/sector.h
+++ b/tools/ld-process-efm/Datatypes/sector.h
@@ -46,13 +46,13 @@ public:
     Sector(QByteArray _sectorData, bool _isValid);
 
     void setData(QByteArray _sectorData, bool _isValid);
-    qint32 getMode();
-    TrackTime getAddress();
+    qint32 getMode() const;
+    TrackTime getAddress() const;
     QByteArray getUserData();
     void setAsNull(TrackTime _address);
-    bool isValid();
-    bool isMissing();
-    bool isCorrected();
+    bool isValid() const;
+    bool isMissing() const;
+    bool isCorrected() const;
 
 private:
     // Mode 1 sector fields:
@@ -70,10 +70,10 @@ private:
     void performQParityECC(uchar *uF1Data, uchar *uF1Erasures);
     void performPParityECC(uchar *uF1Data, uchar *uF1Erasures);
 
-    qint32 bcdToInteger(uchar bcd);
-    QString dataToString(QByteArray data);
+    static qint32 bcdToInteger(uchar bcd);
+    static QString dataToString(QByteArray data);
 
-    quint32 crc32(uchar *src, qint32 size);
+    static quint32 crc32(uchar *src, qint32 size);
 };
 
 // This table is the CRC32 look-up for the EDC process.  The table is generated from the

--- a/tools/ld-process-efm/Datatypes/tracktime.cpp
+++ b/tools/ld-process-efm/Datatypes/tracktime.cpp
@@ -80,14 +80,14 @@ void TrackTime::subtractFrames(qint32 frames)
 }
 
 // Method to get the difference (in frames) between two track times
-qint32 TrackTime::getDifference(TrackTime::Time timeToCompare)
+qint32 TrackTime::getDifference(TrackTime::Time timeToCompare) const
 {
     qint32 framesToCompare = timeToCompare.frames + (timeToCompare.seconds * 75) + (timeToCompare.minutes * 60 * 75);
     return trackFrames - framesToCompare;
 }
 
 // Method to get the track time
-TrackTime::Time TrackTime::getTime()
+TrackTime::Time TrackTime::getTime() const
 {
     Time time;
 
@@ -102,7 +102,7 @@ TrackTime::Time TrackTime::getTime()
 }
 
 // Method to return the track time as a string
-QString TrackTime::getTimeAsQString()
+QString TrackTime::getTimeAsQString() const
 {
     QString timeString;
 
@@ -114,7 +114,7 @@ QString TrackTime::getTimeAsQString()
 }
 
 // Method to return track time in number of frames
-qint32 TrackTime::getFrames()
+qint32 TrackTime::getFrames() const
 {
     return trackFrames;
 }

--- a/tools/ld-process-efm/Datatypes/tracktime.h
+++ b/tools/ld-process-efm/Datatypes/tracktime.h
@@ -48,10 +48,10 @@ public:
     bool setTime(TrackTime::Time timeParam);
     void addFrames(qint32 frames);
     void subtractFrames(qint32 frames);
-    qint32 getDifference(TrackTime::Time timeToCompare);
-    Time getTime();
-    QString getTimeAsQString();
-    qint32 getFrames();
+    qint32 getDifference(TrackTime::Time timeToCompare) const;
+    Time getTime() const;
+    QString getTimeAsQString() const;
+    qint32 getFrames() const;
 
 private:
     qint32 trackFrames;

--- a/tools/ld-process-efm/Decoders/c1circ.cpp
+++ b/tools/ld-process-efm/Decoders/c1circ.cpp
@@ -45,13 +45,13 @@ void C1Circ::resetStatistics()
     statistics.c1flushed = 0;
 }
 
-C1Circ::Statistics C1Circ::getStatistics()
+const C1Circ::Statistics &C1Circ::getStatistics() const
 {
     return statistics;
 }
 
 // Method to write statistics information to qInfo
-void C1Circ::reportStatistics()
+void C1Circ::reportStatistics() const
 {
     qInfo() << "";
     qInfo() << "F3 to F2 frame C1 Error correction:";
@@ -90,14 +90,14 @@ void C1Circ::pushF3Frame(F3Frame f3Frame)
 }
 
 // Return the C1 data symbols if available
-uchar* C1Circ::getDataSymbols()
+const uchar *C1Circ::getDataSymbols() const
 {
     if (c1BufferLevel > 1) return outputC1Data;
     return nullptr;
 }
 
 // Return the C1 error symbols if available
-uchar* C1Circ::getErrorSymbols()
+const uchar *C1Circ::getErrorSymbols() const
 {
     if (c1BufferLevel > 1) return outputC1Errors;
     return nullptr;

--- a/tools/ld-process-efm/Decoders/c1circ.h
+++ b/tools/ld-process-efm/Decoders/c1circ.h
@@ -53,11 +53,11 @@ public:
 
     void reset();
     void resetStatistics();
-    Statistics getStatistics();
-    void reportStatistics();
+    const Statistics &getStatistics() const;
+    void reportStatistics() const;
     void pushF3Frame(F3Frame f3Frame);
-    uchar* getDataSymbols();
-    uchar* getErrorSymbols();
+    const uchar *getDataSymbols() const;
+    const uchar *getErrorSymbols() const;
     void flush();
 
 private:

--- a/tools/ld-process-efm/Decoders/c2circ.cpp
+++ b/tools/ld-process-efm/Decoders/c2circ.cpp
@@ -45,13 +45,13 @@ void C2Circ::resetStatistics()
     statistics.c2flushed = 0;
 }
 
-C2Circ::Statistics C2Circ::getStatistics()
+const C2Circ::Statistics &C2Circ::getStatistics() const
 {
     return statistics;
 }
 
 // Method to write statistics information to qInfo
-void C2Circ::reportStatistics(void)
+void C2Circ::reportStatistics() const
 {
     qInfo() << "";
     qInfo() << "F3 to F2 frame C2 Error correction:";
@@ -62,7 +62,7 @@ void C2Circ::reportStatistics(void)
     qInfo() << " Delay buffer flushes:" << statistics.c2flushed;
 }
 
-void C2Circ::pushC1(uchar* dataSymbols, uchar* errorSymbols)
+void C2Circ::pushC1(const uchar *dataSymbols, const uchar *errorSymbols)
 {
     // Create a new C1 element and append it to the C1 delay buffer
     C1Element newC1Element;
@@ -83,14 +83,14 @@ void C2Circ::pushC1(uchar* dataSymbols, uchar* errorSymbols)
 }
 
 // Return the C2 data symbols if available
-uchar* C2Circ::getDataSymbols()
+const uchar *C2Circ::getDataSymbols() const
 {
     if (c1DelayBuffer.size() >= 109) return outputC2Data;
     return nullptr;
 }
 
 // Return the C2 error symbols if available
-uchar* C2Circ::getErrorSymbols()
+const uchar *C2Circ::getErrorSymbols() const
 {
     if (c1DelayBuffer.size() >= 109) return outputC2Errors;
     return nullptr;

--- a/tools/ld-process-efm/Decoders/c2circ.cpp
+++ b/tools/ld-process-efm/Decoders/c2circ.cpp
@@ -70,11 +70,11 @@ void C2Circ::pushC1(const uchar *dataSymbols, const uchar *errorSymbols)
         newC1Element.c1Data[i] = dataSymbols[i];
         newC1Element.c1Error[i] = errorSymbols[i];
     }
-    c1DelayBuffer.append(newC1Element);
+    c1DelayBuffer.push_back(newC1Element);
 
     if (c1DelayBuffer.size() >= 109) {
         // Maintain the C1 delay buffer at 109 elements maximum
-        if (c1DelayBuffer.size() > 109) c1DelayBuffer.removeFirst();
+        if (c1DelayBuffer.size() > 109) c1DelayBuffer.erase(c1DelayBuffer.begin());
 
         // Interleave the C1 data and perform C2 error correction
         interleave();

--- a/tools/ld-process-efm/Decoders/c2circ.h
+++ b/tools/ld-process-efm/Decoders/c2circ.h
@@ -51,12 +51,12 @@ public:
 
     void reset();
     void resetStatistics();
-    Statistics getStatistics();
-    void reportStatistics();
-    void pushC1(uchar *dataSymbols, uchar *errorSymbols);
-    uchar* getDataSymbols();
-    uchar* getErrorSymbols();
-    bool getDataValid();
+    const Statistics &getStatistics() const;
+    void reportStatistics() const;
+    void pushC1(const uchar *dataSymbols, const uchar *errorSymbols);
+    const uchar *getDataSymbols() const;
+    const uchar *getErrorSymbols() const;
+    bool getDataValid() const;
     void flush();
 
 private:

--- a/tools/ld-process-efm/Decoders/c2circ.h
+++ b/tools/ld-process-efm/Decoders/c2circ.h
@@ -27,6 +27,7 @@
 
 #include <QCoreApplication>
 #include <QDebug>
+#include <vector>
 
 #include <ezpwd/rs_base>
 #include <ezpwd/rs>
@@ -64,7 +65,7 @@ private:
         uchar c1Data[28];
         uchar c1Error[28];
     };
-    QVector<C1Element> c1DelayBuffer;
+    std::vector<C1Element> c1DelayBuffer;
 
     uchar interleavedC2Data[28];
     uchar interleavedC2Errors[28];

--- a/tools/ld-process-efm/Decoders/c2deinterleave.cpp
+++ b/tools/ld-process-efm/Decoders/c2deinterleave.cpp
@@ -69,11 +69,11 @@ void C2Deinterleave::pushC2(const uchar *dataSymbols, const uchar *errorSymbols)
         newC2Element.c2Error[i] = errorSymbols[i];
     }
 
-    c2DelayBuffer.append(newC2Element);
+    c2DelayBuffer.push_back(newC2Element);
 
     if (c2DelayBuffer.size() >= 3) {
         // Maintain the C2 delay buffer at 3 elements maximum
-        if (c2DelayBuffer.size() > 3) c2DelayBuffer.removeFirst();
+        if (c2DelayBuffer.size() > 3) c2DelayBuffer.erase(c2DelayBuffer.begin());
 
         // Deinterleave the C2 data
         deinterleave();

--- a/tools/ld-process-efm/Decoders/c2deinterleave.cpp
+++ b/tools/ld-process-efm/Decoders/c2deinterleave.cpp
@@ -44,13 +44,13 @@ void C2Deinterleave::resetStatistics()
     statistics.c2flushed = 0;
 }
 
-C2Deinterleave::Statistics C2Deinterleave::getStatistics()
+const C2Deinterleave::Statistics &C2Deinterleave::getStatistics() const
 {
     return statistics;
 }
 
 // Method to write statistics information to qInfo
-void C2Deinterleave::reportStatistics()
+void C2Deinterleave::reportStatistics() const
 {
     qInfo() << "";
     qInfo() << "F3 to F2 frame C2 Deinterleave:";
@@ -60,7 +60,7 @@ void C2Deinterleave::reportStatistics()
     qInfo() << " Delay buffer flushes:" << statistics.c2flushed;
 }
 
-void C2Deinterleave::pushC2(uchar *dataSymbols, uchar *errorSymbols)
+void C2Deinterleave::pushC2(const uchar *dataSymbols, const uchar *errorSymbols)
 {
     // Create a new C2 element and append it to the C2 delay buffer
     C2Element newC2Element;
@@ -81,14 +81,14 @@ void C2Deinterleave::pushC2(uchar *dataSymbols, uchar *errorSymbols)
 }
 
 // Return the deinterleaved C2 data symbols if available
-uchar* C2Deinterleave::getDataSymbols()
+const uchar *C2Deinterleave::getDataSymbols() const
 {
     if (c2DelayBuffer.size() >= 3) return outputC2Data;
     return nullptr;
 }
 
 // Return the deinterleaved C2 error symbols if available
-uchar* C2Deinterleave::getErrorSymbols()
+const uchar *C2Deinterleave::getErrorSymbols() const
 {
     if (c2DelayBuffer.size() >= 3) return outputC2Errors;
     return nullptr;

--- a/tools/ld-process-efm/Decoders/c2deinterleave.h
+++ b/tools/ld-process-efm/Decoders/c2deinterleave.h
@@ -27,6 +27,7 @@
 
 #include <QCoreApplication>
 #include <QDebug>
+#include <vector>
 
 class C2Deinterleave
 {
@@ -54,7 +55,7 @@ private:
         uchar c2Data[28];
         uchar c2Error[28];
     };
-    QVector<C2Element> c2DelayBuffer;
+    std::vector<C2Element> c2DelayBuffer;
 
     uchar outputC2Data[24];
     uchar outputC2Errors[24];

--- a/tools/ld-process-efm/Decoders/c2deinterleave.h
+++ b/tools/ld-process-efm/Decoders/c2deinterleave.h
@@ -42,11 +42,11 @@ public:
 
     void reset();
     void resetStatistics();
-    Statistics getStatistics();
-    void reportStatistics();
-    void pushC2(uchar* dataSymbols, uchar* errorSymbols);
-    uchar* getDataSymbols();
-    uchar* getErrorSymbols();
+    const Statistics &getStatistics() const;
+    void reportStatistics() const;
+    void pushC2(const uchar *dataSymbols, const uchar *errorSymbols);
+    const uchar *getDataSymbols() const;
+    const uchar *getErrorSymbols() const;
     void flush();
 
 private:

--- a/tools/ld-process-efm/Decoders/efmtof3frames.cpp
+++ b/tools/ld-process-efm/Decoders/efmtof3frames.cpp
@@ -74,13 +74,13 @@ QVector<F3Frame> EfmToF3Frames::process(QByteArray efmDataIn, bool debugState, b
 }
 
 // Get method - retrieve statistics
-EfmToF3Frames::Statistics EfmToF3Frames::getStatistics()
+const EfmToF3Frames::Statistics &EfmToF3Frames::getStatistics() const
 {
     return statistics;
 }
 
 // Method to report decoding statistics to qInfo
-void EfmToF3Frames::reportStatistics()
+void EfmToF3Frames::reportStatistics() const
 {
     qInfo() << "";
     qInfo() << "EFM to F3 Frames:";
@@ -109,7 +109,7 @@ void EfmToF3Frames::reportStatistics()
 }
 
 // Method to reset the class
-void EfmToF3Frames::reset(void)
+void EfmToF3Frames::reset()
 {
     clearStatistics();
 

--- a/tools/ld-process-efm/Decoders/efmtof3frames.cpp
+++ b/tools/ld-process-efm/Decoders/efmtof3frames.cpp
@@ -33,7 +33,7 @@ EfmToF3Frames::EfmToF3Frames()
 // Public methods -----------------------------------------------------------------------------------------------------
 
 // Main processing method
-QVector<F3Frame> EfmToF3Frames::process(QByteArray efmDataIn, bool debugState, bool _audioIsDts)
+std::vector<F3Frame> EfmToF3Frames::process(QByteArray efmDataIn, bool debugState, bool _audioIsDts)
 {
     debugOn = debugState;
     audioIsDts = _audioIsDts;
@@ -383,11 +383,11 @@ EfmToF3Frames::StateMachine EfmToF3Frames::sm_state_processFrame()
 
     // Now we hand the data over to the F3 frame class which converts the data
     // into a F3 frame and save the F3 frame to our output data buffer
-    f3FramesOut.append(F3Frame(frameT, tLength, audioIsDts));
+    f3FramesOut.emplace_back(frameT, tLength, audioIsDts);
 
-    statistics.validEfmSymbols += f3FramesOut.last().getNumberOfValidEfmSymbols();
-    statistics.invalidEfmSymbols += f3FramesOut.last().getNumberOfInvalidEfmSymbols();
-    statistics.correctedEfmSymbols += f3FramesOut.last().getNumberOfCorrectedEfmSymbols();
+    statistics.validEfmSymbols += f3FramesOut.back().getNumberOfValidEfmSymbols();
+    statistics.invalidEfmSymbols += f3FramesOut.back().getNumberOfInvalidEfmSymbols();
+    statistics.correctedEfmSymbols += f3FramesOut.back().getNumberOfCorrectedEfmSymbols();
 
     // Discard all transitions up to the sync end
     efmDataBuffer.remove(0, endSyncTransition);

--- a/tools/ld-process-efm/Decoders/efmtof3frames.h
+++ b/tools/ld-process-efm/Decoders/efmtof3frames.h
@@ -27,6 +27,7 @@
 
 #include <QCoreApplication>
 #include <QDebug>
+#include <vector>
 
 #include "Datatypes/f3frame.h"
 
@@ -54,7 +55,7 @@ public:
         qint64 correctedEfmSymbols;
     };
 
-    QVector<F3Frame> process(QByteArray efmDataIn, bool debugState, bool _audioIsDts);
+    std::vector<F3Frame> process(QByteArray efmDataIn, bool debugState, bool _audioIsDts);
     const Statistics &getStatistics() const;
     void reportStatistics() const;
     void reset();
@@ -64,7 +65,7 @@ private:
     bool audioIsDts;
     Statistics statistics;
     QByteArray efmDataBuffer;
-    QVector<F3Frame> f3FramesOut;
+    std::vector<F3Frame> f3FramesOut;
 
     // State machine state definitions
     enum StateMachine {

--- a/tools/ld-process-efm/Decoders/efmtof3frames.h
+++ b/tools/ld-process-efm/Decoders/efmtof3frames.h
@@ -55,8 +55,8 @@ public:
     };
 
     QVector<F3Frame> process(QByteArray efmDataIn, bool debugState, bool _audioIsDts);
-    Statistics getStatistics();
-    void reportStatistics();
+    const Statistics &getStatistics() const;
+    void reportStatistics() const;
     void reset();
 
 private:

--- a/tools/ld-process-efm/Decoders/f1toaudio.cpp
+++ b/tools/ld-process-efm/Decoders/f1toaudio.cpp
@@ -71,13 +71,13 @@ QByteArray F1ToAudio::process(QVector<F1Frame> f1FramesIn, bool _padInitialDiscT
 }
 
 // Get method - retrieve statistics
-F1ToAudio::Statistics F1ToAudio::getStatistics()
+const F1ToAudio::Statistics &F1ToAudio::getStatistics() const
 {
     return statistics;
 }
 
 // Method to report decoding statistics to qInfo
-void F1ToAudio::reportStatistics()
+void F1ToAudio::reportStatistics() const
 {
     qInfo()           << "";
     qInfo()           << "F1 Frames to Audio:";
@@ -352,7 +352,7 @@ void F1ToAudio::linearInterpolationConceal()
             samplePointer++;
         }
         outputSample.setSampleValues(sampleValues);
-        pcmOutputBuffer.append(QByteArray(reinterpret_cast<char*>(outputSample.getSampleFrame()), 24));
+        pcmOutputBuffer.append(QByteArray(reinterpret_cast<const char *>(outputSample.getSampleFrame()), 24));
         statistics.concealedSamples += 6;
         statistics.totalSamples += 6;
     }
@@ -421,7 +421,7 @@ void F1ToAudio::predictiveInterpolationConceal()
             samplePointer++;
         }
         outputSample.setSampleValues(sampleValues);
-        pcmOutputBuffer.append(QByteArray(reinterpret_cast<char*>(outputSample.getSampleFrame()), 24));
+        pcmOutputBuffer.append(QByteArray(reinterpret_cast<const char *>(outputSample.getSampleFrame()), 24));
         statistics.concealedSamples += 6;
         statistics.totalSamples += 6;
     }

--- a/tools/ld-process-efm/Decoders/f1toaudio.cpp
+++ b/tools/ld-process-efm/Decoders/f1toaudio.cpp
@@ -33,7 +33,7 @@ F1ToAudio::F1ToAudio()
 // Public methods -----------------------------------------------------------------------------------------------------
 
 // Method to feed the audio processing state-machine with F1 frames
-QByteArray F1ToAudio::process(QVector<F1Frame> f1FramesIn, bool _padInitialDiscTime,
+QByteArray F1ToAudio::process(const std::vector<F1Frame> &f1FramesIn, bool _padInitialDiscTime,
                               ErrorTreatment _errorTreatment, ConcealType _concealType,
                               bool debugState)
 {
@@ -45,10 +45,10 @@ QByteArray F1ToAudio::process(QVector<F1Frame> f1FramesIn, bool _padInitialDiscT
     // Clear the output buffer
     pcmOutputBuffer.clear();
 
-    if (f1FramesIn.isEmpty()) return pcmOutputBuffer;
+    if (f1FramesIn.empty()) return pcmOutputBuffer;
 
     // Append input data to the processing buffer
-    f1FrameBuffer.append(f1FramesIn);
+    f1FrameBuffer.insert(f1FrameBuffer.end(), f1FramesIn.begin(), f1FramesIn.end());
 
     waitingForData = false;
     while (!waitingForData) {
@@ -143,15 +143,15 @@ F1ToAudio::StateMachine F1ToAudio::sm_state_processFrame()
 {
     // If error treatment is silence or pass-though, use a fast, simple method
     if (errorTreatment == ErrorTreatment::silence || errorTreatment == ErrorTreatment::passThrough) {
-        for (qint32 bufferPosition = 0; bufferPosition < f1FrameBuffer.size(); bufferPosition++) {
+        for (const F1Frame &f1Frame: f1FrameBuffer) {
             uchar f1FrameData[24];
 
             // If error correction is silence, set corrupt samples to silence
-            if (f1FrameBuffer[bufferPosition].isCorrupt() || f1FrameBuffer[bufferPosition].isMissing()) {
+            if (f1Frame.isCorrupt() || f1Frame.isMissing()) {
                 // Frame is corrupt, use zeroed data
                 for (qint32 j = 0; j < 24; j++) f1FrameData[j] = 0;
-                if (f1FrameBuffer[bufferPosition].isCorrupt()) statistics.corruptSamples += 6;
-                if (f1FrameBuffer[bufferPosition].isMissing()) {
+                if (f1Frame.isCorrupt()) statistics.corruptSamples += 6;
+                if (f1Frame.isMissing()) {
                     if (!padInitialDiscTime) {
                         // Only count as a missing sample after the first good sample is seen
                         if (gotFirstSample) statistics.missingSamples += 6;
@@ -159,11 +159,11 @@ F1ToAudio::StateMachine F1ToAudio::sm_state_processFrame()
                 }
             } else {
                 // Frame is good - Get the frame data
-                for (qint32 j = 0; j < 24; j++) f1FrameData[j] = f1FrameBuffer[bufferPosition].getDataSymbols()[j];
+                for (qint32 j = 0; j < 24; j++) f1FrameData[j] = f1Frame.getDataSymbols()[j];
                 statistics.audioSamples += 6;
                 gotFirstSample = true;
                 if (!initialDiscTimeSet) {
-                    statistics.startTime = f1FrameBuffer[bufferPosition].getDiscTime();
+                    statistics.startTime = f1Frame.getDiscTime();
                     initialDiscTimeSet = true;
                 }
             }
@@ -181,7 +181,7 @@ F1ToAudio::StateMachine F1ToAudio::sm_state_processFrame()
                 }
             }
 
-            statistics.currentTime = f1FrameBuffer[bufferPosition].getDiscTime();
+            statistics.currentTime = f1Frame.getDiscTime();
             statistics.duration.setTime(0, 0, 0);
             statistics.duration.addFrames(statistics.currentTime.getDifference(statistics.startTime.getTime()));
         }
@@ -196,7 +196,7 @@ F1ToAudio::StateMachine F1ToAudio::sm_state_processFrame()
     // Error treatment is conceal
     qint32 bufferPosition = 0;
     uchar f1FrameData[24];
-    while (bufferPosition < f1FrameBuffer.size()) {
+    while (bufferPosition < static_cast<qint32>(f1FrameBuffer.size())) {
         if (!f1FrameBuffer[bufferPosition].isCorrupt()) {
             if (!f1FrameBuffer[bufferPosition].isMissing()) {
                 // Frame is not corrupt and not missing... good Frame
@@ -258,7 +258,7 @@ F1ToAudio::StateMachine F1ToAudio::sm_state_findEndOfError()
 {
     qint32 bufferPosition = errorStartPosition;
     errorStopPosition = -1;
-    while (bufferPosition < f1FrameBuffer.size() && errorStopPosition == -1) {
+    while (bufferPosition < static_cast<qint32>(f1FrameBuffer.size()) && errorStopPosition == -1) {
         if (!f1FrameBuffer[bufferPosition].isCorrupt()) {
             errorStopPosition = bufferPosition - 1; // Last corrupt frame
         }
@@ -294,7 +294,7 @@ F1ToAudio::StateMachine F1ToAudio::sm_state_findEndOfError()
     }
 
     // Remove the contents of the input buffer (up to the error start)
-    f1FrameBuffer.remove(0, errorStopPosition + 1);
+    f1FrameBuffer.erase(f1FrameBuffer.begin(), f1FrameBuffer.begin() + errorStopPosition + 1);
 
     // Make sure the buffer isn't completely empty
     if (f1FrameBuffer.size() == 0) waitingForData = true;
@@ -318,10 +318,8 @@ void F1ToAudio::linearInterpolationConceal()
     qint32 samplesToGenerate = framesToGenerate * 6; // Per stereo channel
 
     // Create some temporary buffers
-    QVector<qint16> leftSamples;
-    QVector<qint16> rightSamples;
-    leftSamples.resize(samplesToGenerate);
-    rightSamples.resize(samplesToGenerate);
+    std::vector<qint16> leftSamples(samplesToGenerate);
+    std::vector<qint16> rightSamples(samplesToGenerate);
 
     // Calculate sample step values and initial values
     double leftStep = (static_cast<double>(leftChannelEndValue) -
@@ -378,10 +376,8 @@ void F1ToAudio::predictiveInterpolationConceal()
     qint32 samplesToGenerate = framesToGenerate * 6; // Per stereo channel
 
     // Create some temporary buffers
-    QVector<qint16> leftSamples;
-    QVector<qint16> rightSamples;
-    leftSamples.resize(samplesToGenerate);
-    rightSamples.resize(samplesToGenerate);
+    std::vector<qint16> leftSamples(samplesToGenerate);
+    std::vector<qint16> rightSamples(samplesToGenerate);
 
     // Calculate sample step values and initial values
     double leftStep = (static_cast<double>(leftChannelEndValue) -

--- a/tools/ld-process-efm/Decoders/f1toaudio.h
+++ b/tools/ld-process-efm/Decoders/f1toaudio.h
@@ -27,6 +27,7 @@
 
 #include <QCoreApplication>
 #include <QDebug>
+#include <vector>
 
 #include "Datatypes/f1frame.h"
 #include "Datatypes/audio.h"
@@ -61,7 +62,7 @@ public:
         TrackTime duration;
     };
 
-    QByteArray process(QVector<F1Frame> f1FramesIn, bool _padInitialDiscTime,
+    QByteArray process(const std::vector<F1Frame> &f1FramesIn, bool _padInitialDiscTime,
                        ErrorTreatment _errorTreatment, ConcealType _concealType, bool debugState);
     const Statistics &getStatistics() const;
     void reportStatistics() const;
@@ -83,7 +84,7 @@ private:
     StateMachine currentState;
     StateMachine nextState;
     QByteArray pcmOutputBuffer;
-    QVector<F1Frame> f1FrameBuffer;
+    std::vector<F1Frame> f1FrameBuffer;
     bool waitingForData;
     ErrorTreatment errorTreatment;
     ConcealType concealType;

--- a/tools/ld-process-efm/Decoders/f1toaudio.h
+++ b/tools/ld-process-efm/Decoders/f1toaudio.h
@@ -63,8 +63,8 @@ public:
 
     QByteArray process(QVector<F1Frame> f1FramesIn, bool _padInitialDiscTime,
                        ErrorTreatment _errorTreatment, ConcealType _concealType, bool debugState);
-    Statistics getStatistics();
-    void reportStatistics();
+    const Statistics &getStatistics() const;
+    void reportStatistics() const;
     void reset();
     void clearStatistics();
 

--- a/tools/ld-process-efm/Decoders/f1todata.cpp
+++ b/tools/ld-process-efm/Decoders/f1todata.cpp
@@ -48,23 +48,23 @@ F1ToData::F1ToData()
 // Public methods -----------------------------------------------------------------------------------------------------
 
 // Method to feed the sector processing state-machine with F1 frames
-QByteArray F1ToData::process(QVector<F1Frame> f1FramesIn, bool debugState)
+QByteArray F1ToData::process(const std::vector<F1Frame> &f1FramesIn, bool debugState)
 {
     debugOn = debugState;
 
     // Clear the output buffer
     dataOutputBuffer.clear();
 
-    if (f1FramesIn.isEmpty()) return dataOutputBuffer;
+    if (f1FramesIn.empty()) return dataOutputBuffer;
 
     // Append input data to the processing buffer
-    for (qint32 i = 0; i < f1FramesIn.size(); i++) {
-        f1DataBuffer.append(reinterpret_cast<const char *>(f1FramesIn[i].getDataSymbols()), 24);
+    for (const F1Frame &f1Frame: f1FramesIn) {
+        f1DataBuffer.append(reinterpret_cast<const char *>(f1Frame.getDataSymbols()), 24);
 
         // Each validity flag covers 24 bytes of data symbols
         for (qint32 p = 0; p < 24; p++) {
-            f1IsCorruptBuffer.append(f1FramesIn[i].isCorrupt());
-            f1IsMissingBuffer.append(f1FramesIn[i].isMissing());
+            f1IsCorruptBuffer.append(f1Frame.isCorrupt());
+            f1IsMissingBuffer.append(f1Frame.isMissing());
         }
     }
 

--- a/tools/ld-process-efm/Decoders/f1todata.cpp
+++ b/tools/ld-process-efm/Decoders/f1todata.cpp
@@ -59,7 +59,7 @@ QByteArray F1ToData::process(QVector<F1Frame> f1FramesIn, bool debugState)
 
     // Append input data to the processing buffer
     for (qint32 i = 0; i < f1FramesIn.size(); i++) {
-        f1DataBuffer.append(reinterpret_cast<char*>(f1FramesIn[i].getDataSymbols()), 24);
+        f1DataBuffer.append(reinterpret_cast<const char *>(f1FramesIn[i].getDataSymbols()), 24);
 
         // Each validity flag covers 24 bytes of data symbols
         for (qint32 p = 0; p < 24; p++) {
@@ -95,13 +95,13 @@ QByteArray F1ToData::process(QVector<F1Frame> f1FramesIn, bool debugState)
 }
 
 // Get method - retrieve statistics
-F1ToData::Statistics F1ToData::getStatistics()
+const F1ToData::Statistics &F1ToData::getStatistics() const
 {
     return statistics;
 }
 
 // Method to report decoding statistics to qInfo
-void F1ToData::reportStatistics()
+void F1ToData::reportStatistics() const
 {
     qInfo()           << "";
     qInfo()           << "F1 Frames to Data:";

--- a/tools/ld-process-efm/Decoders/f1todata.h
+++ b/tools/ld-process-efm/Decoders/f1todata.h
@@ -27,6 +27,7 @@
 
 #include <QCoreApplication>
 #include <QDebug>
+#include <vector>
 
 #include "Datatypes/f1frame.h"
 #include "Datatypes/sector.h"
@@ -47,7 +48,7 @@ public:
         TrackTime currentAddress;
     };
 
-    QByteArray process(QVector<F1Frame> f1FramesIn, bool debugState);
+    QByteArray process(const std::vector<F1Frame> &f1FramesIn, bool debugState);
 
     const Statistics &getStatistics() const;
     void reportStatistics() const;

--- a/tools/ld-process-efm/Decoders/f1todata.h
+++ b/tools/ld-process-efm/Decoders/f1todata.h
@@ -49,8 +49,8 @@ public:
 
     QByteArray process(QVector<F1Frame> f1FramesIn, bool debugState);
 
-    Statistics getStatistics();
-    void reportStatistics();
+    const Statistics &getStatistics() const;
+    void reportStatistics() const;
     void reset();
     void clearStatistics();
 

--- a/tools/ld-process-efm/Decoders/f2tof1frames.cpp
+++ b/tools/ld-process-efm/Decoders/f2tof1frames.cpp
@@ -33,7 +33,7 @@ F2ToF1Frames::F2ToF1Frames()
 // Public methods -----------------------------------------------------------------------------------------------------
 
 // Method to feed the audio processing state-machine with F2Frames
-QVector<F1Frame> F2ToF1Frames::process(QVector<F2Frame> f2FramesIn, bool _debugState, bool _noTimeStamp)
+const std::vector<F1Frame> &F2ToF1Frames::process(const std::vector<F2Frame> &f2FramesIn, bool _debugState, bool _noTimeStamp)
 {
     debugOn = _debugState;
     noTimeStamp = _noTimeStamp;
@@ -41,10 +41,10 @@ QVector<F1Frame> F2ToF1Frames::process(QVector<F2Frame> f2FramesIn, bool _debugS
     // Clear the output buffer
     f1FramesOut.clear();
 
-    if (f2FramesIn.isEmpty()) return f1FramesOut;
+    if (f2FramesIn.empty()) return f1FramesOut;
 
     // Append input data to the processing buffer
-    f2FrameBuffer.append(f2FramesIn);
+    f2FrameBuffer.insert(f2FrameBuffer.end(), f2FramesIn.begin(), f2FramesIn.end());
 
     waitingForData = false;
     while (!waitingForData) {
@@ -162,7 +162,7 @@ F2ToF1Frames::StateMachine F2ToF1Frames::sm_state_getInitialDiscTime()
             f1Frame.setData(outputData, false, true, true, lastDiscTime, TrackTime(0, 0, 0), 0);
 
             for (qint32 s = 0; s < 98; s++) {
-                f1FramesOut.append(f1Frame);
+                f1FramesOut.push_back(f1Frame);
             }
 
             // Add filled section to statistics
@@ -205,7 +205,7 @@ F2ToF1Frames::StateMachine F2ToF1Frames::sm_state_processSection()
             f1Frame.setData(outputData, false, true, true, lastDiscTime, TrackTime(0, 0, 0), 0);
 
             for (qint32 s = 0; s < 98; s++) {
-                f1FramesOut.append(f1Frame);
+                f1FramesOut.push_back(f1Frame);
             }
 
             // Add filled section to statistics
@@ -234,7 +234,7 @@ F2ToF1Frames::StateMachine F2ToF1Frames::sm_state_processSection()
     for (qint32 i = 0; i < 98; i++) {
         f1Frame.setData(f2FrameBuffer[i].getDataSymbols(), f2FrameBuffer[i].isFrameCorrupt(), sectionEncoderState, false,
                         f2FrameBuffer[i].getDiscTime(), f2FrameBuffer[i].getTrackTime(), f2FrameBuffer[i].getTrackNumber());
-        f1FramesOut.append(f1Frame);
+        f1FramesOut.push_back(f1Frame);
 
         // Update the statistics
         if (f2FrameBuffer[i].isFrameCorrupt()) statistics.invalidF2Frames++; else statistics.validF2Frames++;
@@ -243,7 +243,7 @@ F2ToF1Frames::StateMachine F2ToF1Frames::sm_state_processSection()
     }
 
     // Remove the processed section from the F2 frame buffer
-    f2FrameBuffer.remove(0, 98);
+    f2FrameBuffer.erase(f2FrameBuffer.begin(), f2FrameBuffer.begin() + 98);
 
     // Request more F2 frame data if required
     if (f2FrameBuffer.size() < 98) waitingForData = true;

--- a/tools/ld-process-efm/Decoders/f2tof1frames.cpp
+++ b/tools/ld-process-efm/Decoders/f2tof1frames.cpp
@@ -67,13 +67,13 @@ QVector<F1Frame> F2ToF1Frames::process(QVector<F2Frame> f2FramesIn, bool _debugS
 }
 
 // Get method - retrieve statistics
-F2ToF1Frames::Statistics F2ToF1Frames::getStatistics()
+const F2ToF1Frames::Statistics &F2ToF1Frames::getStatistics() const
 {
     return statistics;
 }
 
 // Method to report decoding statistics to qInfo
-void F2ToF1Frames::reportStatistics()
+void F2ToF1Frames::reportStatistics() const
 {
     qInfo()           << "";
     qInfo()           << "F2 Frames to F1 Frames:";

--- a/tools/ld-process-efm/Decoders/f2tof1frames.h
+++ b/tools/ld-process-efm/Decoders/f2tof1frames.h
@@ -27,6 +27,7 @@
 
 #include <QCoreApplication>
 #include <QDebug>
+#include <vector>
 
 #include "Datatypes/f2frame.h"
 #include "Datatypes/f1frame.h"
@@ -48,7 +49,7 @@ public:
         TrackTime frameCurrent;
     };
 
-    QVector<F1Frame> process(QVector<F2Frame> f2FramesIn, bool _debugState, bool _noTimeStamp);
+    const std::vector<F1Frame> &process(const std::vector<F2Frame> &f2FramesIn, bool _debugState, bool _noTimeStamp);
     const Statistics &getStatistics() const;
     void reportStatistics() const;
     void reset();
@@ -67,8 +68,8 @@ private:
 
     StateMachine currentState;
     StateMachine nextState;
-    QVector<F2Frame> f2FrameBuffer;
-    QVector<F1Frame> f1FramesOut;
+    std::vector<F2Frame> f2FrameBuffer;
+    std::vector<F1Frame> f1FramesOut;
     bool waitingForData;
     TrackTime lastDiscTime;
 

--- a/tools/ld-process-efm/Decoders/f2tof1frames.h
+++ b/tools/ld-process-efm/Decoders/f2tof1frames.h
@@ -49,8 +49,8 @@ public:
     };
 
     QVector<F1Frame> process(QVector<F2Frame> f2FramesIn, bool _debugState, bool _noTimeStamp);
-    Statistics getStatistics();
-    void reportStatistics();
+    const Statistics &getStatistics() const;
+    void reportStatistics() const;
     void reset();
 
 private:

--- a/tools/ld-process-efm/Decoders/f3tof2frames.cpp
+++ b/tools/ld-process-efm/Decoders/f3tof2frames.cpp
@@ -32,13 +32,15 @@ F3ToF2Frames::F3ToF2Frames()
 
 // Public methods -----------------------------------------------------------------------------------------------------
 
-QVector<F2Frame> F3ToF2Frames::process(QVector<F3Frame> f3FramesIn, bool debugState, bool noTimeStamp)
+const std::vector<F2Frame> &F3ToF2Frames::process(const std::vector<F3Frame> &f3FramesIn, bool debugState, bool noTimeStamp)
 {
     debugOn = debugState;
-    QVector<F2Frame> f2FramesOut;
+
+    // Clear the output buffer
+    f2FramesOut.clear();
 
     // Make sure there is something to process
-    if (f3FramesIn.isEmpty()) return f2FramesOut;
+    if (f3FramesIn.empty()) return f2FramesOut;
 
     // Ensure that the upstream is providing only complete sections of
     // 98 frames... otherwise we have an upstream bug.
@@ -48,24 +50,17 @@ QVector<F2Frame> F3ToF2Frames::process(QVector<F3Frame> f3FramesIn, bool debugSt
         // return f2FramesOut;
     }
 
-    // Process the incoming F3 Frames
-    while (!f3FramesIn.isEmpty()) {
-        // Input data must be available in sections of 98 F3 frames, synchronised with a section
-        // read in the 98 F3 Frames
-        F3Frame f3FrameBuffer[98];
-        F3Frame f3Frame;
+    // Process the incoming F3 Frames.
+    // Input data must be available in sections of 98 F3 frames, synchronised with a section.
+    const qint32 numInputFrames = static_cast<qint32>(f3FramesIn.size());
+    for (qint32 inputIndex = 0; inputIndex < numInputFrames; inputIndex += 98) {
+        statistics.totalF3Frames += 98;
+
+        // Collect the 98 subcode data symbols
         uchar sectionData[98];
         for (qint32 i = 0; i < 98; i++) {
-            // Get the incoming F3 frame and place it in the F3 frame buffer
-            f3FrameBuffer[i] = f3FramesIn[i];
-            statistics.totalF3Frames++;
-
-            // Collect the 98 subcode data symbols
-            sectionData[i] = f3FrameBuffer[i].getSubcodeSymbol();
+            sectionData[i] = f3FramesIn[inputIndex + i].getSubcodeSymbol();
         }
-
-        // Remove the consumed F3 frames from the input buffer
-        f3FramesIn.remove(0, 98);
 
         // Process the subcode data into a section
         Section section;
@@ -181,13 +176,13 @@ QVector<F2Frame> F3ToF2Frames::process(QVector<F3Frame> f3FramesIn, bool debugSt
             statistics.currentDiscTime = currentDiscTime;
 
             // Add the new section to our section buffer
-            sectionBuffer.append(section);
-            sectionDiscTimes.append(currentDiscTime);
+            sectionBuffer.push_back(section);
+            sectionDiscTimes.push_back(currentDiscTime);
 
             // Process the F3 frames into F2 frames (payload data)
             for (qint32 i = 0; i < 98; i++) {
                 // Process C1 CIRC
-                c1Circ.pushF3Frame(f3FrameBuffer[i]);
+                c1Circ.pushF3Frame(f3FramesIn[inputIndex + i]);
 
                 // If we have C1 results, process C2
                 if (c1Circ.getDataSymbols() != nullptr) {
@@ -246,7 +241,7 @@ QVector<F2Frame> F3ToF2Frames::process(QVector<F3Frame> f3FramesIn, bool debugSt
                             }
 
                             // Add the F2 frame to our output buffer
-                            f2FrameBuffer.append(newF2Frame);
+                            f2FrameBuffer.push_back(newF2Frame);
 
                         }
                     }
@@ -254,12 +249,12 @@ QVector<F2Frame> F3ToF2Frames::process(QVector<F3Frame> f3FramesIn, bool debugSt
 
                 // If we have 98 F2 frames, move them to the output buffer
                 if (f2FrameBuffer.size() == 98) {
-                    for (qint32 i = 0; i < 98; i++) f2FramesOut.append(f2FrameBuffer[i]);
+                    f2FramesOut.insert(f2FramesOut.end(), f2FrameBuffer.begin(), f2FrameBuffer.end());
                     statistics.totalF2Frames += 98;
                     f2FrameBuffer.clear();
 
-                    sectionBuffer.removeFirst();
-                    sectionDiscTimes.removeFirst();
+                    sectionBuffer.erase(sectionBuffer.begin());
+                    sectionDiscTimes.erase(sectionDiscTimes.begin());
                 }
             }
         }

--- a/tools/ld-process-efm/Decoders/f3tof2frames.cpp
+++ b/tools/ld-process-efm/Decoders/f3tof2frames.cpp
@@ -269,7 +269,7 @@ QVector<F2Frame> F3ToF2Frames::process(QVector<F3Frame> f3FramesIn, bool debugSt
 }
 
 // Get method - retrieve statistics
-F3ToF2Frames::Statistics F3ToF2Frames::getStatistics()
+const F3ToF2Frames::Statistics &F3ToF2Frames::getStatistics()
 {
     // Ensure sub-class statistics are updated
     statistics.c1Circ_statistics = c1Circ.getStatistics();
@@ -280,7 +280,7 @@ F3ToF2Frames::Statistics F3ToF2Frames::getStatistics()
 }
 
 // Method to report decoding statistics to qInfo
-void F3ToF2Frames::reportStatistics()
+void F3ToF2Frames::reportStatistics() const
 {
     qInfo() << "";
     qInfo() << "F3 Frame to F2 Frame decode:";

--- a/tools/ld-process-efm/Decoders/f3tof2frames.h
+++ b/tools/ld-process-efm/Decoders/f3tof2frames.h
@@ -27,6 +27,7 @@
 
 #include <QCoreApplication>
 #include <QDebug>
+#include <vector>
 
 #include "Datatypes/f3frame.h"
 #include "Datatypes/f2frame.h"
@@ -59,7 +60,7 @@ public:
         qint32 preempFrames;
     };
 
-    QVector<F2Frame> process(QVector<F3Frame> f3FramesIn, bool debugState, bool noTimeStamp);
+    const std::vector<F2Frame> &process(const std::vector<F3Frame> &f3FramesIn, bool debugState, bool noTimeStamp);
     const Statistics &getStatistics();
     void reportStatistics() const;
     void reset();
@@ -74,9 +75,10 @@ private:
     C2Circ c2Circ;
     C2Deinterleave c2Deinterleave;
 
-    QVector<F2Frame> f2FrameBuffer;
-    QVector<Section> sectionBuffer;
-    QVector<TrackTime> sectionDiscTimes;
+    std::vector<F2Frame> f2FrameBuffer;
+    std::vector<F2Frame> f2FramesOut;
+    std::vector<Section> sectionBuffer;
+    std::vector<TrackTime> sectionDiscTimes;
 
     bool initialDiscTimeSet;
     TrackTime lastDiscTime;

--- a/tools/ld-process-efm/Decoders/f3tof2frames.h
+++ b/tools/ld-process-efm/Decoders/f3tof2frames.h
@@ -60,8 +60,8 @@ public:
     };
 
     QVector<F2Frame> process(QVector<F3Frame> f3FramesIn, bool debugState, bool noTimeStamp);
-    Statistics getStatistics();
-    void reportStatistics();
+    const Statistics &getStatistics();
+    void reportStatistics() const;
     void reset();
 
 private:

--- a/tools/ld-process-efm/Decoders/syncf3frames.cpp
+++ b/tools/ld-process-efm/Decoders/syncf3frames.cpp
@@ -45,18 +45,18 @@ SyncF3Frames::SyncF3Frames()
 // Public methods -----------------------------------------------------------------------------------------------------
 
 // Main processing method
-QVector<F3Frame> SyncF3Frames::process(QVector<F3Frame> f3FramesIn, bool debugState)
+const std::vector<F3Frame> &SyncF3Frames::process(const std::vector<F3Frame> &f3FramesIn, bool debugState)
 {
     debugOn = debugState;
 
     // Clear the output buffer
     f3FramesOut.clear();
 
-    if (f3FramesIn.isEmpty()) return f3FramesOut;
+    if (f3FramesIn.empty()) return f3FramesOut;
 
     // Append input data to the processing buffer
     statistics.totalF3Frames += f3FramesIn.size();
-    f3FrameBuffer.append(f3FramesIn);
+    f3FrameBuffer.insert(f3FrameBuffer.end(), f3FramesIn.begin(), f3FramesIn.end());
 
     waitingForData = false;
     while (!waitingForData) {
@@ -141,7 +141,8 @@ SyncF3Frames::StateMachine SyncF3Frames::sm_state_findInitialSync0()
     //if (debugOn) qDebug() << "SyncF3Frames::sm_state_findInitialSync0(): Called";
 
     qint32 i = 0;
-    for (i = 0; i < f3FrameBuffer.size() - 1; i++) {
+    const qint32 bufferSize = static_cast<qint32>(f3FrameBuffer.size());
+    for (i = 0; i < bufferSize - 1; i++) {
         if (f3FrameBuffer[i].isSubcodeSync0() || f3FrameBuffer[i+1].isSubcodeSync1()) break;
     }
 
@@ -157,7 +158,7 @@ SyncF3Frames::StateMachine SyncF3Frames::sm_state_findInitialSync0()
         return state_findInitialSync0;
     } else {
         // Found, discard frames up to initial sync
-        f3FrameBuffer.remove(0, i);
+        f3FrameBuffer.erase(f3FrameBuffer.begin(), f3FrameBuffer.begin() + i);
         statistics.discardedFrames += i;
         if (debugOn) qDebug() << "SyncF3Frames::sm_state_findInitialSync0(): Found initial sync0 - discarding" << i << "frames";
     }
@@ -202,7 +203,7 @@ SyncF3Frames::StateMachine SyncF3Frames::sm_state_syncRecovery()
     qint32 requiredF3Frames = 98 * (syncRecoveryAttempts + 2);
 
     // Ensure we have enough data to see the next section
-    if (f3FrameBuffer.size() < (requiredF3Frames + 2)) {
+    if (static_cast<qint32>(f3FrameBuffer.size()) < (requiredF3Frames + 2)) {
         waitingForData = true;
         return state_syncRecovery;
     }
@@ -248,7 +249,7 @@ SyncF3Frames::StateMachine SyncF3Frames::sm_state_syncLost()
     if (debugOn) qDebug() << "SyncF3Frames::sm_state_syncLost(): Called";
 
     // We have lost sync; clear the buffer and go back to looking for an initial sync
-    f3FrameBuffer.remove(0, 98);
+    f3FrameBuffer.erase(f3FrameBuffer.begin(), f3FrameBuffer.begin() + 98);
     statistics.discardedFrames += 98;
     if (debugOn) qDebug() << "SyncF3Frames::sm_state_findNextSync(): Sync lost! - discarding 98 frames";
 
@@ -265,13 +266,11 @@ SyncF3Frames::StateMachine SyncF3Frames::sm_state_processSection()
     //if (debugOn) qDebug() << "SyncF3Frames::sm_state_processSection(): Called";
 
     // Write the complete section of 98 F3 frames to the output buffer
-    for (qint32 i = 0; i < 98; i++) {
-        f3FramesOut.append(f3FrameBuffer[i]);
-    }
+    f3FramesOut.insert(f3FramesOut.end(), f3FrameBuffer.begin(), f3FrameBuffer.begin() + 98);
     statistics.totalSections++;
 
     // Remove the processed section from the F3 frame buffer
-    f3FrameBuffer.remove(0, 98);
+    f3FrameBuffer.erase(f3FrameBuffer.begin(), f3FrameBuffer.begin() + 98);
 
     return state_findNextSync;
 }

--- a/tools/ld-process-efm/Decoders/syncf3frames.cpp
+++ b/tools/ld-process-efm/Decoders/syncf3frames.cpp
@@ -88,13 +88,13 @@ QVector<F3Frame> SyncF3Frames::process(QVector<F3Frame> f3FramesIn, bool debugSt
 }
 
 // Get method - retrieve statistics
-SyncF3Frames::Statistics SyncF3Frames::getStatistics()
+const SyncF3Frames::Statistics &SyncF3Frames::getStatistics() const
 {
     return statistics;
 }
 
 // Method to report decoding statistics to qInfo
-void SyncF3Frames::reportStatistics()
+void SyncF3Frames::reportStatistics() const
 {
     qInfo() << "";
     qInfo() << "F3 Frame synchronisation:";

--- a/tools/ld-process-efm/Decoders/syncf3frames.h
+++ b/tools/ld-process-efm/Decoders/syncf3frames.h
@@ -27,6 +27,7 @@
 
 #include <QCoreApplication>
 #include <QDebug>
+#include <vector>
 
 #include "Datatypes/f3frame.h"
 
@@ -42,7 +43,7 @@ public:
         qint32 totalSections;
     };
 
-    QVector<F3Frame> process(QVector<F3Frame> f3FramesIn, bool debugState);
+    const std::vector<F3Frame> &process(const std::vector<F3Frame> &f3FramesIn, bool debugState);
     const Statistics &getStatistics() const;
     void reportStatistics() const;
     void reset();
@@ -50,8 +51,8 @@ public:
 private:
     bool debugOn;
     Statistics statistics;
-    QVector<F3Frame> f3FrameBuffer;
-    QVector<F3Frame> f3FramesOut;
+    std::vector<F3Frame> f3FrameBuffer;
+    std::vector<F3Frame> f3FramesOut;
     bool waitingForData;
     qint32 syncRecoveryAttempts;
 

--- a/tools/ld-process-efm/Decoders/syncf3frames.h
+++ b/tools/ld-process-efm/Decoders/syncf3frames.h
@@ -43,8 +43,8 @@ public:
     };
 
     QVector<F3Frame> process(QVector<F3Frame> f3FramesIn, bool debugState);
-    Statistics getStatistics();
-    void reportStatistics();
+    const Statistics &getStatistics() const;
+    void reportStatistics() const;
     void reset();
 
 private:

--- a/tools/ld-process-efm/efmprocess.cpp
+++ b/tools/ld-process-efm/efmprocess.cpp
@@ -90,7 +90,7 @@ void EfmProcess::setDecoderOptions(bool _padInitialDiscTime, bool _decodeAsData,
 }
 
 // Output the result of the decode to qInfo
-void EfmProcess::reportStatistics()
+void EfmProcess::reportStatistics() const
 {
     efmToF3Frames.reportStatistics();
     syncF3Frames.reportStatistics();
@@ -192,7 +192,7 @@ bool EfmProcess::process(QString inputFilename, QString outputFilename)
 }
 
 // Return statistics about the decoding process
-EfmProcess::Statistics EfmProcess::getStatistics(void)
+EfmProcess::Statistics EfmProcess::getStatistics()
 {
     // Gather statistics
     statistics.f3ToF2Frames = f3ToF2Frames.getStatistics();

--- a/tools/ld-process-efm/efmprocess.cpp
+++ b/tools/ld-process-efm/efmprocess.cpp
@@ -24,6 +24,8 @@
 
 #include "efmprocess.h"
 
+#include <vector>
+
 EfmProcess::EfmProcess()
 {
     debug_efmToF3Frames = false;
@@ -155,10 +157,10 @@ bool EfmProcess::process(QString inputFilename, QString outputFilename)
         if (bytesRead != bufferSize) inputEfmBuffer.resize(static_cast<qint32>(bytesRead));
 
         // Perform EFM processing
-        QVector<F3Frame> initialF3Frames = efmToF3Frames.process(inputEfmBuffer, debug_efmToF3Frames, audioIsDts);
-        QVector<F3Frame> syncedF3Frames = syncF3Frames.process(initialF3Frames, debug_syncF3Frames);
-        QVector<F2Frame> f2Frames = f3ToF2Frames.process(syncedF3Frames, debug_f3ToF2Frames, noTimeStamp);
-        QVector<F1Frame> f1Frames = f2ToF1Frames.process(f2Frames, debug_f2ToF1Frame, noTimeStamp);
+        const std::vector<F3Frame> &initialF3Frames = efmToF3Frames.process(inputEfmBuffer, debug_efmToF3Frames, audioIsDts);
+        const std::vector<F3Frame> &syncedF3Frames = syncF3Frames.process(initialF3Frames, debug_syncF3Frames);
+        const std::vector<F2Frame> &f2Frames = f3ToF2Frames.process(syncedF3Frames, debug_f3ToF2Frames, noTimeStamp);
+        const std::vector<F1Frame> &f1Frames = f2ToF1Frames.process(f2Frames, debug_f2ToF1Frame, noTimeStamp);
 
         // Process as either audio or data
         if (decodeAsAudio) {

--- a/tools/ld-process-efm/efmprocess.h
+++ b/tools/ld-process-efm/efmprocess.h
@@ -57,7 +57,7 @@ public:
                   bool _debug_f1ToAudio, bool _debug_f1ToData);
     void setAudioErrorTreatment(ErrorTreatment _errorTreatment);
     void setDecoderOptions(bool _padInitialDiscTime, bool _decodeAsData, bool _audioIsDts, bool _noTimeStamp);
-    void reportStatistics();
+    void reportStatistics() const;
     bool process(QString inputFilename, QString outputFilename);
     Statistics getStatistics();
     void reset();


### PR DESCRIPTION
Or: make ld-decode's test suite pass on a Raspberry Pi.

There's one trivial fix for ld-ac3-demodulate here, and some more substantial rework of ld-process-efm to make it use less memory - the test suite was failing on armv7 because it was running out of address space. Less unnecessary copying should be good for "big" architectures too.