### PR TITLE
Give ld-export-metadata support for writing Audacity labels files

### DIFF
--- a/tools/ld-export-metadata/CMakeLists.txt
+++ b/tools/ld-export-metadata/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_executable(ld-export-metadata
+    audacity.cpp
     closedcaptions.cpp
     csv.cpp
     ffmetadata.cpp

--- a/tools/ld-export-metadata/audacity.cpp
+++ b/tools/ld-export-metadata/audacity.cpp
@@ -1,0 +1,73 @@
+/************************************************************************
+
+    audacity.cpp
+
+    ld-export-metadata - Export JSON metadata into other formats
+    Copyright (C) 2023 Adam Sampson
+
+    This file is part of ld-decode-tools.
+
+    ld-export-metadata is free software: you can redistribute it and/or
+    modify it under the terms of the GNU General Public License as
+    published by the Free Software Foundation, either version 3 of the
+    License, or (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+************************************************************************/
+
+#include "audacity.h"
+
+#include "navigation.h"
+
+#include <QtGlobal>
+#include <QFile>
+#include <QTextStream>
+
+bool writeAudacityLabels(LdDecodeMetaData &metaData, const QString &fileName)
+{
+    const auto videoParameters = metaData.getVideoParameters();
+
+    // Positions are given in seconds, with exclusive ranges.
+    // Select a scale factor to convert from 0-based field numbers to seconds.
+    const double timeFactor = videoParameters.system == PAL ? (1.0 / 50.0) : (1001.0 / 60000.0);
+
+    // Extract navigation information
+    const NavigationInfo navInfo(metaData);
+
+    // Open the output file
+    QFile file(fileName);
+    if (!file.open(QFile::WriteOnly | QFile::Text)) {
+        qDebug("writeAudacityLabels: Could not open file for output");
+        return false;
+    }
+    QTextStream stream(&file);
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+    stream.setCodec("UTF-8");
+#endif
+
+    // Write the chapter changes
+    for (const auto &chapter: navInfo.chapters) {
+        stream << QString("%1\t%2\tChapter %3\n")
+                      .arg(static_cast<double>(chapter.startField) * timeFactor, 0, 'f')
+                      .arg(static_cast<double>(chapter.endField) * timeFactor, 0, 'f')
+                      .arg(chapter.number);
+    }
+
+    // Write the stop codes
+    for (qint32 field: navInfo.stopCodes) {
+        stream << QString("%1\t%2\tStop code\n")
+                      .arg(static_cast<double>(field) * timeFactor, 0, 'f')
+                      .arg(static_cast<double>(field) * timeFactor, 0, 'f');
+    }
+
+    // Done!
+    file.close();
+    return true;
+}

--- a/tools/ld-export-metadata/audacity.h
+++ b/tools/ld-export-metadata/audacity.h
@@ -1,0 +1,41 @@
+/************************************************************************
+
+    audacity.h
+
+    ld-export-metadata - Export JSON metadata into other formats
+    Copyright (C) 2023 Adam Sampson
+
+    This file is part of ld-decode-tools.
+
+    ld-export-metadata is free software: you can redistribute it and/or
+    modify it under the terms of the GNU General Public License as
+    published by the Free Software Foundation, either version 3 of the
+    License, or (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+************************************************************************/
+
+#ifndef AUDACITY_H
+#define AUDACITY_H
+
+#include <QString>
+
+#include "lddecodemetadata.h"
+
+/*!
+    Write an Audacity labels file containing navigation information.
+
+    Format description: <https://manual.audacityteam.org/man/importing_and_exporting_labels.html>
+
+    Returns true on success, false on failure.
+*/
+bool writeAudacityLabels(LdDecodeMetaData &metaData, const QString &fileName);
+
+#endif

--- a/tools/ld-export-metadata/ffmetadata.cpp
+++ b/tools/ld-export-metadata/ffmetadata.cpp
@@ -3,7 +3,7 @@
     ffmetadata.cpp
 
     ld-export-metadata - Export JSON metadata into other formats
-    Copyright (C) 2019-2020 Adam Sampson
+    Copyright (C) 2019-2023 Adam Sampson
 
     This file is part of ld-decode-tools.
 
@@ -24,88 +24,21 @@
 
 #include "ffmetadata.h"
 
-#include "vbidecoder.h"
+#include "navigation.h"
 
 #include <QtGlobal>
 #include <QFile>
 #include <QTextStream>
-#include <set>
-#include <vector>
-
-using std::set;
-using std::vector;
-
-struct ChapterChange {
-    qint32 field;
-    qint32 chapter;
-};
 
 bool writeFfmetadata(LdDecodeMetaData &metaData, const QString &fileName)
 {
     const auto videoParameters = metaData.getVideoParameters();
 
-    // We'll give positions using 0-based field indexes directly, rather than
-    // using the times encoded in the VBI, because we might be working with a
-    // capture of only part of a disc. Select the appropriate timebase to make
-    // this work.
+    // Select the appropriate timebase to make 0-based field numbers work
     const QString timeBase = videoParameters.system == PAL ? "1/50" : "1001/60000";
 
-    // Scan through the fields in the input, collecting VBI information
-    vector<ChapterChange> chapterChanges;
-    set<qint32> stopCodes;
-    qint32 chapter = -1;
-    qint32 firstFieldIndex = 0;
-    VbiDecoder vbiDecoder;
-
-    for (qint32 fieldIndex = 0; fieldIndex < videoParameters.numberOfSequentialFields; fieldIndex++) {
-        // Get the (1-based) field
-        const auto& field = metaData.getField(fieldIndex + 1);
-
-        // Codes may be in either field; we want the index of the first
-        if (field.isFirstField) {
-            firstFieldIndex = fieldIndex;
-        }
-
-        // Decode this field's VBI
-        const auto vbi = vbiDecoder.decode(field.vbi.vbiData[0], field.vbi.vbiData[1], field.vbi.vbiData[2]);
-
-        if (vbi.chNo != -1 && vbi.chNo != chapter) {
-            // Chapter change
-            chapter = vbi.chNo;
-            chapterChanges.emplace_back(ChapterChange {firstFieldIndex, chapter});
-        }
-
-        if (vbi.picStop) {
-            // Stop code
-            stopCodes.insert(firstFieldIndex);
-        }
-    }
-
-    // Add a dummy change at the end of the input, so we can get the length of
-    // the last chapter
-    chapterChanges.emplace_back(ChapterChange {videoParameters.numberOfSequentialFields, -1});
-
-    // Because chapter markers have no error detection, a corrupt marker will
-    // result in a spurious chapter change. Remove suspiciously short chapters.
-    // XXX This could be smarter for sequences like 1 1 1 1 *2 2 3* 2 2 2 2
-    vector<ChapterChange> cleanChanges;
-    for (qint32 i = 0; i < static_cast<qint32>(chapterChanges.size() - 1); i++) {
-        const auto &change = chapterChanges[i];
-        const auto &nextChange = chapterChanges[i + 1];
-
-        if ((nextChange.field - change.field) < 10) {
-            // Chapters should be at least 30 tracks (= 60 or more fields) long. So
-            // this is too short -- drop it.
-        } else if ((!cleanChanges.empty()) && (change.chapter == cleanChanges.back().chapter)) {
-            // Change to the same chapter - drop
-        } else {
-            // Keep
-            cleanChanges.emplace_back(change);
-        }
-    }
-
-    // Keep the dummy change
-    cleanChanges.emplace_back(chapterChanges.back());
+    // Extract navigation information
+    const NavigationInfo navInfo(metaData);
 
     // Open the output file
     QFile file(fileName);
@@ -121,24 +54,21 @@ bool writeFfmetadata(LdDecodeMetaData &metaData, const QString &fileName)
     // Write the header
     stream << ";FFMETADATA1\n";
 
-    // Write the chapter changes, skipping the dummy one at the end
-    for (qint32 i = 0; i < static_cast<qint32>(cleanChanges.size() - 1); i++) {
-        const auto &change = cleanChanges[i];
-        const auto &nextChange = cleanChanges[i + 1];
-
+    // Write the chapter changes
+    for (const auto &chapter: navInfo.chapters) {
         stream << "\n";
         stream << "[CHAPTER]\n";
         stream << "TIMEBASE=" << timeBase << "\n";
-        stream << "START=" << change.field << "\n";
-        stream << "END=" << (nextChange.field - 1) << "\n";
-        stream << "title=" << QString("Chapter %1").arg(change.chapter) << "\n";
+        stream << "START=" << chapter.startField << "\n";
+        stream << "END=" << chapter.endField - 1 << "\n";
+        stream << "title=" << QString("Chapter %1").arg(chapter.number) << "\n";
     }
 
-    if (!stopCodes.empty()) {
+    if (!navInfo.stopCodes.empty()) {
         // Write the stop codes, as comments
         // XXX Is there a way to represent these properly?
         stream << "\n";
-        for (qint32 field : stopCodes) {
+        for (qint32 field: navInfo.stopCodes) {
             stream << "; Stop code at " << field << "\n";
         }
     }

--- a/tools/ld-export-metadata/main.cpp
+++ b/tools/ld-export-metadata/main.cpp
@@ -3,7 +3,7 @@
     main.cpp
 
     ld-export-metadata - Export JSON metadata into other formats
-    Copyright (C) 2020 Adam Sampson
+    Copyright (C) 2020-2023 Adam Sampson
     Copyright (C) 2021 Simon Inns
 
     This file is part of ld-decode-tools.
@@ -28,6 +28,7 @@
 #include <QtGlobal>
 #include <QCommandLineParser>
 
+#include "audacity.h"
 #include "csv.h"
 #include "ffmetadata.h"
 #include "closedcaptions.h"
@@ -53,7 +54,7 @@ int main(int argc, char *argv[])
     parser.setApplicationDescription(
                 "ld-export-metadata - Export JSON metadata into other formats\n"
                 "\n"
-                "(c)2020 Adam Sampson\n"
+                "(c)2020-2023 Adam Sampson\n"
                 "(c)2021 Simon Inns\n"
                 "GPLv3 Open-Source - github: https://github.com/happycube/ld-decode");
     parser.addHelpOption();
@@ -75,6 +76,11 @@ int main(int argc, char *argv[])
                                           QCoreApplication::translate("main", "Write VBI information as CSV"),
                                           QCoreApplication::translate("main", "file"));
     parser.addOption(writeVbiCsvOption);
+
+    QCommandLineOption writeAudacityLabelsOption("audacity-labels",
+                                                 QCoreApplication::translate("main", "Write navigation information as Audacity labels"),
+                                                 QCoreApplication::translate("main", "file"));
+    parser.addOption(writeAudacityLabelsOption);
 
     QCommandLineOption writeFfmetadataOption("ffmetadata",
                                              QCoreApplication::translate("main", "Write navigation information as FFMETADATA1"),
@@ -125,6 +131,13 @@ int main(int argc, char *argv[])
     if (parser.isSet(writeVbiCsvOption)) {
         const QString &fileName = parser.value(writeVbiCsvOption);
         if (!writeVbiCsv(metaData, fileName)) {
+            qCritical() << "Failed to write output file:" << fileName;
+            return 1;
+        }
+    }
+    if (parser.isSet(writeAudacityLabelsOption)) {
+        const QString &fileName = parser.value(writeAudacityLabelsOption);
+        if (!writeAudacityLabels(metaData, fileName)) {
             qCritical() << "Failed to write output file:" << fileName;
             return 1;
         }

--- a/tools/library/CMakeLists.txt
+++ b/tools/library/CMakeLists.txt
@@ -4,6 +4,7 @@ add_library(lddecode-library STATIC
     tbc/jsonio.cpp
     tbc/lddecodemetadata.cpp
     tbc/logging.cpp
+    tbc/navigation.cpp
     tbc/sourceaudio.cpp
     tbc/sourcevideo.cpp
     tbc/vbidecoder.cpp

--- a/tools/library/tbc/navigation.cpp
+++ b/tools/library/tbc/navigation.cpp
@@ -1,0 +1,97 @@
+/************************************************************************
+
+    navigation.cpp
+
+    ld-decode-tools TBC library
+    Copyright (C) 2019-2023 Adam Sampson
+
+    This file is part of ld-decode-tools.
+
+    ld-decode-tools is free software: you can redistribute it and/or
+    modify it under the terms of the GNU General Public License as
+    published by the Free Software Foundation, either version 3 of the
+    License, or (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+************************************************************************/
+
+#include "navigation.h"
+
+#include "vbidecoder.h"
+
+// Construct a NavigationInfo from a disc's metadata
+NavigationInfo::NavigationInfo(LdDecodeMetaData &metaData)
+{
+    const qint32 numFields = metaData.getVideoParameters().numberOfSequentialFields;
+
+    // Scan through the fields in the input, collecting VBI information
+    std::vector<Chapter> rawChapters;
+    qint32 chapter = -1;
+    qint32 firstFieldIndex = 0;
+    VbiDecoder vbiDecoder;
+
+    for (qint32 fieldIndex = 0; fieldIndex < numFields; fieldIndex++) {
+        // Get the (1-based) field
+        const auto& field = metaData.getField(fieldIndex + 1);
+
+        // Codes may be in either field; we want the index of the first
+        if (field.isFirstField) {
+            firstFieldIndex = fieldIndex;
+        }
+
+        // Decode this field's VBI
+        const auto vbi = vbiDecoder.decode(field.vbi.vbiData[0], field.vbi.vbiData[1], field.vbi.vbiData[2]);
+
+        if (vbi.chNo != -1 && vbi.chNo != chapter) {
+            // Chapter change
+            chapter = vbi.chNo;
+            rawChapters.emplace_back(Chapter { firstFieldIndex, -1, chapter });
+        }
+
+        if (vbi.picStop) {
+            // Stop code
+            stopCodes.insert(firstFieldIndex);
+        }
+    }
+
+    // Add a dummy chapter at the end of the input, so we can get the length of
+    // the last chapter
+    rawChapters.emplace_back(Chapter { numFields, -1, -1 });
+
+    // Because chapter markers have no error detection, a corrupt marker will
+    // result in a spurious chapter change. Remove suspiciously short chapters.
+    // XXX This could be smarter for sequences like 1 1 1 1 *2 2 3* 2 2 2 2
+    for (qint32 i = 0; i < static_cast<qint32>(rawChapters.size() - 1); i++) {
+        const auto &chapter = rawChapters[i];
+        const auto &nextChapter = rawChapters[i + 1];
+
+        if ((nextChapter.startField - chapter.startField) < 10) {
+            // Chapters should be at least 30 tracks (= 60 or more fields) long. So
+            // this is too short -- drop it.
+            qDebug() << "NavigationInfo::NavigationInfo: Dropped too-short chapter" << chapter.number << "at field" << chapter.startField;
+        } else if ((!chapters.empty()) && (chapter.number == chapters.back().number)) {
+            // Change to the same chapter - drop
+        } else {
+            // Keep it
+            chapters.emplace_back(chapter);
+        }
+    }
+
+    // Keep the dummy chapter for now
+    chapters.emplace_back(rawChapters.back());
+
+    // Fill in endField for all the chapters we've kept
+    for (qint32 i = 0; i < static_cast<qint32>(chapters.size() - 1); i++) {
+        chapters[i].endField = chapters[i + 1].startField;
+    }
+
+    // And drop the dummy chapter
+    chapters.pop_back();
+}

--- a/tools/library/tbc/navigation.h
+++ b/tools/library/tbc/navigation.h
@@ -1,0 +1,55 @@
+/************************************************************************
+
+    navigation.h
+
+    ld-decode-tools TBC library
+    Copyright (C) 2019-2023 Adam Sampson
+
+    This file is part of ld-decode-tools.
+
+    ld-decode-tools is free software: you can redistribute it and/or
+    modify it under the terms of the GNU General Public License as
+    published by the Free Software Foundation, either version 3 of the
+    License, or (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+************************************************************************/
+
+#ifndef NAVIGATION_H
+#define NAVIGATION_H
+
+#include "lddecodemetadata.h"
+
+#include <QtGlobal>
+#include <set>
+#include <vector>
+
+// Navigation information extracted from LaserDisc metadata.
+// Positions are given in 0-based fields, relative to the start of the TBC file
+// (in case we're dealing with a clip from the middle of a disc).
+struct NavigationInfo {
+    NavigationInfo(LdDecodeMetaData &metaData);
+
+    struct Chapter {
+        // First field number
+        qint32 startField;
+        // Last field number (exclusive, i.e. first field of next chapter)
+        qint32 endField;
+        // Chapter number
+        qint32 number;
+    };
+
+    // Field numbers containing stop codes
+    std::set<qint32> stopCodes;
+    // Chapters
+    std::vector<Chapter> chapters;
+};
+
+#endif


### PR DESCRIPTION
CC @Gamnn.

Move the code to extract chapters/stopcodes from the FFmetadata writer into the library, and add a new writer for Audacity labels files.

Fixes #751.