### PR TITLE
y4m: Use more accurate values for PAR

### DIFF
--- a/tools/ld-chroma-decoder/outputwriter.cpp
+++ b/tools/ld-chroma-decoder/outputwriter.cpp
@@ -155,18 +155,19 @@ QByteArray OutputWriter::getStreamHeader() const
     }
 
     // Pixel aspect ratio
-    // XXX Can this be computed, in case the width has been adjusted?
+    // Follows EBU R92 and SMPTE RP 187 except that values are scaled from
+    // BT.601 sampling (13.5 MHz) to 4fSC
     if (videoParameters.system == PAL) {
         if (videoParameters.isWidescreen) {
-            str << " A512:461"; // (16 / 9) * (576 / 922)
+            str << " A865:779"; // (16 / 9) * (576 / (702 * 4*fSC / 13.5))
         } else {
-            str << " A384:461"; // (4 / 3) * (576 / 922)
+            str << " A259:311"; // (4 / 3) * (576 / (702 * 4*fSC / 13.5))
         }
     } else {
         if (videoParameters.isWidescreen) {
-            str << " A194:171"; // (16 / 9) * (485 / 760)
+            str << " A25:22"; // (16 / 9) * (480 / (708 * 4*fSC / 13.5))
         } else {
-            str << " A97:114";  // (4 / 3) * (485 / 760)
+            str << " A352:413"; // (4 / 3) * (480 / (708 * 4*fSC / 13.5))
         }
     }
 


### PR DESCRIPTION
The old values were close enough, but change them to follow EBU R92 and SMPTE RP 187.

There are multiple ways to calculate PAR for NTSC 525-line content.  NTSC does not have a history of well-defined active lines (480 to 487) or active line times (or blanking).  SMPTE RP 187 (and its Annex A.4) was an attempt to standardize the 4:3 clean aperture, but it was withdrawn so I don't know how much acceptance it ever achieved.  Studio blanking (SMPTE 170M, 10.7us) is within broadcast tolerance (BT.470-6,10.9us +/- 0.2us), but Poynton suggests 52+8/9us active line time.  This is just barely outside of BT.470, but is a convenient integer number of Rec.601 samples (exactly 714 samples vs. 713.55).  This matches closely with RP 187, so that's why I've decided on using RP 187.

Note that Annex A.4 doesn't apply to 16:9 content.

For 625-line content, EBU R92 is newer than the withdrawn RP 187 (1999 vs. 1995) so I recommend R92.  The difference in the two is very small anyway (much less than between any of the various 525-line options).