### PR TITLE
Change system python path to env python path

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 from setuptools import setup
 


### PR DESCRIPTION
Don't use the system python path but the current python env path so the building process can be done on custom python environments.

This is needed for example to compile the project on macOS under conda python env. 

/usr/bin/env python3 resolves to /usr/bin/python3 when no custom python env is activated