### PR TITLE
Avoid using bare except

### DIFF
--- a/lddecode/core.py
+++ b/lddecode/core.py
@@ -1170,7 +1170,9 @@ class DemodCache:
                 if b not in self.blocks:
                     LRUupdate(self.lru, b)
 
-                    rawdata = self.loader(self.infile, b * self.blocksize, self.rf.blocklen)
+                    rawdata = self.loader(
+                        self.infile, b * self.blocksize, self.rf.blocklen
+                    )
 
                     if rawdata is None or len(rawdata) < self.rf.blocklen:
                         self.blocks[b] = None
@@ -1183,29 +1185,38 @@ class DemodCache:
                     reached_end = True
                     break
 
-                try:
-                    waiting = self.block_status[b]["waiting"]
-                except:
-                    waiting = False
+                waiting = (
+                    self.block_status[b].get("waiting", False)
+                    if b in self.block_status
+                    else False
+                )
 
-                try:
-                    # Until the block is actually ready, this comparison will hit an unknown key
-                    if not redo and not waiting and self.blocks[b]["request"] == self.block_status[b]['request']:
-                        continue
-                except:
-                    pass
+                # Until the block is actually ready, this comparison will hit an unknown key
+                if (
+                    not redo
+                    and not waiting
+                    and "request" in self.blocks[b]
+                    and "request" in self.block_status[b]
+                    and self.blocks[b]["request"] == self.block_status[b]["request"]
+                ):
+                    continue
 
                 if redo or not waiting:
                     queuelist.append(b)
                     need_blocks.append(b)
                 elif waiting:
                     need_blocks.append(b)
-               
+
                 if not prefetch:
                     self.waiting.add(b)
 
             for b in queuelist:
-                self.block_status[b] = {'MTF': MTF, 'waiting': True, 'request': self.request, 'prefetch': prefetch}
+                self.block_status[b] = {
+                    "MTF": MTF,
+                    "waiting": True,
+                    "request": self.request,
+                    "prefetch": prefetch,
+                }
                 self.q_in.put(("DEMOD", b, self.blocks[b], MTF, self.request))
 
         self.q_out_event.clear()
@@ -3035,7 +3046,7 @@ class FieldPAL(Field):
                 # and on a bad disk, this value could be None...
                 if self.prevfield.phase_adjust[l] is not None:
                     prev_phaseadjust = self.prevfield.phase_adjust[l]
-            except:
+            except AttributeError:
                 pass
 
             rising, self.phase_adjust[l] = self.compute_line_bursts(

--- a/lddecode/utils.py
+++ b/lddecode/utils.py
@@ -17,6 +17,12 @@ from numba import jit, njit
 import numpy as np
 import scipy.signal as sps
 
+# Try to make sure ffmpeg is available
+try:
+    import static_ffmpeg
+except ImportError:
+    pass
+
 # This runs a cubic scaler on a line.
 # originally from https://www.paulinternet.nl/?page=bicubic
 @njit(nogil=True, cache=True)
@@ -571,7 +577,8 @@ def get_version():
 
         fdata = fd.read()
         return fdata.strip() # remove trailing \n etc
-    except: # usually FileNotFoundError
+    except (FileNotFoundError, OSError):
+        # Just return 'unknown' if we fail to find anything.
         return "unknown"
 
 

--- a/lddecode/utils_logging.py
+++ b/lddecode/utils_logging.py
@@ -1,5 +1,6 @@
 import logging
 import sys
+import os
 
 
 def init_logging(outfile_name, columns=80):
@@ -34,7 +35,7 @@ def init_logging(outfile_name, columns=80):
         # Delete old logfile if it exists
         try:
             os.unlink(outfile_name)
-        except Exception:
+        except (OSError, FileNotFoundError):
             pass
 
         logger_file = logging.FileHandler(outfile_name)


### PR DESCRIPTION
Avoid using bare except clauses, this is kinda [bad practice](https://peps.python.org/pep-0008/#programming-recommendations) and ends up catching keyboard interrupts which may or may not be what's causing ctrl-c to not always work as excpected.

Also adds in an optional import of static_ffmpeg that's used when packaging for pypi and such, it's a module that auto-downloads ffmpeg but it won't do anything if the module isn't available.