### PR TITLE
add key shortcut to save json

### DIFF
--- a/tools/ld-analyse/mainwindow.ui
+++ b/tools/ld-analyse/mainwindow.ui
@@ -669,6 +669,9 @@
    <property name="text">
     <string>Save JSON</string>
    </property>
+   <property name="shortcut">
+    <string>Ctrl+J</string>
+   </property>
   </action>
   <action name="actionWhite_SNR_analysis">
    <property name="text">

--- a/tools/ld-analyse/mainwindow.ui
+++ b/tools/ld-analyse/mainwindow.ui
@@ -601,7 +601,7 @@
     <string>Save frame as PNG...</string>
    </property>
    <property name="shortcut">
-    <string>Ctrl+S</string>
+    <string>Ctrl+F</string>
    </property>
   </action>
   <action name="actionVITS_Metrics">
@@ -670,7 +670,7 @@
     <string>Save JSON</string>
    </property>
    <property name="shortcut">
-    <string>Ctrl+J</string>
+    <string>Ctrl+S</string>
    </property>
   </action>
   <action name="actionWhite_SNR_analysis">


### PR DESCRIPTION
* Add CTRL-S key shortcut to save tbc json
* Assign CTRL-F (previously CTRL-S) to save a frame grab

~We can change the shortcut letter if needed. I picked `CTRL-J` since `CTRL-S` was already taken by the png frame export option.~ Using `CTRL-S` per [discussion on Discord](https://discord.com/channels/665557267189334046/676084498097766451/1257075128974573618).