### PR TITLE
ld-analyse - View Modes Update

### DIFF
--- a/tools/ld-analyse/mainwindow.h
+++ b/tools/ld-analyse/mainwindow.h
@@ -88,18 +88,20 @@ private slots:
     // Media control frame handlers
     void on_previousPushButton_clicked();
     void on_nextPushButton_clicked();
-    void on_endFramePushButton_clicked();
-    void on_startFramePushButton_clicked();
-    void on_frameNumberSpinBox_editingFinished();
-    void on_frameHorizontalSlider_valueChanged(int value);
+    void on_endPushButton_clicked();
+    void on_startPushButton_clicked();
+    void on_posNumberSpinBox_editingFinished();
+    void on_posHorizontalSlider_valueChanged(int value);
     void on_videoPushButton_clicked();
     void on_aspectPushButton_clicked();
     void on_dropoutsPushButton_clicked();
     void on_sourcesPushButton_clicked();
+    void on_viewPushButton_clicked();
     void on_fieldOrderPushButton_clicked();
     void on_zoomInPushButton_clicked();
     void on_zoomOutPushButton_clicked();
     void on_originalSizePushButton_clicked();
+    void on_stretchFieldButton_clicked();
     void on_mouseModePushButton_clicked();
 
     // Miscellaneous handlers
@@ -142,24 +144,29 @@ private:
     bool displayAspectRatio;
     qint32 lastScopeLine;
     qint32 lastScopeDot;
-    qint32 currentFrameNumber;
+    qint32 currentFieldNumber, currentFrameNumber;
     double scaleFactor;
     QPalette buttonPalette;
     QString lastFilename;
 
     // Update GUI methods
     void setGuiEnabled(bool enabled);
+    void resetGui();
     void updateGuiLoaded();
     void updateGuiUnloaded();
     void updateAspectPushButton();
     void updateSourcesPushButton();
+    void setViewValues();
+    void setCurrentFrame(qint32 frame);
+    void setCurrentField(qint32 field);
+    void sanitizeCurrentPosition();
 
-    // Frame display methods
-    void showFrame();
-    void updateFrame();
+    // Image display methods
+    void showImage();
+    void updateImage();
     qint32 getAspectAdjustment();
-    void updateFrameViewer();
-    void hideFrame();
+    void updateImageViewer();
+    void hideImage();
 
     // TBC source signal handlers
     void loadTbcFile(QString inputFileName);

--- a/tools/ld-analyse/mainwindow.ui
+++ b/tools/ld-analyse/mainwindow.ui
@@ -58,7 +58,7 @@
          </property>
          <layout class="QVBoxLayout" name="verticalLayout_2">
           <item>
-           <widget class="QLabel" name="frameViewerLabel">
+           <widget class="QLabel" name="imageViewerLabel">
             <property name="text">
              <string>Image goes here</string>
             </property>
@@ -87,7 +87,7 @@
         </property>
         <layout class="QVBoxLayout" name="verticalLayout_3">
          <item>
-          <widget class="QSlider" name="frameHorizontalSlider">
+          <widget class="QSlider" name="posHorizontalSlider">
            <property name="orientation">
             <enum>Qt::Horizontal</enum>
            </property>
@@ -96,14 +96,20 @@
          <item>
           <layout class="QHBoxLayout" name="horizontalLayout_3">
            <item>
-            <widget class="QLabel" name="label_17">
+            <widget class="QLabel" name="posNumberSpinBoxLabel">
+             <property name="minimumSize">
+              <size>
+               <width>60</width>
+               <height>0</height>
+              </size>
+             </property>
              <property name="text">
               <string>Frame #:</string>
              </property>
             </widget>
            </item>
            <item>
-            <widget class="QSpinBox" name="frameNumberSpinBox">
+            <widget class="QSpinBox" name="posNumberSpinBox">
              <property name="toolTip">
               <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Enter a frame number and press &amp;lt;Enter&amp;gt; to go to a frame&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
              </property>
@@ -113,10 +119,16 @@
              <property name="value">
               <number>79999</number>
              </property>
+             <property name="maximumSize">
+              <size>
+               <width>120</width>
+               <height>50</height>
+              </size>
+             </property>
             </widget>
            </item>
            <item>
-            <widget class="QPushButton" name="startFramePushButton">
+            <widget class="QPushButton" name="startPushButton">
              <property name="minimumSize">
               <size>
                <width>30</width>
