### PR TITLE
ld-analyse fix 2

### DIFF
--- a/tools/ld-analyse/mainwindow.cpp
+++ b/tools/ld-analyse/mainwindow.cpp
@@ -539,7 +539,8 @@ void MainWindow::updateOscilloscopeDialogue()
 void MainWindow::updateVectorscopeDialogue()
 {
     // Update the vectorscope dialogue
-    vectorscopeDialog->showTraceImage(tbcSource.getComponentFrame(), tbcSource.getVideoParameters());
+    vectorscopeDialog->showTraceImage(tbcSource.getComponentFrame(), tbcSource.getVideoParameters(),
+                                      tbcSource.getViewMode(), currentFieldNumber % 2);
 }
 
 // Method to set the view (field/frame) values

--- a/tools/ld-analyse/vectorscopedialog.cpp
+++ b/tools/ld-analyse/vectorscopedialog.cpp
@@ -40,7 +40,7 @@ VectorscopeDialog::VectorscopeDialog(QWidget *parent) :
     setWindowFlags(Qt::Window);
 
     ui->fieldSelectFirstRadioButton->setStyleSheet("color: green;");
-    ui->fieldSelectSecondRadioButton->setStyleSheet("color: red;");
+    ui->fieldSelectSecondRadioButton->setStyleSheet("color: darkcyan;");
 }
 
 VectorscopeDialog::~VectorscopeDialog()
@@ -131,11 +131,11 @@ QImage VectorscopeDialog::getTraceImage(const ComponentFrame &componentFrame, co
     qint32 startingFrame = !ui->fieldSelectSecondRadioButton->isChecked() ? 0 : 1;
 
     for (auto fieldN = startingFrame; fieldN < fieldCount; fieldN++) {
-        // Set color to red on second field if blend enabled...
-        if (ui->fieldSelectAllRadioButton->isChecked() && ui->blendColorCheckBox->isChecked() && fieldN == 1) color = Qt::red;
+        // Set color to cyan on second field if blend enabled...
+        if (ui->fieldSelectAllRadioButton->isChecked() && ui->blendColorCheckBox->isChecked() && fieldN == 1) color = Qt::cyan;
 
         // ...or second only is selected
-        if (ui->fieldSelectSecondRadioButton->isChecked()) color = Qt::red;
+        if (ui->fieldSelectSecondRadioButton->isChecked()) color = Qt::cyan;
 
         scopePainter.setPen(color);
 

--- a/tools/ld-analyse/vectorscopedialog.h
+++ b/tools/ld-analyse/vectorscopedialog.h
@@ -45,7 +45,8 @@ public:
     explicit VectorscopeDialog(QWidget *parent = nullptr);
     ~VectorscopeDialog();
 
-    void showTraceImage(const ComponentFrame &componentFrame, const LdDecodeMetaData::VideoParameters &videoParameters);
+    void showTraceImage(const ComponentFrame &componentFrame, const LdDecodeMetaData::VideoParameters &videoParameters,
+                        const TbcSource::ViewMode& viewMode, const bool isFirstField);
 
 signals:
     void scopeChanged();
@@ -59,8 +60,7 @@ private slots:
 private:
     Ui::VectorscopeDialog *ui;
 
-    QImage getTraceImage(const ComponentFrame &componentFrame, const LdDecodeMetaData::VideoParameters &videoParameters,
-                         const TbcSource::ViewMode &viewMode, const bool firstField = false);
+    QImage getTraceImage(const ComponentFrame &componentFrame, const LdDecodeMetaData::VideoParameters &videoParameters);
 };
 
 #endif // VECTORSCOPEDIALOG_H


### PR DESCRIPTION
This fix patches the load crashing error.

This also fixes the line-scope modes and the vector scope per field view modes have proper locking.

This also changes the vector scope to Green/Cyan instead of Green/Red which had rendering issues . 

![ld-analyse-vectorscope](https://github.com/user-attachments/assets/9f9c1de5-8274-40c5-bfe4-a808f99d1818)
