### PR TITLE
Improve ld-disk-stacker handling of padded field metadata

### DIFF
--- a/tools/ld-disc-stacker/stackingpool.h
+++ b/tools/ld-disc-stacker/stackingpool.h
@@ -103,6 +103,10 @@ private:
     qint32 convertVbiFrameNumberToSequential(qint32 vbiFrameNumber, qint32 sourceNumber);
     QVector<qint32> getAvailableSourcesForFrame(qint32 vbiFrameNumber);
     bool writeOutputField(const SourceVideo::Data &fieldData);
+    void correctPhaseIDs();
+    template<int field>
+    void replaceFieldMetaData(qint32 frameNumber);
+    LdDecodeMetaData &correctMetaData();
 };
 
 #endif // STACKINGPOOL_H


### PR DESCRIPTION
This fixes a bug where corrupt field metadata from the first input is propagated to the output metadata of `ld-disc-stacker`. Essentially it assumes that `ld-discmap` was run with -u so that all corrupt fields get marked with `"pad": true`. It then takes all fields that have `"pad": true` and replaces them with field metadata from other fields where `"pad": false` if such metadata exists. This is necessary since corrupt metadata tends to mess up colors when running `ld-chroma-decoder`.

There's a lot of code duplication in this commit which I'm not particularly happy about, but I can't really think of a cleaner way to do it. If you have any ideas, I'm all ears.