### PR TITLE
add video start and width adjustments to ld-analyse

### DIFF
--- a/tools/ld-analyse/videoparametersdialog.cpp
+++ b/tools/ld-analyse/videoparametersdialog.cpp
@@ -44,10 +44,14 @@ VideoParametersDialog::~VideoParametersDialog()
 void VideoParametersDialog::setVideoParameters(const LdDecodeMetaData::VideoParameters &_videoParameters)
 {
     videoParameters = _videoParameters;
+    originalActiveVideoStart = videoParameters.activeVideoStart;
+    originalActiveVideoWidth = videoParameters.activeVideoEnd - videoParameters.activeVideoStart;
 
     // Transfer values to the dialogue
     ui->blackLevelSpinBox->setValue(videoParameters.black16bIre);
     ui->whiteLevelSpinBox->setValue(videoParameters.white16bIre);
+    ui->activeVideoWidthSpinBox->setValue(videoParameters.activeVideoEnd - videoParameters.activeVideoStart);
+    ui->activeVideoStartSpinBox->setValue(videoParameters.activeVideoStart);
     if (videoParameters.isWidescreen) ui->aspectRatio169RadioButton->setChecked(true);
     else ui->aspectRatio43RadioButton->setChecked(true);
 
@@ -96,6 +100,21 @@ void VideoParametersDialog::on_whiteLevelSpinBox_valueChanged(int value)
     emit videoParametersChanged(videoParameters);
 }
 
+void VideoParametersDialog::on_activeVideoStartSpinBox_valueChanged(int value)
+{
+    int adjustAmount = videoParameters.activeVideoStart - value;
+    videoParameters.activeVideoStart = value;
+    videoParameters.activeVideoEnd = value + ui->activeVideoWidthSpinBox->value();
+    updateDialog();
+    emit videoParametersChanged(videoParameters);
+}
+
+void VideoParametersDialog::on_activeVideoWidthSpinBox_valueChanged(int value)
+{
+    videoParameters.activeVideoEnd = videoParameters.activeVideoStart + value;
+    updateDialog();
+    emit videoParametersChanged(videoParameters);
+}
 // The reset black and white levels come from EBU Tech 3280 p6 (PAL) and SMPTE
 // 244M p2 (NTSC), and match what ld-decode uses by default.
 
@@ -120,6 +139,16 @@ void VideoParametersDialog::on_whiteLevelResetButton_clicked()
     } else {
         ui->whiteLevelSpinBox->setValue(0xD300);
     }
+}
+
+void VideoParametersDialog::on_activeVideoStartResetButton_clicked()
+{
+    ui->activeVideoStartSpinBox->setValue(originalActiveVideoStart);
+}
+
+void VideoParametersDialog::on_activeVideoWidthResetButton_clicked()
+{
+    ui->activeVideoWidthSpinBox->setValue(originalActiveVideoWidth);
 }
 
 void VideoParametersDialog::on_aspectRatioButtonGroup_buttonClicked(QAbstractButton *button)

--- a/tools/ld-analyse/videoparametersdialog.h
+++ b/tools/ld-analyse/videoparametersdialog.h
@@ -53,16 +53,22 @@ public slots:
 private slots:
     void on_blackLevelSpinBox_valueChanged(int value);
     void on_whiteLevelSpinBox_valueChanged(int value);
+    void on_activeVideoStartSpinBox_valueChanged(int value);
+    void on_activeVideoWidthSpinBox_valueChanged(int value);
 
     void on_blackLevelResetButton_clicked();
     void on_blackLevelAltResetButton_clicked();
     void on_whiteLevelResetButton_clicked();
+    void on_activeVideoStartResetButton_clicked();
+    void on_activeVideoWidthResetButton_clicked();
 
     void on_aspectRatioButtonGroup_buttonClicked(QAbstractButton *button);
 
 private:
     Ui::VideoParametersDialog *ui;
     LdDecodeMetaData::VideoParameters videoParameters;
