### PR TITLE
changed ffmpeg log level to 'quiet'

### DIFF
--- a/lddecode/utils.py
+++ b/lddecode/utils.py
@@ -347,7 +347,7 @@ class LoadFFmpeg:
         readlen_bytes = readlen * 2
 
         if self.ffmpeg is None:
-            command = ["ffmpeg", "-hide_banner", "-loglevel", "error"]
+            command = ["ffmpeg", "-hide_banner", "-loglevel", "quiet"]
             command += self.input_args
             command += ["-i", "-"]
             command += self.output_args
@@ -502,7 +502,7 @@ class LoadLDF:
 
 
 def ffmpeg_pipe(outname: str, opts: str):
-    cmd = f"ffmpeg -y -hide_banner -loglevel error -f s16le -ar 40k -ac 1 -i -"
+    cmd = f"ffmpeg -y -hide_banner -loglevel quiet -f s16le -ar 40k -ac 1 -i -"
     if opts and len(opts):
         cmd += f" {opts}"
 


### PR DESCRIPTION
Workaround for `Application provided invalid, non monotonically increasing dts to muxer in stream 0` that occurs when decoding 2h+ length tapes sometimes.

**Issue**: After decoding about 2 hours (media time) of a video file, ffmpeg repeatedly spits out this error message. Continuously writing to stderr drastically reduces the FPS of the decode to almost <1 FPS. This issue is observed on the latest branch, both Windows and Ubuntu.

![image](https://github.com/user-attachments/assets/7734c9c0-acd5-4713-b9de-50348dca6014)
 
**Change:** The log level for ffmpeg is set to `quiet` to prevent any output. This improves the decode speed to regular rates (as tested on the two forum posts below):
https://discord.com/channels/665557267189334046/665834485975351307/1349381086144368722
https://discord.com/channels/665557267189334046/665834485975351307/1349733081615175741

**Note:** Please verify whether both lines 350 and 505 need to be changed. This change will also hide any ffmpeg errors from the user. I'll leave it to the maintainers to decide if this should be behind a flag instead.