@@ -194,7 +206,7 @@
             </widget>
            </item>
            <item>
-            <widget class="QPushButton" name="endFramePushButton">
+            <widget class="QPushButton" name="endPushButton">
              <property name="minimumSize">
               <size>
                <width>30</width>
@@ -314,6 +326,22 @@
             </widget>
            </item>
            <item>
+            <widget class="QPushButton" name="stretchFieldButton">
+             <property name="minimumSize">
+              <size>
+               <width>30</width>
+               <height>30</height>
+              </size>
+             </property>
+             <property name="toolTip">
+              <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Stretch field to frame height&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+             </property>
+             <property name="text">
+              <string>2:1</string>
+             </property>
+            </widget>
+           </item>
+           <item>
             <widget class="QPushButton" name="mouseModePushButton">
              <property name="minimumSize">
               <size>
@@ -416,6 +444,22 @@
              </property>
              <property name="text">
               <string>Y+C Sources</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QPushButton" name="viewPushButton">
+             <property name="minimumSize">
+              <size>
+               <width>100</width>
+               <height>0</height>
+              </size>
+             </property>
+             <property name="toolTip">
+              <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Toggle views&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+             </property>
+             <property name="text">
+              <string>Field View</string>
              </property>
             </widget>
            </item>

--- a/tools/ld-analyse/tbcsource.h
+++ b/tools/ld-analyse/tbcsource.h
@@ -77,10 +77,25 @@ public:
 
     void setHighlightDropouts(bool _state);
     void setChromaDecoder(bool _state);
+    void setFieldView(bool _state);
     void setFieldOrder(bool _state);
     bool getHighlightDropouts();
     bool getChromaDecoder();
     bool getFieldOrder();
