### PR TITLE
Fix pipe output on windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -81,3 +81,4 @@ ui_*.h
 
 # vscode related thingss
 .vscode/
+.theia/

--- a/tools/ld-chroma-decoder/encoder/main.cpp
+++ b/tools/ld-chroma-decoder/encoder/main.cpp
@@ -28,8 +28,11 @@
 #include <QtGlobal>
 #include <QCommandLineParser>
 #include <cstdio>
-#include <io.h>
-#include <fcntl.h>
+
+#ifdef _WIN32
+	#include <io.h>
+	#include <fcntl.h>
+#endif
 
 #include "lddecodemetadata.h"
 #include "logging.h"
@@ -39,7 +42,7 @@
 
 int main(int argc, char *argv[])
 {
-	#ifdef _WIN32 || _WIN64
+	#ifdef _WIN32
 	_setmode(_fileno(stdout), O_BINARY);
 	_setmode(_fileno(stdin), O_BINARY);	
 	#endif

--- a/tools/ld-chroma-decoder/encoder/main.cpp
+++ b/tools/ld-chroma-decoder/encoder/main.cpp
@@ -28,6 +28,8 @@
 #include <QtGlobal>
 #include <QCommandLineParser>
 #include <cstdio>
+#include <io.h>
+#include <fcntl.h>
 
 #include "lddecodemetadata.h"
 #include "logging.h"
@@ -37,6 +39,10 @@
 
 int main(int argc, char *argv[])
 {
+	#ifdef _WIN32 || _WIN64
+	_setmode(_fileno(stdout), O_BINARY);
+	_setmode(_fileno(stdin), O_BINARY);	
+	#endif
     // Install the local debug message handler
     setDebug(true);
     qInstallMessageHandler(debugOutputHandler);

--- a/tools/ld-chroma-decoder/main.cpp
+++ b/tools/ld-chroma-decoder/main.cpp
@@ -32,6 +32,8 @@
 #include <QThread>
 #include <fstream>
 #include <memory>
+#include <io.h>
+#include <fcntl.h>
 
 #include "decoderpool.h"
 #include "lddecodemetadata.h"
@@ -97,6 +99,10 @@ static bool loadTransformThresholds(QCommandLineParser &parser, QCommandLineOpti
 
 int main(int argc, char *argv[])
 {
+	#ifdef _WIN32 || _WIN64
+	_setmode(_fileno(stdout), O_BINARY);
+	_setmode(_fileno(stdin), O_BINARY);	
+	#endif
     // Install the local debug message handler
     setDebug(true);
     qInstallMessageHandler(debugOutputHandler);

--- a/tools/ld-chroma-decoder/main.cpp
+++ b/tools/ld-chroma-decoder/main.cpp
@@ -33,11 +33,6 @@
 #include <fstream>
 #include <memory>
 
-#ifdef _WIN32
-	#include <io.h>
-	#include <fcntl.h>
-#endif
-
 #include "decoderpool.h"
 #include "lddecodemetadata.h"
 #include "logging.h"
@@ -102,10 +97,8 @@ static bool loadTransformThresholds(QCommandLineParser &parser, QCommandLineOpti
 
 int main(int argc, char *argv[])
 {
-	#ifdef _WIN32
-	_setmode(_fileno(stdout), O_BINARY);
-	_setmode(_fileno(stdin), O_BINARY);	
-	#endif
+    //set 'binary mode' for stdin and stdout on windows
+    setBinaryMode();
     // Install the local debug message handler
     setDebug(true);
     qInstallMessageHandler(debugOutputHandler);

--- a/tools/ld-chroma-decoder/main.cpp
+++ b/tools/ld-chroma-decoder/main.cpp
@@ -32,8 +32,11 @@
 #include <QThread>
 #include <fstream>
 #include <memory>
-#include <io.h>
-#include <fcntl.h>
+
+#ifdef _WIN32
+	#include <io.h>
+	#include <fcntl.h>
+#endif
 
 #include "decoderpool.h"
 #include "lddecodemetadata.h"
@@ -99,7 +102,7 @@ static bool loadTransformThresholds(QCommandLineParser &parser, QCommandLineOpti
 
 int main(int argc, char *argv[])
 {
-	#ifdef _WIN32 || _WIN64
+	#ifdef _WIN32
 	_setmode(_fileno(stdout), O_BINARY);
 	_setmode(_fileno(stdin), O_BINARY);	
 	#endif

--- a/tools/ld-disc-stacker/main.cpp
+++ b/tools/ld-disc-stacker/main.cpp
@@ -29,6 +29,8 @@
 #include <QThread>
 #include <QFile>
 #include <QFileInfo>
+#include <io.h>
+#include <fcntl.h>
 
 #include "logging.h"
 #include "lddecodemetadata.h"
@@ -37,6 +39,10 @@
 
 int main(int argc, char *argv[])
 {
+	#ifdef _WIN32 || _WIN64
+	_setmode(_fileno(stdout), O_BINARY);
+	_setmode(_fileno(stdin), O_BINARY);	
+	#endif
     // Install the local debug message handler
     setDebug(true);
     qInstallMessageHandler(debugOutputHandler);

--- a/tools/ld-disc-stacker/main.cpp
+++ b/tools/ld-disc-stacker/main.cpp
@@ -29,8 +29,11 @@
 #include <QThread>
 #include <QFile>
 #include <QFileInfo>
-#include <io.h>
-#include <fcntl.h>
+
+#ifdef _WIN32
+	#include <io.h>
+	#include <fcntl.h>
+#endif
 
 #include "logging.h"
 #include "lddecodemetadata.h"
@@ -39,7 +42,7 @@
 
 int main(int argc, char *argv[])
 {
-	#ifdef _WIN32 || _WIN64
+	#ifdef _WIN32
 	_setmode(_fileno(stdout), O_BINARY);
 	_setmode(_fileno(stdin), O_BINARY);	
 	#endif

--- a/tools/ld-disc-stacker/main.cpp
+++ b/tools/ld-disc-stacker/main.cpp
@@ -30,11 +30,6 @@
 #include <QFile>
 #include <QFileInfo>
 
-#ifdef _WIN32
-	#include <io.h>
-	#include <fcntl.h>
-#endif
-
 #include "logging.h"
 #include "lddecodemetadata.h"
 #include "sourcevideo.h"
@@ -42,10 +37,8 @@
 
 int main(int argc, char *argv[])
 {
-	#ifdef _WIN32
-	_setmode(_fileno(stdout), O_BINARY);
-	_setmode(_fileno(stdin), O_BINARY);	
-	#endif
+    //set 'binary mode' for stdin and stdout on windows
+    setBinaryMode();
     // Install the local debug message handler
     setDebug(true);
     qInstallMessageHandler(debugOutputHandler);

--- a/tools/ld-discmap/main.cpp
+++ b/tools/ld-discmap/main.cpp
@@ -27,15 +27,18 @@
 #include <QtGlobal>
 #include <QCommandLineParser>
 #include <QFileInfo>
-#include <io.h>
-#include <fcntl.h>
+
+#ifdef _WIN32
+	#include <io.h>
+	#include <fcntl.h>
+#endif
 
 #include "logging.h"
 #include "discmapper.h"
 
 int main(int argc, char *argv[])
 {
-	#ifdef _WIN32 || _WIN64
+	#ifdef _WIN32
 	_setmode(_fileno(stdout), O_BINARY);
 	_setmode(_fileno(stdin), O_BINARY);	
 	#endif

--- a/tools/ld-discmap/main.cpp
+++ b/tools/ld-discmap/main.cpp
@@ -27,12 +27,18 @@
 #include <QtGlobal>
 #include <QCommandLineParser>
 #include <QFileInfo>
+#include <io.h>
+#include <fcntl.h>
 
 #include "logging.h"
 #include "discmapper.h"
 
 int main(int argc, char *argv[])
 {
+	#ifdef _WIN32 || _WIN64
+	_setmode(_fileno(stdout), O_BINARY);
+	_setmode(_fileno(stdin), O_BINARY);	
+	#endif
     // Install the local debug message handler
     setDebug(true);
     qInstallMessageHandler(debugOutputHandler);

--- a/tools/ld-discmap/main.cpp
+++ b/tools/ld-discmap/main.cpp
@@ -28,20 +28,13 @@
 #include <QCommandLineParser>
 #include <QFileInfo>
 
-#ifdef _WIN32
-	#include <io.h>
-	#include <fcntl.h>
-#endif
-
 #include "logging.h"
 #include "discmapper.h"
 
 int main(int argc, char *argv[])
 {
-	#ifdef _WIN32
-	_setmode(_fileno(stdout), O_BINARY);
-	_setmode(_fileno(stdin), O_BINARY);	
-	#endif
+    //set 'binary mode' for stdin and stdout on windows
+    setBinaryMode();
     // Install the local debug message handler
     setDebug(true);
     qInstallMessageHandler(debugOutputHandler);

--- a/tools/ld-dropout-correct/main.cpp
+++ b/tools/ld-dropout-correct/main.cpp
@@ -30,20 +30,13 @@
 #include <QFileInfo>
 #include <QThread>
 
-#ifdef _WIN32
-	#include <io.h>
-	#include <fcntl.h>
-#endif
-
 #include "logging.h"
 #include "correctorpool.h"
 
 int main(int argc, char *argv[])
 {
-	#ifdef _WIN32
-	_setmode(_fileno(stdout), O_BINARY);
-	_setmode(_fileno(stdin), O_BINARY);	
-	#endif
+    //set 'binary mode' for stdin and stdout on windows
+    setBinaryMode();
     // Install the local debug message handler
     setDebug(true);
     qInstallMessageHandler(debugOutputHandler);

--- a/tools/ld-dropout-correct/main.cpp
+++ b/tools/ld-dropout-correct/main.cpp
@@ -29,12 +29,18 @@
 #include <QCommandLineParser>
 #include <QFileInfo>
 #include <QThread>
+#include <io.h>
+#include <fcntl.h>
 
 #include "logging.h"
 #include "correctorpool.h"
 
 int main(int argc, char *argv[])
 {
+	#ifdef _WIN32 || _WIN64
+	_setmode(_fileno(stdout), O_BINARY);
+	_setmode(_fileno(stdin), O_BINARY);	
+	#endif
     // Install the local debug message handler
     setDebug(true);
     qInstallMessageHandler(debugOutputHandler);

--- a/tools/ld-dropout-correct/main.cpp
+++ b/tools/ld-dropout-correct/main.cpp
@@ -29,15 +29,18 @@
 #include <QCommandLineParser>
 #include <QFileInfo>
 #include <QThread>
-#include <io.h>
-#include <fcntl.h>
+
+#ifdef _WIN32
+	#include <io.h>
+	#include <fcntl.h>
+#endif
 
 #include "logging.h"
 #include "correctorpool.h"
 
 int main(int argc, char *argv[])
 {
-	#ifdef _WIN32 || _WIN64
+	#ifdef _WIN32
 	_setmode(_fileno(stdout), O_BINARY);
 	_setmode(_fileno(stdin), O_BINARY);	
 	#endif

--- a/tools/ld-export-metadata/main.cpp
+++ b/tools/ld-export-metadata/main.cpp
@@ -28,11 +28,6 @@
 #include <QtGlobal>
 #include <QCommandLineParser>
 
-#ifdef _WIN32
-	#include <io.h>
-	#include <fcntl.h>
-#endif
-
 #include "audacity.h"
 #include "csv.h"
 #include "ffmetadata.h"
@@ -43,10 +38,8 @@
 
 int main(int argc, char *argv[])
 {
-	#ifdef _WIN32
-	_setmode(_fileno(stdout), O_BINARY);
-	_setmode(_fileno(stdin), O_BINARY);	
-	#endif
+    //set 'binary mode' for stdin and stdout on windows
+    setBinaryMode();
     // Install the local debug message handler
     setDebug(true);
     qInstallMessageHandler(debugOutputHandler);

--- a/tools/ld-export-metadata/main.cpp
+++ b/tools/ld-export-metadata/main.cpp
@@ -27,6 +27,8 @@
 #include <QDebug>
 #include <QtGlobal>
 #include <QCommandLineParser>
+#include <io.h>
+#include <fcntl.h>
 
 #include "audacity.h"
 #include "csv.h"
@@ -38,6 +40,10 @@
 
 int main(int argc, char *argv[])
 {
+	#ifdef _WIN32 || _WIN64
+	_setmode(_fileno(stdout), O_BINARY);
+	_setmode(_fileno(stdin), O_BINARY);	
+	#endif
     // Install the local debug message handler
     setDebug(true);
     qInstallMessageHandler(debugOutputHandler);

--- a/tools/ld-export-metadata/main.cpp
+++ b/tools/ld-export-metadata/main.cpp
@@ -27,8 +27,11 @@
 #include <QDebug>
 #include <QtGlobal>
 #include <QCommandLineParser>
-#include <io.h>
-#include <fcntl.h>
+
+#ifdef _WIN32
+	#include <io.h>
+	#include <fcntl.h>
+#endif
 
 #include "audacity.h"
 #include "csv.h"
@@ -40,7 +43,7 @@
 
 int main(int argc, char *argv[])
 {
-	#ifdef _WIN32 || _WIN64
+	#ifdef _WIN32
 	_setmode(_fileno(stdout), O_BINARY);
 	_setmode(_fileno(stdin), O_BINARY);	
 	#endif

--- a/tools/ld-lds-converter/main.cpp
+++ b/tools/ld-lds-converter/main.cpp
@@ -26,12 +26,18 @@
 #include <QDebug>
 #include <QtGlobal>
 #include <QCommandLineParser>
+#include <io.h>
+#include <fcntl.h>
 
 #include "logging.h"
 #include "dataconverter.h"
 
 int main(int argc, char *argv[])
 {
+	#ifdef _WIN32 || _WIN64
+	_setmode(_fileno(stdout), O_BINARY);
+	_setmode(_fileno(stdin), O_BINARY);	
+	#endif
     // Install the local debug message handler
     setDebug(true);
     qInstallMessageHandler(debugOutputHandler);

--- a/tools/ld-lds-converter/main.cpp
+++ b/tools/ld-lds-converter/main.cpp
@@ -26,15 +26,18 @@
 #include <QDebug>
 #include <QtGlobal>
 #include <QCommandLineParser>
-#include <io.h>
-#include <fcntl.h>
+
+#ifdef _WIN32
+	#include <io.h>
+	#include <fcntl.h>
+#endif
 
 #include "logging.h"
 #include "dataconverter.h"
 
 int main(int argc, char *argv[])
 {
-	#ifdef _WIN32 || _WIN64
+	#ifdef _WIN32
 	_setmode(_fileno(stdout), O_BINARY);
 	_setmode(_fileno(stdin), O_BINARY);	
 	#endif

--- a/tools/ld-lds-converter/main.cpp
+++ b/tools/ld-lds-converter/main.cpp
@@ -27,20 +27,13 @@
 #include <QtGlobal>
 #include <QCommandLineParser>
 
-#ifdef _WIN32
-	#include <io.h>
-	#include <fcntl.h>
-#endif
-
 #include "logging.h"
 #include "dataconverter.h"
 
 int main(int argc, char *argv[])
 {
-	#ifdef _WIN32
-	_setmode(_fileno(stdout), O_BINARY);
-	_setmode(_fileno(stdin), O_BINARY);	
-	#endif
+    //set 'binary mode' for stdin and stdout on windows
+    setBinaryMode();
     // Install the local debug message handler
     setDebug(true);
     qInstallMessageHandler(debugOutputHandler);

--- a/tools/ld-process-ac3/decode/main.cpp
+++ b/tools/ld-process-ac3/decode/main.cpp
@@ -29,8 +29,8 @@
 #include <cstring>
 
 #ifdef _WIN32
-	#include <io.h>
-	#include <fcntl.h>
+    #include <io.h>
+    #include <fcntl.h>
 #endif
 
 #include "../logger.hpp"
@@ -54,10 +54,10 @@ void doHelp(const std::string &app) {
 }
 
 int main(int argc, char *argv[]) {
-	#ifdef _WIN32
-	_setmode(_fileno(stdout), O_BINARY);
-	_setmode(_fileno(stdin), O_BINARY);	
-	#endif
+    #ifdef _WIN32
+    _setmode(_fileno(stdout), O_BINARY);
+    _setmode(_fileno(stdin), O_BINARY);	
+    #endif	
     while (true) {
         switch (getopt(argc, argv, "v:h?")) {
             // could have stdin/stdout as defaults, with switches to change them

--- a/tools/ld-process-ac3/decode/main.cpp
+++ b/tools/ld-process-ac3/decode/main.cpp
@@ -27,8 +27,11 @@
 #include <getopt.h>
 #include <cassert>
 #include <cstring>
-#include <io.h>
-#include <fcntl.h>
+
+#ifdef _WIN32
+	#include <io.h>
+	#include <fcntl.h>
+#endif
 
 #include "../logger.hpp"
 #include "AC3Framer.hpp"
@@ -51,7 +54,7 @@ void doHelp(const std::string &app) {
 }
 
 int main(int argc, char *argv[]) {
-	#ifdef _WIN32 || _WIN64
+	#ifdef _WIN32
 	_setmode(_fileno(stdout), O_BINARY);
 	_setmode(_fileno(stdin), O_BINARY);	
 	#endif

--- a/tools/ld-process-ac3/decode/main.cpp
+++ b/tools/ld-process-ac3/decode/main.cpp
@@ -27,6 +27,8 @@
 #include <getopt.h>
 #include <cassert>
 #include <cstring>
+#include <io.h>
+#include <fcntl.h>
 
 #include "../logger.hpp"
 #include "AC3Framer.hpp"
@@ -49,6 +51,10 @@ void doHelp(const std::string &app) {
 }
 
 int main(int argc, char *argv[]) {
+	#ifdef _WIN32 || _WIN64
+	_setmode(_fileno(stdout), O_BINARY);
+	_setmode(_fileno(stdin), O_BINARY);	
+	#endif
     while (true) {
         switch (getopt(argc, argv, "v:h?")) {
             // could have stdin/stdout as defaults, with switches to change them

--- a/tools/ld-process-ac3/demodulate/main.cpp
+++ b/tools/ld-process-ac3/demodulate/main.cpp
@@ -28,6 +28,8 @@
 #include <getopt.h>
 #include <cstring>
 #include <cassert>
+#include <io.h>
+#include <fcntl.h>
 
 #include "../logger.hpp"
 #include "OneBitADC.hpp"
@@ -52,6 +54,11 @@ void doHelp(const std::string &app) {
 
 
 int main(int argc, char *argv[]) {
+
+	#ifdef _WIN32 || _WIN64
+	_setmode(_fileno(stdout), O_BINARY);
+	_setmode(_fileno(stdin), O_BINARY);	
+	#endif
     int slidingAvgLength = 1e3;
 
     // todo 8/16bit and little-/big-endian switches? leave it to sox?

--- a/tools/ld-process-ac3/demodulate/main.cpp
+++ b/tools/ld-process-ac3/demodulate/main.cpp
@@ -28,8 +28,11 @@
 #include <getopt.h>
 #include <cstring>
 #include <cassert>
-#include <io.h>
-#include <fcntl.h>
+
+#ifdef _WIN32
+	#include <io.h>
+	#include <fcntl.h>
+#endif
 
 #include "../logger.hpp"
 #include "OneBitADC.hpp"
@@ -55,7 +58,7 @@ void doHelp(const std::string &app) {
 
 int main(int argc, char *argv[]) {
 
-	#ifdef _WIN32 || _WIN64
+	#ifdef _WIN32
 	_setmode(_fileno(stdout), O_BINARY);
 	_setmode(_fileno(stdin), O_BINARY);	
 	#endif

--- a/tools/ld-process-efm/main.cpp
+++ b/tools/ld-process-efm/main.cpp
@@ -27,15 +27,18 @@
 #include <QtGlobal>
 #include <QCommandLineParser>
 #include <QThread>
-#include <io.h>
-#include <fcntl.h>
+
+#ifdef _WIN32
+	#include <io.h>
+	#include <fcntl.h>
+#endif
 
 #include "logging.h"
 #include "efmprocess.h"
 
 int main(int argc, char *argv[])
 {
-	#ifdef _WIN32 || _WIN64
+	#ifdef _WIN32
 	_setmode(_fileno(stdout), O_BINARY);
 	_setmode(_fileno(stdin), O_BINARY);	
 	#endif

--- a/tools/ld-process-efm/main.cpp
+++ b/tools/ld-process-efm/main.cpp
@@ -27,12 +27,18 @@
 #include <QtGlobal>
 #include <QCommandLineParser>
 #include <QThread>
+#include <io.h>
+#include <fcntl.h>
 
 #include "logging.h"
 #include "efmprocess.h"
 
 int main(int argc, char *argv[])
 {
+	#ifdef _WIN32 || _WIN64
+	_setmode(_fileno(stdout), O_BINARY);
+	_setmode(_fileno(stdin), O_BINARY);	
+	#endif
     // Install the local debug message handler
     setDebug(true);
     qInstallMessageHandler(debugOutputHandler);

--- a/tools/ld-process-efm/main.cpp
+++ b/tools/ld-process-efm/main.cpp
@@ -28,20 +28,13 @@
 #include <QCommandLineParser>
 #include <QThread>
 
-#ifdef _WIN32
-	#include <io.h>
-	#include <fcntl.h>
-#endif
-
 #include "logging.h"
 #include "efmprocess.h"
 
 int main(int argc, char *argv[])
 {
-	#ifdef _WIN32
-	_setmode(_fileno(stdout), O_BINARY);
-	_setmode(_fileno(stdin), O_BINARY);	
-	#endif
+    //set 'binary mode' for stdin and stdout on windows
+    setBinaryMode();
     // Install the local debug message handler
     setDebug(true);
     qInstallMessageHandler(debugOutputHandler);

--- a/tools/ld-process-vbi/main.cpp
+++ b/tools/ld-process-vbi/main.cpp
@@ -27,15 +27,18 @@
 #include <QtGlobal>
 #include <QCommandLineParser>
 #include <QThread>
-#include <io.h>
-#include <fcntl.h>
+
+#ifdef _WIN32
+	#include <io.h>
+	#include <fcntl.h>
+#endif
 
 #include "logging.h"
 #include "decoderpool.h"
 
 int main(int argc, char *argv[])
 {
-	#ifdef _WIN32 || _WIN64
+	#ifdef _WIN32
 	_setmode(_fileno(stdout), O_BINARY);
 	_setmode(_fileno(stdin), O_BINARY);	
 	#endif

--- a/tools/ld-process-vbi/main.cpp
+++ b/tools/ld-process-vbi/main.cpp
@@ -28,20 +28,13 @@
 #include <QCommandLineParser>
 #include <QThread>
 
-#ifdef _WIN32
-	#include <io.h>
-	#include <fcntl.h>
-#endif
-
 #include "logging.h"
 #include "decoderpool.h"
 
 int main(int argc, char *argv[])
 {
-	#ifdef _WIN32
-	_setmode(_fileno(stdout), O_BINARY);
-	_setmode(_fileno(stdin), O_BINARY);	
-	#endif
+    //set 'binary mode' for stdin and stdout on windows
+    setBinaryMode();
     // Install the local debug message handler
     setDebug(true);
     qInstallMessageHandler(debugOutputHandler);

--- a/tools/ld-process-vbi/main.cpp
+++ b/tools/ld-process-vbi/main.cpp
@@ -27,12 +27,18 @@
 #include <QtGlobal>
 #include <QCommandLineParser>
 #include <QThread>
+#include <io.h>
+#include <fcntl.h>
 
 #include "logging.h"
 #include "decoderpool.h"
 
 int main(int argc, char *argv[])
 {
+	#ifdef _WIN32 || _WIN64
+	_setmode(_fileno(stdout), O_BINARY);
+	_setmode(_fileno(stdin), O_BINARY);	
+	#endif
     // Install the local debug message handler
     setDebug(true);
     qInstallMessageHandler(debugOutputHandler);

--- a/tools/ld-process-vits/main.cpp
+++ b/tools/ld-process-vits/main.cpp
@@ -29,6 +29,8 @@
 #include <QThread>
 #include <QFile>
 #include <QFileInfo>
+#include <io.h>
+#include <fcntl.h>
 
 #include "logging.h"
 #include "lddecodemetadata.h"
@@ -37,6 +39,10 @@
 
 int main(int argc, char *argv[])
 {
+	#ifdef _WIN32 || _WIN64
+	_setmode(_fileno(stdout), O_BINARY);
+	_setmode(_fileno(stdin), O_BINARY);	
+	#endif
     // Install the local debug message handler
     setDebug(true);
     qInstallMessageHandler(debugOutputHandler);

--- a/tools/ld-process-vits/main.cpp
+++ b/tools/ld-process-vits/main.cpp
@@ -29,8 +29,11 @@
 #include <QThread>
 #include <QFile>
 #include <QFileInfo>
-#include <io.h>
-#include <fcntl.h>
+
+#ifdef _WIN32
+	#include <io.h>
+	#include <fcntl.h>
+#endif
 
 #include "logging.h"
 #include "lddecodemetadata.h"
@@ -39,7 +42,7 @@
 
 int main(int argc, char *argv[])
 {
-	#ifdef _WIN32 || _WIN64
+	#ifdef _WIN32
 	_setmode(_fileno(stdout), O_BINARY);
 	_setmode(_fileno(stdin), O_BINARY);	
 	#endif

--- a/tools/ld-process-vits/main.cpp
+++ b/tools/ld-process-vits/main.cpp
@@ -30,11 +30,6 @@
 #include <QFile>
 #include <QFileInfo>
 
-#ifdef _WIN32
-	#include <io.h>
-	#include <fcntl.h>
-#endif
-
 #include "logging.h"
 #include "lddecodemetadata.h"
 #include "sourcevideo.h"
@@ -42,10 +37,8 @@
 
 int main(int argc, char *argv[])
 {
-	#ifdef _WIN32
-	_setmode(_fileno(stdout), O_BINARY);
-	_setmode(_fileno(stdin), O_BINARY);	
-	#endif
+    //set 'binary mode' for stdin and stdout on windows
+    setBinaryMode();
     // Install the local debug message handler
     setDebug(true);
     qInstallMessageHandler(debugOutputHandler);

--- a/tools/library/tbc/logging.cpp
+++ b/tools/library/tbc/logging.cpp
@@ -122,6 +122,14 @@ void setQuiet(bool state)
     quietDebug = state;
 }
 
+void setBinaryMode(void)
+{
+    #ifdef _WIN32
+   _setmode(_fileno(stdout), O_BINARY);
+   _setmode(_fileno(stdin), O_BINARY);	
+    #endif
+}
+
 // Method to add the standard debug options to the command line parser
 void addStandardDebugOptions(QCommandLineParser &parser)
 {

--- a/tools/library/tbc/logging.h
+++ b/tools/library/tbc/logging.h
@@ -31,10 +31,16 @@
 #include <QString>
 #include <QCommandLineParser>
 
+#ifdef _WIN32
+    #include <io.h>
+    #include <fcntl.h>
+#endif
+
 // Prototypes
 void debugOutputHandler(QtMsgType type, const QMessageLogContext &context, const QString &msg);
 void setDebug(bool state);
 void setQuiet(bool state);
+void setBinaryMode(void);
 void openDebugFile(QString filename);
 void closeDebugFile(void);
 void addStandardDebugOptions(QCommandLineParser &parser);


### PR DESCRIPTION
Fix pipe output on Windows for all tool by setting output mode to binary instead of the default mode (text mode)