+    qint32 originalActiveVideoStart = -1;
+    qint32 originalActiveVideoWidth = -1;
 
     void updateDialog();
 };

--- a/tools/ld-analyse/videoparametersdialog.ui
+++ b/tools/ld-analyse/videoparametersdialog.ui
@@ -77,7 +77,7 @@
      </property>
     </widget>
    </item>
-   <item row="3" column="0">
+   <item row="4" column="0">
     <widget class="QLabel" name="aspectRatioLabel">
      <property name="text">
       <string>Display aspect ratio:</string>
@@ -118,6 +118,74 @@
      </property>
     </widget>
    </item>
+   <item row="2" column="1">
+    <widget class="QSpinBox" name="activeVideoStartSpinBox">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="minimumSize">
+      <size>
+       <width>70</width>
+       <height>30</height>
+      </size>
+     </property>
+     <property name="prefix">
+      <string></string>
+     </property>
+     <property name="minimum">
+      <number>16</number>
+     </property>
+     <property name="maximum">
+      <number>200</number>
+     </property>
+     <property name="singleStep">
+      <number>1</number>
+     </property>
+     <property name="value">
+      <number>16</number>
+     </property>
+     <property name="displayIntegerBase">
+      <number>10</number>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="1">
+    <widget class="QSpinBox" name="activeVideoWidthSpinBox">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="minimumSize">
+      <size>
+       <width>70</width>
+       <height>30</height>
+      </size>
+     </property>
+     <property name="prefix">
+      <string></string>
+     </property>
+     <property name="minimum">
+      <number>1</number>
+     </property>
+     <property name="maximum">
+      <number>1000</number>
+     </property>
+     <property name="singleStep">
+      <number>1</number>
+     </property>
+     <property name="value">
+      <number>1</number>
+     </property>
+     <property name="displayIntegerBase">
+      <number>10</number>
+     </property>
+    </widget>
+   </item>
    <item row="1" column="2">
     <widget class="QPushButton" name="whiteLevelResetButton">
      <property name="minimumSize">
@@ -154,6 +222,52 @@
      </property>
     </widget>
    </item>
+   <item row="2" column="2">
+    <widget class="QPushButton" name="activeVideoStartResetButton">
+     <property name="minimumSize">
+      <size>
+       <width>100</width>
+       <height>0</height>
+      </size>
+     </property>
+     <property name="text">
+      <string>Reset</string>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="0">
+    <widget class="QLabel" name="activeVideoStartlLabel">
+     <property name="text">
+      <string>Active video start:</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="2">
+    <widget class="QPushButton" name="activeVideoWidthResetButton">
+     <property name="minimumSize">
+      <size>
+       <width>100</width>
+       <height>0</height>
+      </size>
+     </property>
+     <property name="text">
+      <string>Reset</string>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="0">
+    <widget class="QLabel" name="activeVideoWidthlLabel">
+     <property name="text">
+      <string>Active video width:</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+     </property>
+    </widget>
+   </item>
    <item row="2" column="0">
     <spacer name="verticalSpacer_1">
      <property name="orientation">
@@ -170,7 +284,7 @@
      </property>
     </spacer>
    </item>
-   <item row="3" column="1" colspan="3">
+   <item row="4" column="1" colspan="3">
     <widget class="QWidget" name="aspectRatioWidget" native="true">
      <layout class="QHBoxLayout" name="horizontalLayout">
       <property name="leftMargin">


### PR DESCRIPTION
Moved from https://github.com/oyvindln/vhs-decode/pull/152

Add the ability to adjust the active video start and width so the picture can be centered on off-spec tapes.

See: https://discord.com/channels/665557267189334046/801161098967121933/1253599479530258443

![video parameters](https://github.com/happycube/ld-decode/assets/9789076/d098c331-f242-48e6-9a56-bc65fc7f4273)
