### PR TITLE
Add stdin support for ld-decode

### DIFF
--- a/lddecode/core.py
+++ b/lddecode/core.py
@@ -3333,8 +3333,10 @@ class LDdecode:
         self.demodcache = None
 
         self.branch, self.commit = get_git_info()
-
-        self.infile = open(fname_in, "rb")
+        if fname_in == '-':
+            self.infile = sys.stdin
+        else:
+            self.infile = open(fname_in, "rb")
         self.freader = freader
 
         self.est_frames = est_frames


### PR DESCRIPTION
A simple change that would help me a lot.
As ld-decode has no progress bar or ETA,
I can't know when the decodings would end.

Then, If I pipe the RF capture from pv into
x-decode, It works, and I only need to redirect
the stdout and stderr to null. :)

It does not affect the common file opening.