### PR TITLE
ld-cut: add custom ffmpeg-settings

### DIFF
--- a/ld-cut
+++ b/ld-cut
@@ -72,6 +72,15 @@ parser.add_argument(
     help="compression level for .ldf files",
 )
 
+parser.add_argument(
+    "-F",
+    "--fmpeg-options",
+    dest="ffmpeg_options",
+    type=str,
+    default=None,
+    help="custom ffmpeg format options"
+)
+
 args = parser.parse_args()
 
 # print(args)
@@ -134,7 +143,9 @@ startidx = int(ldd.fdoffset)
 ldd.roughseek(endloc)
 endidx = int(ldd.fdoffset)
 
-if makelds:
+if args.ffmpeg_options is not None:
+    process, fd = ffmpeg_pipe(outname, args.ffmpeg_options)
+elif makelds:
     process = subprocess.Popen(
         ["ld-lds-converter", "-o", outname, "-p"], stdin=subprocess.PIPE
     )

--- a/ld-cut
+++ b/ld-cut
@@ -78,6 +78,9 @@ args = parser.parse_args()
 filename = args.infile
 outname = args.outfile
 
+if outname == '-':
+    outname = "/dev/stdout"
+
 vid_standard = "PAL" if args.pal else "NTSC"
 
 if args.pal and args.ntsc:
@@ -139,7 +142,7 @@ if makelds:
 elif makeldf:
     process, fd = ldf_pipe(outname, args.ldfcomp)
 else:
-    fd = open(args.outfile, "wb")
+    fd = open(outname, "wb")
 
 # print(startloc, endloc, startidx, endidx)
 

--- a/lddecode/utils.py
+++ b/lddecode/utils.py
@@ -529,16 +529,24 @@ class LoadLDF:
         return self.read(infile, sample, readlen)
 
 
-def ldf_pipe(outname: str, compression_level: int = 6):
-    corecmd = "ffmpeg -y -hide_banner -loglevel error -f s16le -ar 40k -ac 1 -i - -acodec flac -f ogg".split(
-        " "
-    )
+def ffmpeg_pipe(outname: str, opts: str):
+    cmd = f"ffmpeg -y -hide_banner -loglevel error -f s16le -ar 40k -ac 1 -i -"
+    if opts and len(opts):
+        cmd += f" {opts}"
+
+    cmd = cmd.split(' ')
+
     process = subprocess.Popen(
-        [*corecmd, "-compression_level", str(compression_level), outname],
+        [*cmd, outname],
         stdin=subprocess.PIPE,
     )
 
     return process, process.stdin
+
+
+def ldf_pipe(outname: str, compression_level: int = 6):
+    return ffmpeg_pipe(outname, f"-acodec flac -f ogg -compression_level {compression_level}")
+
 
 def ac3_pipe(outname: str):
     processes = []


### PR DESCRIPTION
This lets you try different lossless compressors if/when they exist, and create glitchy decodes by doing things like:

```./ld-cut ../testdata/ve-snw-cut.lds test.ogg -F "-b:a 64k"```

(If ld-decode does not know the extension, it'll automatically use ffmpeg so you can pass test.ogg right in)