### PR TITLE
fix data types for fileLoc and diskLoc in tools code and fix reading of json floats on non-US locales

### DIFF
--- a/tools/ld-disc-stacker/stackingpool.cpp
+++ b/tools/ld-disc-stacker/stackingpool.cpp
@@ -23,6 +23,7 @@
 ************************************************************************/
 
 #include "stackingpool.h"
+#include "vbidecoder.h"
 
 StackingPool::StackingPool(QString _outputFilename, QString _outputJsonFilename,
                              qint32 _maxThreads, QVector<LdDecodeMetaData *> &_ldDecodeMetaData, QVector<SourceVideo *> &_sourceVideos,

--- a/tools/ld-dropout-correct/correctorpool.cpp
+++ b/tools/ld-dropout-correct/correctorpool.cpp
@@ -24,6 +24,7 @@
 ************************************************************************/
 
 #include "correctorpool.h"
+#include "vbidecoder.h"
 
 CorrectorPool::CorrectorPool(QString _outputFilename, QString _outputJsonFilename,
                              qint32 _maxThreads, QVector<LdDecodeMetaData *> &_ldDecodeMetaData, QVector<SourceVideo *> &_sourceVideos,

--- a/tools/library/tbc/jsonio.cpp
+++ b/tools/library/tbc/jsonio.cpp
@@ -25,6 +25,11 @@
 #include "jsonio.h"
 
 #include <limits>
+#if ((defined(_MSVC_LANG) && _MSVC_LANG >= 201703L) || __cplusplus >= 201703L)
+#include <charconv>
+#else
+#include <sstream>
+#endif
 
 // Recognise JSON space characters
 static bool isAsciiSpace(char c)
@@ -332,8 +337,13 @@ void JsonReader::readNumber(double &value)
         }
     }
 
-    // XXX In C++17 we could use std::from_chars instead, which is slightly more efficient
-    value = std::stod(buf);
+#if ((defined(_MSVC_LANG) && _MSVC_LANG >= 201703L) || __cplusplus >= 201703L)
+    // Use the faster C++17 method if available.
+    std::from_chars(buf.data(), buf.data() + buf.size(), value);
+#else
+    std::istringstream(buf) >> value;
+#endif
+
 
     // We've read one character beyond the end of the number (there's no way to
     // tell where the end is otherwise), so we must unget the last char

--- a/tools/library/tbc/jsonio.cpp
+++ b/tools/library/tbc/jsonio.cpp
@@ -24,7 +24,6 @@
 
 #include "jsonio.h"
 
-#include <cmath>
 #include <limits>
 
 // Recognise JSON space characters
@@ -46,10 +45,12 @@ JsonReader::JsonReader(std::istream &_input)
 
 void JsonReader::read(int &value)
 {
-    // Round to the nearest integer
-    double d;
-    readNumber(d);
-    value = static_cast<int>(std::lround(d));
+    readSignedInteger(value);
+}
+
+void JsonReader::read(qint64 &value)
+{
+    readSignedInteger(value);
 }
 
 void JsonReader::read(double &value)
@@ -347,6 +348,11 @@ JsonWriter::JsonWriter(std::ostream &_output)
 }
 
 void JsonWriter::write(int value)
+{
+    output << value;
+}
+
+void JsonWriter::write(qint64 value)
 {
     output << value;
 }

--- a/tools/library/tbc/jsonio.h
+++ b/tools/library/tbc/jsonio.h
@@ -32,6 +32,7 @@
 #include <stdexcept>
 #include <string>
 #include <stack>
+#include <cmath>
 
 class JsonReader
 {
@@ -51,6 +52,7 @@ public:
     }
 
     // Numbers
+    void read(qint64 &value);
     void read(int &value);
     void read(double &value);
 
@@ -81,6 +83,12 @@ private:
 
     void readString(std::string &value);
     void readNumber(double &value);
+    template <typename T> void readSignedInteger(T& value) {
+        // Round to the nearest integer
+        double d;
+        readNumber(d);
+        value = static_cast<T>(std::llround(d));
+    }
 
     // The input stream
     std::istream &input;
@@ -101,6 +109,7 @@ public:
 
     // Numbers
     void write(int value);
+    void write(qint64 value);
     void write(double value);
 
     // Booleans

--- a/tools/library/tbc/lddecodemetadata.h
+++ b/tools/library/tbc/lddecodemetadata.h
@@ -33,7 +33,6 @@
 #include <QDebug>
 #include <array>
 
-#include "vbidecoder.h"
 #include "dropouts.h"
 
 class JsonReader;
@@ -203,7 +202,7 @@ public:
         bool pad = false;
 
         qint32 diskLoc = -1;
-        qint32 fileLoc = -1;
+        qint64 fileLoc = -1;
         qint32 decodeFaults = -1;
         qint32 efmTValues = -1;
 

--- a/tools/library/tbc/lddecodemetadata.h
+++ b/tools/library/tbc/lddecodemetadata.h
@@ -201,7 +201,7 @@ public:
         DropOuts dropOuts;
         bool pad = false;
 
-        qint32 diskLoc = -1;
+        double diskLoc = -1;
         qint64 fileLoc = -1;
         qint32 decodeFaults = -1;
         qint32 efmTValues = -1;


### PR DESCRIPTION
fileLoc gets truncated if the json is saved as it can easily be larger than a signed 32-bit integer can store
diskLoc should have decimal places according to @happycube  and is output with them from the python code. (Though it's not super useful at the moment and maybe not accurate either if there is data in the input before the start of the disk since it's just fileLoc divided by lines per field with the current code)

```std::stod``` (and related) is locale-dependent at least on linux annoyingly so on many non-US locales it will not interpret ```.``` as the decimal separator and thus load floating point values as integers.