+
+    enum ViewMode {
+        FRAME_VIEW,
+        SPLIT_VIEW,
+        FIELD_VIEW,
+    };
+    void setViewMode(ViewMode viewMode);
+    void setStretchField(bool _stretch);
+
+    ViewMode getViewMode();
+    bool getFrameViewEnabled();
+    bool getFieldViewEnabled();
+    bool getSplitViewEnabled();
+    bool getStretchField();
 
     enum SourceMode {
         ONE_SOURCE,
@@ -91,9 +106,9 @@ public:
     SourceMode getSourceMode();
     void setSourceMode(SourceMode sourceMode);
 
-    void loadFrame(qint32 frameNumber);
+    void load(qint32 frameNumber, qint32 fieldNumber);
 
-    QImage getFrameImage();
+    QImage getImage();
     qint32 getNumberOfFrames();
     qint32 getNumberOfFields();
     bool getIsWidescreen();
@@ -156,10 +171,12 @@ private:
     QVector<double> dropoutGraphData;
     QVector<double> visibleDropoutGraphData;
 
-    // Frame image options
+    // Image options
     bool chromaOn;
     bool dropoutsOn;
     bool reverseFoOn;
+    bool stretchFieldOn;
+    ViewMode viewMode;
 
     // Source globals
     SourceVideo sourceVideo;
@@ -187,7 +204,7 @@ private:
     // Metadata for the loaded frame
     qint32 firstFieldNumber, secondFieldNumber;
     LdDecodeMetaData::Field firstField, secondField;
-    qint32 loadedFrameNumber;
+    qint32 loadedFieldNumber, loadedFrameNumber;
 
     // Source fields needed to decode the loaded frame
     QVector<SourceField> inputFields;
@@ -200,8 +217,8 @@ private:
     bool decodedFrameValid;
 
     // RGB image data for the loaded frame
-    QImage frameCache;
-    bool frameCacheValid;
+    QImage cache;
+    bool cacheValid;
 
     // Chroma decoder configuration
     PalColour::Configuration palConfiguration;
@@ -212,11 +229,13 @@ private:
     QVector<qint32> chapterMap;
 
     void resetState();
-    void invalidateFrameCache();
+    void invalidateImageCache();
     void configureChromaDecoder();
     void loadInputFields();
     void decodeFrame();
     QImage generateQImage();
+    QImage generateChromaImage();
+    QImage generateMonoImage();
     void generateData();
     bool startBackgroundLoad(QString sourceFilename);
     bool startBackgroundSave(QString jsonFilename);

--- a/tools/ld-analyse/vectorscopedialog.h
+++ b/tools/ld-analyse/vectorscopedialog.h
@@ -1,4 +1,4 @@
-﻿/************************************************************************
+/************************************************************************
 
     vectorscopedialog.cpp
 
@@ -31,6 +31,7 @@
 
 #include "componentframe.h"
 #include "lddecodemetadata.h"
+#include "tbcsource.h"
 
 namespace Ui {
 class VectorscopeDialog;
@@ -51,12 +52,15 @@ signals:
 
 private slots:
     void on_defocusCheckBox_clicked();
+    void on_blendColorCheckBox_clicked();
     void on_graticuleButtonGroup_buttonClicked(QAbstractButton *button);
+    void on_fieldSelectButtonGroup_buttonClicked(QAbstractButton *button);
 
 private:
     Ui::VectorscopeDialog *ui;
 
-    QImage getTraceImage(const ComponentFrame &componentFrame, const LdDecodeMetaData::VideoParameters &videoParameters);
+    QImage getTraceImage(const ComponentFrame &componentFrame, const LdDecodeMetaData::VideoParameters &videoParameters,
+                         const TbcSource::ViewMode &viewMode, const bool firstField = false);
 };
 
 #endif // VECTORSCOPEDIALOG_H

--- a/tools/ld-analyse/vectorscopedialog.ui
+++ b/tools/ld-analyse/vectorscopedialog.ui
@@ -55,6 +55,56 @@
      </property>
      <layout class="QVBoxLayout" name="verticalLayout">
       <item>
+       <widget class="QLabel" name="fieldSelectLabel">
+        <property name="text">
+         <string>Field:</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QRadioButton" name="fieldSelectAllRadioButton">
+        <property name="text">
+         <string>All</string>
+        </property>
+        <property name="checked">
+         <bool>true</bool>
+        </property>
+        <attribute name="buttonGroup">
+         <string notr="true">fieldSelectButtonGroup</string>
+        </attribute>
+       </widget>
+      </item>
+      <item>
+       <widget class="QRadioButton" name="fieldSelectFirstRadioButton">
+        <property name="text">
+         <string>Field 1</string>
+        </property>
+        <attribute name="buttonGroup">
+         <string notr="true">fieldSelectButtonGroup</string>
+        </attribute>
+       </widget>
+      </item>
+      <item>
+       <widget class="QRadioButton" name="fieldSelectSecondRadioButton">
+        <property name="text">
+         <string>Field 2</string>
+        </property>
+        <attribute name="buttonGroup">
+         <string notr="true">fieldSelectButtonGroup</string>
+        </attribute>
+       </widget>
+      </item>
+      <item>
+       <spacer name="verticalSpacer">
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>20</width>
+          <height>40</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+      <item>
        <widget class="QCheckBox" name="defocusCheckBox">
         <property name="toolTip">
          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Blur the display to make small points more visible&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
@@ -65,7 +115,17 @@
        </widget>
       </item>
       <item>
-       <spacer name="verticalSpacer">
+       <widget class="QCheckBox" name="blendColorCheckBox">
+        <property name="toolTip">
+         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Blend overlapping data points&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+        </property>
+        <property name="text">
+         <string>Blend colors</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <spacer name="verticalSpacer_2">
         <property name="orientation">
          <enum>Qt::Vertical</enum>
         </property>
@@ -125,6 +185,7 @@
  <resources/>
  <connections/>
  <buttongroups>
+  <buttongroup name="fieldSelectButtonGroup"/>
   <buttongroup name="graticuleButtonGroup"/>
  </buttongroups>
 </ui>


### PR DESCRIPTION
## Changes

Video View Modes: 

Field/Frame/Split

1:1

![image](https://github.com/user-attachments/assets/d273f91d-12b0-4d10-a785-21a0d5cd995e)

2:1

![image](https://github.com/user-attachments/assets/c8b1c596-5926-43e6-bc79-c7ff3587646b)

Split

![image](https://github.com/user-attachments/assets/3fdd477e-3bc7-4dad-a13d-67cd29a677a3)


Vectorscope: 

Field 1 / Field 2 / Combined

Field 1

![image](https://github.com/user-attachments/assets/55caaeff-8d05-480b-969f-d4675f300704)

Field 2 

![image](https://github.com/user-attachments/assets/9b3d39a5-f706-4521-a5cf-208a8e2f60ff)

Combined

![image](https://github.com/user-attachments/assets/41c1d2c2-a7af-4813-9236-2db9f7380b9e)
