### PR TITLE
fix build on MVSC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -84,13 +84,24 @@ if(USE_QWT)
     endif()
 endif()
 
-pkg_check_modules(FFTW IMPORTED_TARGET fftw3)
-if(FFTW_FOUND)
-    # .....
-    set(FFTW_INCLUDE_DIR ${FFTW_INCLUDE_DIRS})
-    set(FFTW_LIBRARY PkgConfig::FFTW)
+if(NOT MSVC)
+    pkg_check_modules(FFTW IMPORTED_TARGET fftw3)
+    if(FFTW_FOUND)
+        # .....
+        set(FFTW_INCLUDE_DIR ${FFTW_INCLUDE_DIRS})
+        set(FFTW_LIBRARY PkgConfig::FFTW)
+    else()
+        find_package(FFTW REQUIRED)
+    endif()
 else()
-    find_package(FFTW REQUIRED)
+    # pkg-config seems to
+    # result in trying to link to m.lib
+    # which breaks build on
+    # MSVC, so just use the cmake.config from
+    # the vcpkg install instead.
+    find_package(FFTW3 REQUIRED)
+    set(FFTW_INCLUDE_DIR ${FFTW3_INCLUDE_DIRS})
+    find_library(FFTW_LIBRARY ${FFTW3_LIBRARIES} ${FFTW3_LIBRARY_DIRS})
 endif()
 
 # Get the Git branch and revision

--- a/tools/ld-chroma-decoder/CMakeLists.txt
+++ b/tools/ld-chroma-decoder/CMakeLists.txt
@@ -19,6 +19,8 @@ target_include_directories(lddecode-chroma PUBLIC .)
 
 target_link_libraries(lddecode-chroma PRIVATE Qt::Core ${FFTW_LIBRARY} lddecode-library)
 
+target_include_directories(lddecode-chroma PRIVATE ${FFTW_INCLUDE_DIR})
+
 # ld-chroma-decoder
 
 add_executable(ld-chroma-decoder


### PR DESCRIPTION
There seems to be a bug with fftw3's pkg-config .pc files when using MSVC:
https://github.com/FFTW/fftw3/issues/236

Not sure why we haven't hit this issue previously since fftw hasn't had an update in ages but I hit it now after updating to latest library versions (if it was just failing to find it via pkg-config and falling back to findfftw.cmake it would have failed on missing includes I think as I had to add a missing include to make it work) - fix it by just not using pkg-config when using msvc and instead just using the bundled cmake.config files instead