### PR TITLE
Fallback on ffmpeg rather than lds format and use sys.exit instead of exit

### DIFF
--- a/lddecode/main.py
+++ b/lddecode/main.py
@@ -273,7 +273,7 @@ def main(args=None):
 
     if args.pal and (args.ntsc or args.ntscj):
         print("ERROR: Can only be PAL or NTSC")
-        exit(1)
+        sys.exit(1)
 
     audio_pipe = None
 
@@ -299,7 +299,7 @@ def main(args=None):
 
     if vid_standard == "PAL" and args.AC3:
         print("ERROR: AC3 audio decoding is only supported for NTSC")
-        exit(1)
+        sys.exit(1)
 
     if args.lowband:
         extra_options["lowband"] = True
@@ -308,7 +308,7 @@ def main(args=None):
         loader = make_loader(filename, args.inputfreq)
     except ValueError as e:
         print(e)
-        exit(1)
+        sys.exit(1)
 
     # Wrap the LDdecode creation so that the signal handler is not taken by sub-threads,
     # allowing SIGINT/control-C's to be handled cleanly
@@ -348,7 +348,7 @@ def main(args=None):
     if args.seek != -1:
         if ldd.seek(args.seek if firstframe == 0 else firstframe, args.seek) is None:
             print("ERROR: Seeking failed", file=sys.stderr)
-            exit(1)
+            sys.exit(1)
 
     if args.MTF is not None:
         ldd.rf.mtf_mult = args.MTF
@@ -390,7 +390,7 @@ def main(args=None):
         except KeyboardInterrupt as kbd:
             print("\nTerminated, saving JSON and exiting", file=sys.stderr)
             cleanup()
-            exit(1)
+            sys.exit(1)
         except Exception as err:
             print(
                 "\nERROR - please paste the following into a bug report:",
@@ -401,7 +401,7 @@ def main(args=None):
             print("Exception:", err, " Traceback:", file=sys.stderr)
             traceback.print_tb(err.__traceback__)
             cleanup()
-            exit(1)
+            sys.exit(1)
 
         if f is None or (args.ignoreleadout == False and ldd.leadOut == True):
             done = True

--- a/lddecode/utils.py
+++ b/lddecode/utils.py
@@ -142,13 +142,12 @@ def make_loader(filename, inputfreq=None):
         or filename.endswith(".vhs")
     ):
         try:
-            rv = LoadLDF(filename)
+            return LoadLDF(filename)
         except FileNotFoundError:
             print(
                 "ld-ldf-reader not found in PATH, using ffmpeg instead.",
                 file=sys.stderr,
             )
-            rv = LoadFFmpeg()
         except Exception:
             # print("Please build and install ld-ldf-reader in your PATH for improved performance", file=sys.stderr)
             traceback.print_exc()
@@ -156,11 +155,8 @@ def make_loader(filename, inputfreq=None):
                 "Failed to load with ld-ldf-reader, trying ffmpeg instead.",
                 file=sys.stderr,
             )
-            rv = LoadFFmpeg()
 
-        return rv
-    else:
-        return load_packed_data_4_40
+    return LoadFFmpeg()
 
 
 def load_unpacked_data(infile, sample, readlen, sampletype):


### PR DESCRIPTION
See https://docs.python.org/3/library/constants.html#exit for exit change reasoning.

Change to fall back on ffmpeg with unknown extension when not resampling. Whatever the input is it's not going to be .lds format at least and flac can be in a bunch of different containers.