### PR TITLE
lddecode: add --deemp_adjust_cb option for adjusting color burst deemph

### DIFF
--- a/lddecode/main.py
+++ b/lddecode/main.py
@@ -189,6 +189,14 @@ def main(args=None):
         help="Deemphasis level multiplier",
     )
     parser.add_argument(
+        "-D",
+        "--deemp_adjust_cb",
+        metavar="deemp_adjust_cb",
+        type=float,
+        default=None,
+        help="Deemphasis level multiplier for the color burst region",
+    )
+    parser.add_argument(
         "--deemp_low",
         metavar="deemp_low",
         type=float,
@@ -282,7 +290,7 @@ def main(args=None):
         "write_RF_TBC": args.RF_TBC,
         "pipe_RF_TBC": audio_pipe,
         "write_pre_efm": args.prefm,
-        "deemp_mult": (args.deemp_adjust, args.deemp_adjust),
+        "deemp_mult": (args.deemp_adjust, args.deemp_adjust_cb if args.deemp_adjust_cb != None else args.deemp_adjust),
         "deemp_coeff": (args.deemp_low, args.deemp_high),
         "audio_filterwidth": args.audio_filterwidth,
         "AC3": args.AC3,
@@ -419,7 +427,7 @@ def main(args=None):
         timeused2 = time.time() - seconddecode
         frames = ldd.fields_written // 2
         fps = frames / timeused2
- 
+
         print(f"\nCompleted: saving JSON and exiting.  Took {timeused:.2f} seconds to decode {frames} frames ({fps:.2f} FPS post-setup)", file=sys.stderr)
     else:
         print(f"\nCompleted without handling any frames.", file=sys.stderr)


### PR DESCRIPTION
Allows color burst and 0.5 MHz region to have a different deemphasis adjust applied from the video burst region. This can potentially reduce rightwards smearing in the video region, without coming at the cost of introducing color banding that isn't present at high deemph adjust values.

For some background, I was having difficulty with rightwards ghosting and bright color smear pretty bad at default ld-decode settings. Eventually I discovered --deemp_adjust and this greatly reduced rightwards smearing and ghosting, but it came at the cost of introducing horizontal color banding not present at higher --deemph_adjust values. After examining the frames with banding in ld-analyse, I saw the color burst was slightly distorted for those lines. I thought I could fix it by decoding the color burst region with a higher deemph_adjust than the video burst region and found it worked perfectly.

Sorry for the white space changes in the files. My editor is configured to remove trailing white space on save. I can edit the commit without these changes if you like.