### PR TITLE
y4m: Always signal field dominance correctly

### DIFF
--- a/tools/ld-chroma-decoder/outputwriter.cpp
+++ b/tools/ld-chroma-decoder/outputwriter.cpp
@@ -148,7 +148,11 @@ QByteArray OutputWriter::getStreamHeader() const
     }
 
     // Field order
-    str << " It";
+    if (videoParameters.firstActiveFrameLine % 2 ^ topPadLines % 2) {
+        str << " Ib";
+    } else {
+        str << " It";
+    }
 
     // Pixel aspect ratio
     // XXX Can this be computed, in case the width has been adjusted?


### PR DESCRIPTION
Field dominance can change depending on the first active line and any padding at the top.

This has been potentially broken ever since dynamic padding and the ffll/lfll/ffrl/lfrl options were added to `ld-chroma-decoder`