### PR TITLE
Y/C and mono decoding for ld-analyse + QOL improvements.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -85,3 +85,6 @@ ui_*.h
 
 # Installation tool things
 ld_decode.egg-info/
+
+# Compilation script
+compile.bat

--- a/tools/ld-analyse/chromadecoderconfigdialog.cpp
+++ b/tools/ld-analyse/chromadecoderconfigdialog.cpp
@@ -163,12 +163,11 @@ void ChromaDecoderConfigDialog::updateDialog()
 			palConfiguration.chromaFilter = PalColour::transform2DFilter;
 			ntscConfiguration.dimensions = 2;
 		}
-		ntscConfiguration.phaseCompensation = false;
+		ntscConfiguration.phaseCompensation = (tbcSource->getVideoParameters().tapeFormat != "");//enable phase compensation only for tape
 		ui->enableYNRCheckBox->setChecked(yNREnabled);
 		ui->enableYCCombineCheckBox->setChecked(combine);
 		
 		isInit = true;
-		
 	}
 
     // Shared settings

--- a/tools/ld-analyse/chromadecoderconfigdialog.cpp
+++ b/tools/ld-analyse/chromadecoderconfigdialog.cpp
@@ -164,9 +164,8 @@ void ChromaDecoderConfigDialog::updateDialog()
 			ntscConfiguration.dimensions = 2;
 		}
 		ntscConfiguration.phaseCompensation = false;
-		
-		ui->enableYNRCheckBox->setChecked(true);
-		ui->enableYCCombineCheckBox->setChecked(false);
+		ui->enableYNRCheckBox->setChecked(yNREnabled);
+		ui->enableYCCombineCheckBox->setChecked(combine);
 		
 		isInit = true;
 		
@@ -184,10 +183,8 @@ void ChromaDecoderConfigDialog::updateDialog()
     ui->chromaPhaseValueLabel->setEnabled(true);
     ui->chromaPhaseValueLabel->setText(QString::number(palConfiguration.chromaPhase, 'f', 1) + QChar(0xB0));
     
-    double yNRLevel = isSourcePal ? palConfiguration.yNRLevel : ntscConfiguration.yNRLevel;
-    
-    ui->yNRHorizontalSlider->setValue(static_cast<qint32>(yNRLevel * 10));
-    ui->yNRValueLabel->setText(QString::number(yNRLevel, 'f', 1) + " IRE");
+    ui->yNRHorizontalSlider->setValue(static_cast<qint32>(ynrLevel * 10));
+    ui->yNRValueLabel->setText(QString::number(ynrLevel, 'f', 1) + " IRE");
 	
 	if(sourceMode == TbcSource::BOTH_SOURCES)
 	{
@@ -321,7 +318,9 @@ void ChromaDecoderConfigDialog::on_chromaPhaseHorizontalSlider_valueChanged(int 
 
 void ChromaDecoderConfigDialog::on_enableYNRCheckBox_clicked()
 {
-	ui->yNRHorizontalSlider->setEnabled(ui->enableYNRCheckBox->isChecked());
+	yNREnabled = ui->enableYNRCheckBox->isChecked();
+	ui->yNRHorizontalSlider->setEnabled(yNREnabled);
+	
 	if(ui->enableYNRCheckBox->isChecked())
 	{
 		palConfiguration.yNRLevel = ynrLevel;
@@ -418,6 +417,7 @@ void ChromaDecoderConfigDialog::on_yNRHorizontalSlider_valueChanged(int value)
     palConfiguration.yNRLevel = static_cast<double>(value) / 10;
     ntscConfiguration.yNRLevel = static_cast<double>(value) / 10;
 	monoConfiguration.yNRLevel = static_cast<double>(value) / 10;
+	ynrLevel = static_cast<double>(value) / 10;
     ui->yNRValueLabel->setText(QString::number(ntscConfiguration.yNRLevel, 'f', 1) + " IRE");
     emit chromaDecoderConfigChanged();
 }
@@ -437,6 +437,7 @@ void ChromaDecoderConfigDialog::updateSourceMode(TbcSource::SourceMode mode)
 
 void ChromaDecoderConfigDialog::on_enableYCCombineCheckBox_clicked()
 {
-	tbcSource->setCombine(ui->enableYCCombineCheckBox->isChecked());
+	combine = ui->enableYCCombineCheckBox->isChecked();
+	tbcSource->setCombine(combine);
 	emit chromaDecoderConfigChanged();
 }

--- a/tools/ld-analyse/chromadecoderconfigdialog.cpp
+++ b/tools/ld-analyse/chromadecoderconfigdialog.cpp
@@ -163,6 +163,8 @@ void ChromaDecoderConfigDialog::updateDialog()
 			palConfiguration.chromaFilter = PalColour::transform2DFilter;
 			ntscConfiguration.dimensions = 2;
 		}
+		ntscConfiguration.phaseCompensation = false;
+		
 		ui->enableYNRCheckBox->setChecked(true);
 		ui->enableYCCombineCheckBox->setChecked(false);
 		

--- a/tools/ld-analyse/chromadecoderconfigdialog.cpp
+++ b/tools/ld-analyse/chromadecoderconfigdialog.cpp
@@ -176,6 +176,8 @@ void ChromaDecoderConfigDialog::updateDialog()
     
     ui->yNRHorizontalSlider->setValue(static_cast<qint32>(yNRLevel * 10));
     ui->yNRValueLabel->setText(QString::number(yNRLevel, 'f', 1) + " IRE");
+	
+	ui->enableYNRCheckBox->setChecked(true);
 
     // PAL settings
 	

--- a/tools/ld-analyse/chromadecoderconfigdialog.cpp
+++ b/tools/ld-analyse/chromadecoderconfigdialog.cpp
@@ -163,7 +163,11 @@ void ChromaDecoderConfigDialog::updateDialog()
 			palConfiguration.chromaFilter = PalColour::transform2DFilter;
 			ntscConfiguration.dimensions = 2;
 		}
+		ui->enableYNRCheckBox->setChecked(true);
+		ui->enableYCCombineCheckBox->setChecked(false);
+		
 		isInit = true;
+		
 	}
 
     // Shared settings
@@ -183,8 +187,6 @@ void ChromaDecoderConfigDialog::updateDialog()
     ui->yNRHorizontalSlider->setValue(static_cast<qint32>(yNRLevel * 10));
     ui->yNRValueLabel->setText(QString::number(yNRLevel, 'f', 1) + " IRE");
 	
-	ui->enableYNRCheckBox->setChecked(true);
-	ui->enableYCCombineCheckBox->setChecked(false);
 	if(sourceMode == TbcSource::BOTH_SOURCES)
 	{
 		ui->enableYCCombineCheckBox->show();

--- a/tools/ld-analyse/chromadecoderconfigdialog.cpp
+++ b/tools/ld-analyse/chromadecoderconfigdialog.cpp
@@ -25,6 +25,7 @@
 
 #include "chromadecoderconfigdialog.h"
 #include "ui_chromadecoderconfigdialog.h"
+#include "mainwindow.h"
 
 #include <cmath>
 
@@ -78,6 +79,11 @@ ChromaDecoderConfigDialog::ChromaDecoderConfigDialog(QWidget *parent) :
     ui->yNRHorizontalSlider->setMinimum(0);
     ui->yNRHorizontalSlider->setMaximum(100);
     
+	//get tbcSource instance from mainWindow
+	if (auto mw = qobject_cast<MainWindow*>(parent)) {
+		tbcSource = &mw->getTbcSource();
+	}
+	
     // Update the dialogue
     updateDialog();
 }
@@ -178,6 +184,15 @@ void ChromaDecoderConfigDialog::updateDialog()
     ui->yNRValueLabel->setText(QString::number(yNRLevel, 'f', 1) + " IRE");
 	
 	ui->enableYNRCheckBox->setChecked(true);
+	ui->enableYCCombineCheckBox->setChecked(false);
+	if(sourceMode == TbcSource::BOTH_SOURCES)
+	{
+		ui->enableYCCombineCheckBox->show();
+	}
+	else
+	{
+		ui->enableYCCombineCheckBox->hide();
+	}
 
     // PAL settings
 	
@@ -401,4 +416,23 @@ void ChromaDecoderConfigDialog::on_yNRHorizontalSlider_valueChanged(int value)
 	monoConfiguration.yNRLevel = static_cast<double>(value) / 10;
     ui->yNRValueLabel->setText(QString::number(ntscConfiguration.yNRLevel, 'f', 1) + " IRE");
     emit chromaDecoderConfigChanged();
+}
+
+void ChromaDecoderConfigDialog::updateSourceMode(TbcSource::SourceMode mode)
+{
+	sourceMode = mode;
+	if(sourceMode == TbcSource::BOTH_SOURCES)
+	{
+		ui->enableYCCombineCheckBox->show();
+	}
+	else
+	{
+		ui->enableYCCombineCheckBox->hide();
+	}
+}
+
+void ChromaDecoderConfigDialog::on_enableYCCombineCheckBox_clicked()
+{
+	tbcSource->setCombine(ui->enableYCCombineCheckBox->isChecked());
+	emit chromaDecoderConfigChanged();
 }

--- a/tools/ld-analyse/chromadecoderconfigdialog.h
+++ b/tools/ld-analyse/chromadecoderconfigdialog.h
@@ -32,6 +32,7 @@
 #include "outputwriter.h"
 #include "palcolour.h"
 #include "monodecoder.h"
+#include "tbcsource.h"
 
 namespace Ui {
 class ChromaDecoderConfigDialog;
@@ -47,6 +48,9 @@ public:
 
     void setConfiguration(VideoSystem system, const PalColour::Configuration &palConfiguration,
                           const Comb::Configuration &ntscConfiguration,
+                          const MonoDecoder::MonoConfiguration &monoConfiguration,
+                          const TbcSource::SourceMode &_mode,
+						  const bool _isInit,
                           const OutputWriter::Configuration &outputConfiguration);
     const PalColour::Configuration &getPalConfiguration();
     const Comb::Configuration &getNtscConfiguration();
@@ -58,6 +62,7 @@ signals:
 private slots:
     void on_chromaGainHorizontalSlider_valueChanged(int value);
     void on_chromaPhaseHorizontalSlider_valueChanged(int value);
+	void on_enableYNRCheckBox_clicked();
 
     void on_palFilterButtonGroup_buttonClicked(QAbstractButton *button);
     void on_thresholdHorizontalSlider_valueChanged(int value);
@@ -78,6 +83,9 @@ private:
     Comb::Configuration ntscConfiguration;
     MonoDecoder::MonoConfiguration monoConfiguration;
     OutputWriter::Configuration outputConfiguration;
+	TbcSource::SourceMode sourceMode;
+	double ynrLevel = 0;
+	bool isInit = true;
 
     void updateDialog();
 };

--- a/tools/ld-analyse/chromadecoderconfigdialog.h
+++ b/tools/ld-analyse/chromadecoderconfigdialog.h
@@ -31,6 +31,7 @@
 #include "comb.h"
 #include "outputwriter.h"
 #include "palcolour.h"
+#include "monodecoder.h"
 
 namespace Ui {
 class ChromaDecoderConfigDialog;
@@ -75,6 +76,7 @@ private:
     VideoSystem system;
     PalColour::Configuration palConfiguration;
     Comb::Configuration ntscConfiguration;
+    MonoDecoder::MonoConfiguration monoConfiguration;
     OutputWriter::Configuration outputConfiguration;
 
     void updateDialog();

--- a/tools/ld-analyse/chromadecoderconfigdialog.h
+++ b/tools/ld-analyse/chromadecoderconfigdialog.h
@@ -59,10 +59,14 @@ public:
 signals:
     void chromaDecoderConfigChanged();
 
+public slots:
+	void updateSourceMode(TbcSource::SourceMode mode);
+
 private slots:
     void on_chromaGainHorizontalSlider_valueChanged(int value);
     void on_chromaPhaseHorizontalSlider_valueChanged(int value);
 	void on_enableYNRCheckBox_clicked();
+	void on_enableYCCombineCheckBox_clicked();
 
     void on_palFilterButtonGroup_buttonClicked(QAbstractButton *button);
     void on_thresholdHorizontalSlider_valueChanged(int value);
@@ -83,6 +87,7 @@ private:
     Comb::Configuration ntscConfiguration;
     MonoDecoder::MonoConfiguration monoConfiguration;
     OutputWriter::Configuration outputConfiguration;
+	TbcSource* tbcSource = nullptr;
 	TbcSource::SourceMode sourceMode;
 	double ynrLevel = 0;
 	bool isInit = true;

--- a/tools/ld-analyse/chromadecoderconfigdialog.h
+++ b/tools/ld-analyse/chromadecoderconfigdialog.h
@@ -91,6 +91,8 @@ private:
 	TbcSource::SourceMode sourceMode;
 	double ynrLevel = 0;
 	bool isInit = true;
+	bool combine = false;
+	bool yNREnabled = true;
 
     void updateDialog();
 };

--- a/tools/ld-analyse/chromadecoderconfigdialog.ui
+++ b/tools/ld-analyse/chromadecoderconfigdialog.ui
@@ -115,6 +115,13 @@
     </widget>
    </item>
    <item>
+    <widget class="QCheckBox" name="enableYCCombineCheckBox">
+     <property name="text">
+      <string>Combine Y/C -> CVBS</string>
+     </property>
+    </widget>
+   </item>
+   <item>
     <spacer name="verticalSpacer_1">
      <property name="orientation">
       <enum>Qt::Vertical</enum>

--- a/tools/ld-analyse/chromadecoderconfigdialog.ui
+++ b/tools/ld-analyse/chromadecoderconfigdialog.ui
@@ -108,6 +108,13 @@
     </widget>
    </item>
    <item>
+    <widget class="QCheckBox" name="enableYNRCheckBox">
+     <property name="text">
+      <string>Enable luma noise reduction</string>
+     </property>
+    </widget>
+   </item>
+   <item>
     <spacer name="verticalSpacer_1">
      <property name="orientation">
       <enum>Qt::Vertical</enum>

--- a/tools/ld-analyse/chromadecoderconfigdialog.ui
+++ b/tools/ld-analyse/chromadecoderconfigdialog.ui
@@ -137,6 +137,16 @@
          </property>
         </widget>
        </item>
+	   <item>
+        <widget class="QRadioButton" name="palMonoRadioButton">
+         <property name="text">
+          <string>Mono</string>
+         </property>
+         <attribute name="buttonGroup">
+          <string notr="true">palFilterButtonGroup</string>
+         </attribute>
+        </widget>
+       </item>
        <item>
         <widget class="QRadioButton" name="palFilterPalColourRadioButton">
          <property name="text">
@@ -272,6 +282,16 @@
          <property name="text">
           <string>Chroma filter:</string>
          </property>
+        </widget>
+       </item>
+	   <item>
+        <widget class="QRadioButton" name="ntscMonoRadioButton">
+         <property name="text">
+          <string>Mono</string>
+         </property>
+         <attribute name="buttonGroup">
+          <string notr="true">ntscFilterButtonGroup</string>
+         </attribute>
         </widget>
        </item>
        <item>

--- a/tools/ld-analyse/mainwindow.cpp
+++ b/tools/ld-analyse/mainwindow.cpp
@@ -187,7 +187,7 @@ void MainWindow::resetGui()
 
     ui->posNumberSpinBox->setValue(1);
     ui->posHorizontalSlider->setValue(1);
-    ui->dropoutsPushButton->setText(tr("Dropouts Off"));
+   (this->width() >= 930) ? ui->dropoutsPushButton->setText(tr("Dropouts Off")) : ui->dropoutsPushButton->setText(tr("Drop N"));
 
     setViewValues();
 
@@ -201,10 +201,15 @@ void MainWindow::resetGui()
 
     // Set option button states
     ui->videoPushButton->setText(tr("Source"));
-    displayAspectRatio = false;
+    displayAspectRatio = true;
     updateAspectPushButton();
     updateSourcesPushButton();
-    ui->fieldOrderPushButton->setText(tr("Normal Field-order"));
+    if (this->width() > 1000)
+		ui->fieldOrderPushButton->setText(tr("Normal Field-order"));
+	else if (this->width() >= 930)
+		ui->fieldOrderPushButton->setText(tr("Normal order"));
+	else
+		ui->fieldOrderPushButton->setText(tr("Normal"));
 
     // Zoom button options
     ui->zoomInPushButton->setAutoRepeat(true);
@@ -264,6 +269,9 @@ void MainWindow::updateGuiLoaded()
 
     // Disable "Save JSON", now we've loaded the metadata into the GUI
     ui->actionSave_JSON->setEnabled(false);
+	
+	//resize the windows to fit the content in full screen
+	MainWindow::resize_on_aspect();
 }
 
 // Method to update the GUI when a file is unloaded
@@ -288,11 +296,16 @@ void MainWindow::updateGuiUnloaded()
 
     // Set option button states
     ui->videoPushButton->setText(tr("Source"));
-    ui->dropoutsPushButton->setText(tr("Dropouts Off"));
+    (this->width() >= 930) ? ui->dropoutsPushButton->setText(tr("Dropouts Off")) : ui->dropoutsPushButton->setText(tr("Drop N"));
     displayAspectRatio = false;
     updateAspectPushButton();
     updateSourcesPushButton();
-    ui->fieldOrderPushButton->setText(tr("Normal Field-order"));
+    if (this->width() > 1000)
+		ui->fieldOrderPushButton->setText(tr("Normal Field-order"));
+	else if (this->width() >= 930)
+		ui->fieldOrderPushButton->setText(tr("Normal order"));
+	else
+		ui->fieldOrderPushButton->setText(tr("Normal"));
 
     // Hide the displayed image
     hideImage();
@@ -313,7 +326,7 @@ void MainWindow::updateAspectPushButton()
     if (!displayAspectRatio) {
         ui->aspectPushButton->setText(tr("SAR 1:1"));
     } else if (tbcSource.getIsWidescreen()) {
-        ui->aspectPushButton->setText(tr("DAR 16:9"));
+        (this->width() >= 1020) ? ui->aspectPushButton->setText(tr("DAR 16:9")) : ui->aspectPushButton->setText(tr("16:9"));
     } else {
         ui->aspectPushButton->setText(tr("DAR 4:3"));
     }
@@ -322,20 +335,40 @@ void MainWindow::updateAspectPushButton()
 // Update the source selection button
 void MainWindow::updateSourcesPushButton()
 {
-    switch (tbcSource.getSourceMode()) {
-    case TbcSource::ONE_SOURCE:
-        ui->sourcesPushButton->setText(tr("One Source"));
-        break;
-    case TbcSource::LUMA_SOURCE:
-        ui->sourcesPushButton->setText(tr("Y Source"));
-        break;
-    case TbcSource::CHROMA_SOURCE:
-        ui->sourcesPushButton->setText(tr("C Source"));
-        break;
-    case TbcSource::BOTH_SOURCES:
-        ui->sourcesPushButton->setText(tr("Y+C Sources"));
-        break;
-    }
+	if (this->width() >= 930)
+	{
+		switch (tbcSource.getSourceMode()) {
+		case TbcSource::ONE_SOURCE:
+			ui->sourcesPushButton->setText(tr("One Source"));
+			break;
+		case TbcSource::LUMA_SOURCE:
+			ui->sourcesPushButton->setText(tr("Y Source"));
+			break;
+		case TbcSource::CHROMA_SOURCE:
+			ui->sourcesPushButton->setText(tr("C Source"));
+			break;
+		case TbcSource::BOTH_SOURCES:
+			ui->sourcesPushButton->setText(tr("Y+C Sources"));
+			break;
+		}
+	}
+	else
+	{
+		switch (tbcSource.getSourceMode()) {
+		case TbcSource::ONE_SOURCE:
+			ui->sourcesPushButton->setText(tr(".TBC"));
+			break;
+		case TbcSource::LUMA_SOURCE:
+			ui->sourcesPushButton->setText(tr("Y"));
+			break;
+		case TbcSource::CHROMA_SOURCE:
+			ui->sourcesPushButton->setText(tr("C"));
+			break;
+		case TbcSource::BOTH_SOURCES:
+			ui->sourcesPushButton->setText(tr("Y+C"));
+			break;
+		}
+	}
 }
 
 // Frame display methods ----------------------------------------------------------------------------------------------
@@ -548,27 +581,53 @@ void MainWindow::setViewValues()
 {
     qint32 currentNumber, maximum;
     QString buttonLabel, spinLabel;
+	
+	if (this->width() >= 930)
+	{
+		if (tbcSource.getFieldViewEnabled()) {
+			currentNumber = currentFieldNumber;
+			maximum = tbcSource.getNumberOfFields();
+			spinLabel = QString("Field #:");
+			buttonLabel = QString("Field View");
 
-    if (tbcSource.getFieldViewEnabled()) {
-        currentNumber = currentFieldNumber;
-        maximum = tbcSource.getNumberOfFields();
-        spinLabel = QString("Field #:");
-        buttonLabel = QString("Field View");
+			ui->stretchFieldButton->setEnabled(true);
+		} else {
+			currentNumber = currentFrameNumber;
+			maximum = tbcSource.getNumberOfFrames();
+			spinLabel = QString("Frame #:");
 
-        ui->stretchFieldButton->setEnabled(true);
-    } else {
-        currentNumber = currentFrameNumber;
-        maximum = tbcSource.getNumberOfFrames();
-        spinLabel = QString("Frame #:");
+			ui->stretchFieldButton->setEnabled(false);
 
-        ui->stretchFieldButton->setEnabled(false);
+			if (tbcSource.getSplitViewEnabled()) {
+				buttonLabel = QString("Split View");
+			} else {
+				buttonLabel = QString("Frame View");
+			}
+		}
+	}
+	else
+	{
+		if (tbcSource.getFieldViewEnabled()) {
+			currentNumber = currentFieldNumber;
+			maximum = tbcSource.getNumberOfFields();
+			spinLabel = QString("Field #:");
+			buttonLabel = QString("Field");
 
-        if (tbcSource.getSplitViewEnabled()) {
-            buttonLabel = QString("Split View");
-        } else {
-            buttonLabel = QString("Frame View");
-        }
-    }
+			ui->stretchFieldButton->setEnabled(true);
+		} else {
+			currentNumber = currentFrameNumber;
+			maximum = tbcSource.getNumberOfFrames();
+			spinLabel = QString("Frame #:");
+
+			ui->stretchFieldButton->setEnabled(false);
+
+			if (tbcSource.getSplitViewEnabled()) {
+				buttonLabel = QString("Split");
+			} else {
+				buttonLabel = QString("Frame");
+			}
+		}
+	}
 
     ui->posNumberSpinBox->setMaximum(maximum);
     ui->posNumberSpinBox->setValue(currentNumber);
@@ -994,21 +1053,72 @@ void MainWindow::on_aspectPushButton_clicked()
     displayAspectRatio = !displayAspectRatio;
 
     // Update the button text
-    updateAspectPushButton();
+	updateAspectPushButton();
 
     // Update the image viewer (the scopes don't depend on this)
     updateImageViewer();
+	
+	//resize the windows to fit the new size
+	resize_on_aspect();
+}
+
+void MainWindow::resize_on_aspect()
+{
+	if (tbcSource.getSystem() == PAL){
+		if (displayAspectRatio && !tbcSource.getIsWidescreen())// 4:3
+		{
+			this->resize(959, 765);
+		}
+		else if (displayAspectRatio && tbcSource.getIsWidescreen())// 16:9
+		{
+			this->resize(1258, 765);
+		}
+		else// 1:1
+		{
+			this->resize(1155, 765);
+		}
+		
+	} else {
+		if (displayAspectRatio && !tbcSource.getIsWidescreen())// 4:3
+		{
+			this->resize(780, 665);
+		}
+		else if (displayAspectRatio && tbcSource.getIsWidescreen())// 16:9
+		{
+			this->resize(1052, 665);
+		}
+		else// 1:1
+		{
+			this->resize(930, 665);
+		}
+	}
 }
 
 // Show/hide dropouts button clicked
 void MainWindow::on_dropoutsPushButton_clicked()
 {
+	int width = this->width();
+	
     if (tbcSource.getHighlightDropouts()) {
         tbcSource.setHighlightDropouts(false);
-        ui->dropoutsPushButton->setText(tr("Dropouts Off"));
+		if (width >= 930)
+		{			
+			ui->dropoutsPushButton->setText(tr("Dropouts Off"));
+		}
+		else
+		{
+			ui->dropoutsPushButton->setText(tr("Drop N"));
+		}
     } else {
         tbcSource.setHighlightDropouts(true);
-        ui->dropoutsPushButton->setText(tr("Dropouts On"));
+        if (width >= 930)
+		{			
+			ui->dropoutsPushButton->setText(tr("Dropouts On"));
+		}
+		else
+		{
+			ui->dropoutsPushButton->setText(tr("Drop Y"));
+		}
     }
 
     // Show the current image (why isn't this option passed?)
@@ -1079,20 +1189,32 @@ void MainWindow::on_viewPushButton_clicked()
 // Normal/Reverse field order button clicked
 void MainWindow::on_fieldOrderPushButton_clicked()
 {
+	int width = this->width();
+	
     if (tbcSource.getFieldOrder()) {
         tbcSource.setFieldOrder(false);
 
         // If the TBC field order is changed, the number of available frames can change, so we need to update the GUI
         resetGui();
         updateGuiLoaded();
-        ui->fieldOrderPushButton->setText(tr("Normal Field-order"));
+        if (width > 1000)
+			ui->fieldOrderPushButton->setText(tr("Normal Field-order"));
+		else if (width >= 930)
+			ui->fieldOrderPushButton->setText(tr("Normal order"));
+		else
+			ui->fieldOrderPushButton->setText(tr("Normal"));
     } else {
         tbcSource.setFieldOrder(true);
 
         // If the TBC field order is changed, the number of available frames can change, so we need to update the GUI
         resetGui();
         updateGuiLoaded();
-        ui->fieldOrderPushButton->setText(tr("Reverse Field-order"));
+        if (width > 1000)
+			ui->fieldOrderPushButton->setText(tr("Reverse Field-order"));
+		else if (width >= 930)
+			ui->fieldOrderPushButton->setText(tr("Reverse order"));
+		else
+			ui->fieldOrderPushButton->setText(tr("Reverse"));
     }
 
     // Show the current image
@@ -1401,3 +1523,96 @@ void MainWindow::on_finishedSaving(bool success)
     // Enable the main window
     this->setEnabled(true);
 }
+
+void MainWindow::resizeEvent(QResizeEvent *event)
+{
+    QMainWindow::resizeEvent(event);
+    int width = this->width();
+	
+	//field order rename depending on size
+	if (!tbcSource.getFieldOrder())
+	{
+		if (width > 1000)
+			ui->fieldOrderPushButton->setText(tr("Normal Field-order"));
+		else if (width >= 930)
+			ui->fieldOrderPushButton->setText(tr("Normal order"));
+		else
+			ui->fieldOrderPushButton->setText(tr("Normal"));
+	}
+	else
+	{
+		if (width > 1000)
+			ui->fieldOrderPushButton->setText(tr("Reverse Field-order"));
+		else if (width >= 930)
+			ui->fieldOrderPushButton->setText(tr("Reverse order"));
+		else
+			ui->fieldOrderPushButton->setText(tr("Reverse"));
+	}
+	
+	//source label depending on size
+	updateSourcesPushButton();
+	
+	//dropout label
+	if (!tbcSource.getHighlightDropouts()) 
+	{
+		if (width >= 930)
+		{			
+			ui->dropoutsPushButton->setText(tr("Dropouts Off"));
+		}
+		else
+		{
+			ui->dropoutsPushButton->setText(tr("Drop N"));
+		}
+
+	}
+	else
+	{
+		if (width >= 930)
+		{			
+			ui->dropoutsPushButton->setText(tr("Dropouts On"));
+		}
+		else
+		{
+			ui->dropoutsPushButton->setText(tr("Drop Y"));
+		}
+	}
+	
+	//view label
+	if (this->width() >= 930)
+	{
+		if (tbcSource.getFieldViewEnabled()) {
+			ui->viewPushButton->setText("Field View");
+
+			ui->stretchFieldButton->setEnabled(true);
+		} else {
+			ui->stretchFieldButton->setEnabled(false);
+
+			if (tbcSource.getSplitViewEnabled()) {
+				ui->viewPushButton->setText("Split View");
+			} else {
+				ui->viewPushButton->setText("Frame View");
+			}
+		}
+	}
+	else
+	{
+		if (tbcSource.getFieldViewEnabled()) {
+			ui->viewPushButton->setText("Field");
+
+			ui->stretchFieldButton->setEnabled(true);
+		} else {
+			ui->stretchFieldButton->setEnabled(false);
+
+			if (tbcSource.getSplitViewEnabled()) {
+				ui->viewPushButton->setText("Split");
+			} else {
+				ui->viewPushButton->setText("Frame");
+			}
+		}
+	}
+	
+	//asepec ratio label
+	updateAspectPushButton();
+	
+}
+

--- a/tools/ld-analyse/mainwindow.cpp
+++ b/tools/ld-analyse/mainwindow.cpp
@@ -1078,32 +1078,35 @@ void MainWindow::on_aspectPushButton_clicked()
 
 void MainWindow::resize_on_aspect()
 {
-	if (tbcSource.getSystem() == PAL){
-		if (displayAspectRatio && !tbcSource.getIsWidescreen())// 4:3
-		{
-			this->resize(959, 765);
-		}
-		else if (displayAspectRatio && tbcSource.getIsWidescreen())// 16:9
-		{
-			this->resize(1258, 765);
-		}
-		else// 1:1
-		{
-			this->resize(1155, 765);
-		}
-		
-	} else {
-		if (displayAspectRatio && !tbcSource.getIsWidescreen())// 4:3
-		{
-			this->resize(780, 665);
-		}
-		else if (displayAspectRatio && tbcSource.getIsWidescreen())// 16:9
-		{
-			this->resize(1052, 665);
-		}
-		else// 1:1
-		{
-			this->resize(930, 665);
+	if(!this->isFullScreen() && !this->isMaximized())
+	{
+		if (tbcSource.getSystem() == PAL){
+			if (displayAspectRatio && !tbcSource.getIsWidescreen())// 4:3
+			{
+				this->resize(959, 765);
+			}
+			else if (displayAspectRatio && tbcSource.getIsWidescreen())// 16:9
+			{
+				this->resize(1258, 765);
+			}
+			else// 1:1
+			{
+				this->resize(1155, 765);
+			}
+			
+		} else {
+			if (displayAspectRatio && !tbcSource.getIsWidescreen())// 4:3
+			{
+				this->resize(780, 665);
+			}
+			else if (displayAspectRatio && tbcSource.getIsWidescreen())// 16:9
+			{
+				this->resize(1052, 665);
+			}
+			else// 1:1
+			{
+				this->resize(930, 665);
+			}
 		}
 	}
 }

--- a/tools/ld-analyse/mainwindow.cpp
+++ b/tools/ld-analyse/mainwindow.cpp
@@ -244,9 +244,12 @@ void MainWindow::updateGuiLoaded()
 {
     // Enable the GUI controls
     setGuiEnabled(true);
-
+	
     // Update the status bar
     QString statusText;
+	if(tbcSource.getVideoParameters().tapeFormat != "") {
+		statusText += (tbcSource.getVideoParameters().tapeFormat + " ");
+	}
     statusText += tbcSource.getSystemDescription();
     statusText += " source loaded with ";
 

--- a/tools/ld-analyse/mainwindow.cpp
+++ b/tools/ld-analyse/mainwindow.cpp
@@ -227,7 +227,11 @@ void MainWindow::resetGui()
 
     // Update the chroma decoder configuration dialogue
     chromaDecoderConfigDialog->setConfiguration(tbcSource.getSystem(), tbcSource.getPalConfiguration(),
-                                                tbcSource.getNtscConfiguration(), tbcSource.getOutputConfiguration());
+                                                tbcSource.getNtscConfiguration(),
+                                                tbcSource.getMonoConfiguration(),
+                                                tbcSource.getSourceMode(),
+												true,//set to true because the chroma decoder is already init
+												tbcSource.getOutputConfiguration());
 }
 
 // Method to update the GUI when a file is loaded
@@ -261,8 +265,12 @@ void MainWindow::updateGuiLoaded()
     videoParametersDialog->setVideoParameters(tbcSource.getVideoParameters());
 
     // Update the chroma decoder configuration dialogue
-    chromaDecoderConfigDialog->setConfiguration(tbcSource.getSystem(), tbcSource.getPalConfiguration(),
-                                                tbcSource.getNtscConfiguration(), tbcSource.getOutputConfiguration());
+        chromaDecoderConfigDialog->setConfiguration(tbcSource.getSystem(), tbcSource.getPalConfiguration(),
+                                                tbcSource.getNtscConfiguration(),
+                                                tbcSource.getMonoConfiguration(),
+                                                tbcSource.getSourceMode(),
+												false,//set to false to init the chroma decoder selection
+												tbcSource.getOutputConfiguration());
 
     // Ensure the busy dialogue is hidden
     busyDialog->hide();

--- a/tools/ld-analyse/mainwindow.cpp
+++ b/tools/ld-analyse/mainwindow.cpp
@@ -1083,8 +1083,14 @@ void MainWindow::on_aspectPushButton_clicked()
 
 void MainWindow::resize_on_aspect()
 {
-	int width = ui->imageViewerLabel->pixmap().size().width();
-	int height = ui->imageViewerLabel->pixmap().size().height();
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+	int width = ui->imageViewerLabel->pixmap().width();
+	int height = ui->imageViewerLabel->pixmap().height();
+#else
+	int width = ui->imageViewerLabel->pixmap()->width();
+	int height = ui->imageViewerLabel->pixmap()->height();
+#endif
+	
 	if(!this->isFullScreen() && !this->isMaximized())
 	{
 		this->resize(width + 20, height + 140);

--- a/tools/ld-analyse/mainwindow.cpp
+++ b/tools/ld-analyse/mainwindow.cpp
@@ -361,7 +361,7 @@ void MainWindow::updateSourcesPushButton()
 			ui->sourcesPushButton->setText(tr("C Source"));
 			break;
 		case TbcSource::BOTH_SOURCES:
-			ui->sourcesPushButton->setText(tr("Y+C Sources"));
+			ui->sourcesPushButton->setText(tr("Y/C Sources"));
 			break;
 		}
 	}
@@ -378,7 +378,7 @@ void MainWindow::updateSourcesPushButton()
 			ui->sourcesPushButton->setText(tr("C"));
 			break;
 		case TbcSource::BOTH_SOURCES:
-			ui->sourcesPushButton->setText(tr("Y+C"));
+			ui->sourcesPushButton->setText(tr("Y/C"));
 			break;
 		}
 	}

--- a/tools/ld-analyse/mainwindow.cpp
+++ b/tools/ld-analyse/mainwindow.cpp
@@ -885,18 +885,21 @@ void MainWindow::on_actionSave_frame_as_PNG_triggered()
 void MainWindow::on_actionZoom_In_triggered()
 {
     on_zoomInPushButton_clicked();
+	MainWindow::resize_on_aspect();
 }
 
 // Zoom out menu option
 void MainWindow::on_actionZoom_Out_triggered()
 {
     on_zoomOutPushButton_clicked();
+	MainWindow::resize_on_aspect();
 }
 
 // Original size 1:1 zoom menu option
 void MainWindow::on_actionZoom_1x_triggered()
 {
     on_originalSizePushButton_clicked();
+	MainWindow::resize_on_aspect();
 }
 
 // 2:1 zoom menu option
@@ -904,6 +907,7 @@ void MainWindow::on_actionZoom_2x_triggered()
 {
     scaleFactor = 2.0;
     updateImageViewer();
+	MainWindow::resize_on_aspect();
 }
 
 // 3:1 zoom menu option
@@ -911,6 +915,7 @@ void MainWindow::on_actionZoom_3x_triggered()
 {
     scaleFactor = 3.0;
     updateImageViewer();
+	MainWindow::resize_on_aspect();
 }
 
 // Show closed captions
@@ -1078,36 +1083,11 @@ void MainWindow::on_aspectPushButton_clicked()
 
 void MainWindow::resize_on_aspect()
 {
+	int width = ui->imageViewerLabel->pixmap().size().width();
+	int height = ui->imageViewerLabel->pixmap().size().height();
 	if(!this->isFullScreen() && !this->isMaximized())
 	{
-		if (tbcSource.getSystem() == PAL){
-			if (displayAspectRatio && !tbcSource.getIsWidescreen())// 4:3
-			{
-				this->resize(959, 765);
-			}
-			else if (displayAspectRatio && tbcSource.getIsWidescreen())// 16:9
-			{
-				this->resize(1258, 765);
-			}
-			else// 1:1
-			{
-				this->resize(1155, 765);
-			}
-			
-		} else {
-			if (displayAspectRatio && !tbcSource.getIsWidescreen())// 4:3
-			{
-				this->resize(780, 665);
-			}
-			else if (displayAspectRatio && tbcSource.getIsWidescreen())// 16:9
-			{
-				this->resize(1052, 665);
-			}
-			else// 1:1
-			{
-				this->resize(930, 665);
-			}
-		}
+		this->resize(width + 20, height + 140);
 	}
 }
 

--- a/tools/ld-analyse/mainwindow.cpp
+++ b/tools/ld-analyse/mainwindow.cpp
@@ -180,6 +180,11 @@ void MainWindow::setGuiEnabled(bool enabled)
     ui->originalSizePushButton->setEnabled(enabled);
 }
 
+TbcSource& MainWindow::getTbcSource()
+{
+	return this->tbcSource;
+}
+
 void MainWindow::resetGui()
 {
     ui->posNumberSpinBox->setMinimum(1);
@@ -377,6 +382,7 @@ void MainWindow::updateSourcesPushButton()
 			break;
 		}
 	}
+	chromaDecoderConfigDialog->updateSourceMode(tbcSource.getSourceMode());
 }
 
 // Frame display methods ----------------------------------------------------------------------------------------------

--- a/tools/ld-analyse/mainwindow.cpp
+++ b/tools/ld-analyse/mainwindow.cpp
@@ -1094,7 +1094,7 @@ void MainWindow::resize_on_aspect()
 	int height = ui->imageViewerLabel->pixmap()->height();
 #endif
 	
-	if(!this->isFullScreen() && !this->isMaximized())
+	if(!this->isFullScreen() && !this->isMaximized() && autoResize)
 	{
 		this->resize(width + 20, height + 140);
 	}
@@ -1225,6 +1225,11 @@ void MainWindow::on_fieldOrderPushButton_clicked()
 
     // Show the current image
     showImage();
+}
+
+void MainWindow::on_toggleAutoResize_toggled(bool checked)
+{
+	autoResize = checked;
 }
 
 // Zoom in

--- a/tools/ld-analyse/mainwindow.h
+++ b/tools/ld-analyse/mainwindow.h
@@ -59,6 +59,7 @@ class MainWindow : public QMainWindow
 
 public:
     explicit MainWindow(QString inputFilenameParam, QWidget *parent = nullptr);
+	TbcSource& getTbcSource();
     ~MainWindow();
 
 private slots:

--- a/tools/ld-analyse/mainwindow.h
+++ b/tools/ld-analyse/mainwindow.h
@@ -104,6 +104,8 @@ private slots:
     void on_originalSizePushButton_clicked();
     void on_stretchFieldButton_clicked();
     void on_mouseModePushButton_clicked();
+    //void on_autoResizeButton_clicked();
+	void on_toggleAutoResize_toggled(bool checked);
 
     // Miscellaneous handlers
     void scopeCoordsChangedSignalHandler(qint32 xCoord, qint32 yCoord);
@@ -146,6 +148,7 @@ private:
     QLabel timeCodeStatus;
     TbcSource tbcSource;
     bool displayAspectRatio;
+	bool autoResize = true;
     qint32 lastScopeLine;
     qint32 lastScopeDot;
     qint32 currentFieldNumber, currentFrameNumber;

--- a/tools/ld-analyse/mainwindow.h
+++ b/tools/ld-analyse/mainwindow.h
@@ -116,6 +116,9 @@ private slots:
     void on_busy(QString infoMessage);
     void on_finishedLoading(bool success);
     void on_finishedSaving(bool success);
+	
+	// UI handler
+	void resize_on_aspect();
 
 private:
     Ui::MainWindow *ui;
@@ -173,6 +176,7 @@ private:
     void updateOscilloscopeDialogue();
     void updateVectorscopeDialogue();
     void mouseScanLineSelect(qint32 oX, qint32 oY);
+	void resizeEvent(QResizeEvent *event);
 };
 
 #endif // MAINWINDOW_H

--- a/tools/ld-analyse/mainwindow.ui
+++ b/tools/ld-analyse/mainwindow.ui
@@ -18,7 +18,7 @@
   </property>
   <property name="minimumSize">
    <size>
-    <width>900</width>
+    <width>780</width>
     <height>600</height>
    </size>
   </property>
@@ -30,6 +30,12 @@
     <normaloff>:/icons/Graphics/16-analyse.png</normaloff>:/icons/Graphics/16-analyse.png</iconset>
   </property>
   <widget class="QWidget" name="centralWidget">
+   <property name="sizePolicy">
+    <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+     <horstretch>0</horstretch>
+     <verstretch>0</verstretch>
+    </sizepolicy>
+   </property>
    <property name="minimumSize">
     <size>
      <width>450</width>
@@ -40,8 +46,14 @@
     <property name="sizeConstraint">
      <enum>QLayout::SetDefaultConstraint</enum>
     </property>
+    <property name="bottomMargin">
+     <number>0</number>
+    </property>
     <item>
      <layout class="QVBoxLayout" name="verticalLayout">
+      <property name="spacing">
+       <number>6</number>
+      </property>
       <item>
        <widget class="QScrollArea" name="scrollArea">
         <property name="widgetResizable">
@@ -53,10 +65,25 @@
            <x>0</x>
            <y>0</y>
            <width>969</width>
-           <height>576</height>
+           <height>586</height>
           </rect>
          </property>
          <layout class="QVBoxLayout" name="verticalLayout_2">
+          <property name="spacing">
+           <number>0</number>
+          </property>
+          <property name="leftMargin">
+           <number>0</number>
+          </property>
+          <property name="topMargin">
+           <number>0</number>
+          </property>
+          <property name="rightMargin">
+           <number>0</number>
+          </property>
+          <property name="bottomMargin">
+           <number>0</number>
+          </property>
           <item>
            <widget class="QLabel" name="imageViewerLabel">
             <property name="text">
@@ -97,7 +124,25 @@
           <layout class="QHBoxLayout" name="horizontalLayout_3">
            <item>
             <widget class="QLabel" name="posNumberSpinBoxLabel">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
              <property name="minimumSize">
+              <size>
+               <width>0</width>
+               <height>0</height>
+              </size>
+             </property>
+             <property name="maximumSize">
+              <size>
+               <width>60</width>
+               <height>16777215</height>
+              </size>
+             </property>
+             <property name="baseSize">
               <size>
                <width>60</width>
                <height>0</height>
@@ -110,6 +155,12 @@
            </item>
            <item>
             <widget class="QSpinBox" name="posNumberSpinBox">
+             <property name="maximumSize">
+              <size>
+               <width>120</width>
+               <height>50</height>
+              </size>
+             </property>
              <property name="toolTip">
               <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Enter a frame number and press &amp;lt;Enter&amp;gt; to go to a frame&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
              </property>
@@ -118,12 +169,6 @@
              </property>
              <property name="value">
               <number>79999</number>
-             </property>
-             <property name="maximumSize">
-              <size>
-               <width>120</width>
-               <height>50</height>
-              </size>
              </property>
             </widget>
            </item>
@@ -237,7 +282,7 @@
               <enum>Qt::Horizontal</enum>
              </property>
              <property name="sizeType">
-              <enum>QSizePolicy::Fixed</enum>
+              <enum>QSizePolicy::Maximum</enum>
              </property>
              <property name="sizeHint" stdset="0">
               <size>
@@ -333,6 +378,12 @@
                <height>30</height>
               </size>
              </property>
+             <property name="baseSize">
+              <size>
+               <width>30</width>
+               <height>30</height>
+              </size>
+             </property>
              <property name="toolTip">
               <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Stretch field to frame height&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
              </property>
@@ -394,9 +445,27 @@
            </item>
            <item>
             <widget class="QPushButton" name="videoPushButton">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
              <property name="minimumSize">
               <size>
+               <width>50</width>
+               <height>0</height>
+              </size>
+             </property>
+             <property name="maximumSize">
+              <size>
                <width>80</width>
+               <height>16777215</height>
+              </size>
+             </property>
+             <property name="baseSize">
+              <size>
+               <width>0</width>
                <height>0</height>
               </size>
              </property>
@@ -410,6 +479,30 @@
            </item>
            <item>
             <widget class="QPushButton" name="aspectPushButton">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="minimumSize">
+              <size>
+               <width>48</width>
+               <height>0</height>
+              </size>
+             </property>
+             <property name="maximumSize">
+              <size>
+               <width>70</width>
+               <height>16777215</height>
+              </size>
+             </property>
+             <property name="baseSize">
+              <size>
+               <width>0</width>
+               <height>0</height>
+              </size>
+             </property>
              <property name="text">
               <string>DAR 1:1</string>
              </property>
@@ -417,9 +510,27 @@
            </item>
            <item>
             <widget class="QPushButton" name="dropoutsPushButton">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
              <property name="minimumSize">
               <size>
+               <width>0</width>
+               <height>0</height>
+              </size>
+             </property>
+             <property name="maximumSize">
+              <size>
                <width>115</width>
+               <height>16777215</height>
+              </size>
+             </property>
+             <property name="baseSize">
+              <size>
+               <width>0</width>
                <height>0</height>
               </size>
              </property>
@@ -433,9 +544,27 @@
            </item>
            <item>
             <widget class="QPushButton" name="sourcesPushButton">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
              <property name="minimumSize">
               <size>
+               <width>0</width>
+               <height>0</height>
+              </size>
+             </property>
+             <property name="maximumSize">
+              <size>
                <width>110</width>
+               <height>16777215</height>
+              </size>
+             </property>
+             <property name="baseSize">
+              <size>
+               <width>0</width>
                <height>0</height>
               </size>
              </property>
@@ -449,9 +578,27 @@
            </item>
            <item>
             <widget class="QPushButton" name="viewPushButton">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
              <property name="minimumSize">
               <size>
+               <width>0</width>
+               <height>0</height>
+              </size>
+             </property>
+             <property name="maximumSize">
+              <size>
                <width>100</width>
+               <height>16777215</height>
+              </size>
+             </property>
+             <property name="baseSize">
+              <size>
+               <width>0</width>
                <height>0</height>
               </size>
              </property>
@@ -465,9 +612,27 @@
            </item>
            <item>
             <widget class="QPushButton" name="fieldOrderPushButton">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
              <property name="minimumSize">
               <size>
+               <width>0</width>
+               <height>0</height>
+              </size>
+             </property>
+             <property name="maximumSize">
+              <size>
                <width>145</width>
+               <height>16777215</height>
+              </size>
+             </property>
+             <property name="baseSize">
+              <size>
+               <width>0</width>
                <height>0</height>
               </size>
              </property>
@@ -494,7 +659,7 @@
      <x>0</x>
      <y>0</y>
      <width>991</width>
-     <height>22</height>
+     <height>21</height>
     </rect>
    </property>
    <widget class="QMenu" name="menuFile">

--- a/tools/ld-analyse/mainwindow.ui
+++ b/tools/ld-analyse/mainwindow.ui
@@ -705,6 +705,7 @@
     <addaction name="actionZoom_1x"/>
     <addaction name="actionZoom_2x"/>
     <addaction name="actionZoom_3x"/>
+    <addaction name="toggleAutoResize"/>
    </widget>
    <addaction name="menuFile"/>
    <addaction name="menuView"/>
@@ -795,6 +796,17 @@
    </property>
    <property name="shortcut">
     <string>Ctrl+3</string>
+   </property>
+  </action>
+  <action name="toggleAutoResize">
+   <property name="text">
+	<string>Toggle Auto Resize</string>
+   </property>
+   <property name="checkable">
+	<bool>true</bool>
+   </property>
+   <property name="checked">
+	<bool>true</bool>
    </property>
   </action>
   <action name="actionDropout_analysis">

--- a/tools/ld-analyse/tbcsource.cpp
+++ b/tools/ld-analyse/tbcsource.cpp
@@ -144,6 +144,12 @@ void TbcSource::setFieldOrder(bool _state)
     else ldDecodeMetaData.setIsFirstFieldFirst(true);
 }
 
+// Method to set if we combine source
+void TbcSource::setCombine(bool _state)
+{
+	combine = _state;
+}
+
 // Method to get the state of the highlight dropouts mode
 bool TbcSource::getHighlightDropouts()
 {
@@ -817,20 +823,22 @@ void TbcSource::loadInputFields()
         SourceField::loadFields(chromaSourceVideo, ldDecodeMetaData,
                                 loadedFrameNumber, 1, lookBehind, lookAhead,
                                 chromaInputFields, inputStartIndex, inputEndIndex);
+		if(combine)
+		{
+			// Separate chroma is offset (see chroma_to_u16 in vhsdecode/chroma.py)
+			static constexpr qint32 CHROMA_OFFSET = 32767;
 
-        // Separate chroma is offset (see chroma_to_u16 in vhsdecode/chroma.py)
-        static constexpr qint32 CHROMA_OFFSET = 32767;
+			// Add chroma to luma, removing the offset
+			for (qint32 fieldIndex = inputStartIndex; fieldIndex < inputEndIndex; fieldIndex++) {
+				auto &sourceData = inputFields[fieldIndex].data;
+				const auto &chromaData = chromaInputFields[fieldIndex].data;
 
-        // Add chroma to luma, removing the offset
-        for (qint32 fieldIndex = inputStartIndex; fieldIndex < inputEndIndex; fieldIndex++) {
-            auto &sourceData = inputFields[fieldIndex].data;
-            const auto &chromaData = chromaInputFields[fieldIndex].data;
-
-            for (qint32 i = 0; i < sourceData.size(); i++) {
-                qint32 sum = static_cast<qint32>(sourceData[i]) + static_cast<qint32>(chromaData[i]) - CHROMA_OFFSET;
-                sourceData[i] = static_cast<quint16>(qBound(0, sum, 65535));
-            }
-        }
+				for (qint32 i = 0; i < sourceData.size(); i++) {
+					qint32 sum = static_cast<qint32>(sourceData[i]) + static_cast<qint32>(chromaData[i]) - CHROMA_OFFSET;
+					sourceData[i] = static_cast<quint16>(qBound(0, sum, 65535));
+				}
+			}
+		}
     }
 
     inputFieldsValid = true;
@@ -845,21 +853,45 @@ void TbcSource::decodeFrame()
 
     // Decode the current frame to components
     componentFrames.resize(1);
-	if (getSystem() == PAL || getSystem() == PAL_M) {
-		if(palConfiguration.chromaFilter == palColour.ChromaFilterMode::mono){
-			monoDecoder.decodeFrames(inputFields, inputStartIndex, inputEndIndex, componentFrames);
+    yFrames.resize(1);
+    cFrames.resize(1);
+	if(combine)
+	{
+		if (getSystem() == PAL || getSystem() == PAL_M) {
+			if(palConfiguration.chromaFilter == palColour.ChromaFilterMode::mono){
+				monoDecoder.decodeFrames(inputFields, inputStartIndex, inputEndIndex, componentFrames);
+			} else {
+				// PAL source
+				palColour.decodeFrames(inputFields, inputStartIndex, inputEndIndex, componentFrames);
+			}
 		} else {
-			// PAL source
-			palColour.decodeFrames(inputFields, inputStartIndex, inputEndIndex, componentFrames);
+			if(ntscConfiguration.dimensions == 0){
+				monoDecoder.decodeFrames(inputFields, inputStartIndex, inputEndIndex, componentFrames);
+			} else {
+				// NTSC source
+				ntscColour.decodeFrames(inputFields, inputStartIndex, inputEndIndex, componentFrames);
+			}
 		}
-    } else {
-		if(ntscConfiguration.dimensions == 0){
-			monoDecoder.decodeFrames(inputFields, inputStartIndex, inputEndIndex, componentFrames);
+	}
+	else
+	{
+		monoDecoder.decodeFrames(inputFields, inputStartIndex, inputEndIndex, yFrames);
+		if (getSystem() == PAL || getSystem() == PAL_M) {
+			// PAL source
+			palColour.decodeFrames(chromaInputFields, inputStartIndex, inputEndIndex, cFrames);
 		} else {
 			// NTSC source
-			ntscColour.decodeFrames(inputFields, inputStartIndex, inputEndIndex, componentFrames);
+			ntscColour.decodeFrames(chromaInputFields, inputStartIndex, inputEndIndex, cFrames);
 		}
-    }
+		
+		for (qint32 fieldIndex = inputStartIndex, frameIndex = 0; fieldIndex < inputEndIndex; fieldIndex += 2, frameIndex++)
+		{
+			componentFrames[frameIndex].init(ldDecodeMetaData.getVideoParameters(), false);
+			componentFrames[frameIndex].setY(yFrames[frameIndex].getY());
+			componentFrames[frameIndex].setU(cFrames[frameIndex].getU());
+			componentFrames[frameIndex].setV(cFrames[frameIndex].getV());
+		}
+	}
 
     decodedFrameValid = true;
 }

--- a/tools/ld-analyse/tbcsource.cpp
+++ b/tools/ld-analyse/tbcsource.cpp
@@ -679,6 +679,11 @@ const Comb::Configuration &TbcSource::getNtscConfiguration()
     return ntscConfiguration;
 }
 
+const MonoDecoder::MonoConfiguration &TbcSource::getMonoConfiguration()
+{
+    return monoConfiguration;
+}
+
 const OutputWriter::Configuration &TbcSource::getOutputConfiguration()
 {
     return outputConfiguration;

--- a/tools/ld-analyse/tbcsource.h
+++ b/tools/ld-analyse/tbcsource.h
@@ -80,6 +80,7 @@ public:
     void setChromaDecoder(bool _state);
     void setFieldView(bool _state);
     void setFieldOrder(bool _state);
+	void setCombine(bool _state);
     bool getHighlightDropouts();
     bool getChromaDecoder();
     bool getFieldOrder();
@@ -217,6 +218,8 @@ private:
 
     // Chroma decoder output for the loaded frame
     QVector<ComponentFrame> componentFrames;
+    QVector<ComponentFrame> yFrames;
+    QVector<ComponentFrame> cFrames;
     bool decodedFrameValid;
 
     // RGB image data for the loaded frame
@@ -228,6 +231,7 @@ private:
     Comb::Configuration ntscConfiguration;
 	MonoDecoder::MonoConfiguration monoConfiguration;
     OutputWriter::Configuration outputConfiguration;
+	bool combine = false;
 
     // Chapter map
     QVector<qint32> chapterMap;

--- a/tools/ld-analyse/tbcsource.h
+++ b/tools/ld-analyse/tbcsource.h
@@ -149,6 +149,7 @@ public:
                                 const OutputWriter::Configuration &outputConfiguration);
     const PalColour::Configuration &getPalConfiguration();
     const Comb::Configuration &getNtscConfiguration();
+    const MonoDecoder::MonoConfiguration &getMonoConfiguration();
     const OutputWriter::Configuration &getOutputConfiguration();
 
     qint32 startOfNextChapter(qint32 currentFrameNumber);

--- a/tools/ld-analyse/tbcsource.h
+++ b/tools/ld-analyse/tbcsource.h
@@ -45,6 +45,7 @@
 #include "configuration.h"
 #include "palcolour.h"
 #include "comb.h"
+#include "monodecoder.h"
 
 class TbcSource : public QObject
 {
@@ -190,6 +191,7 @@ private:
     // Chroma decoder objects
     PalColour palColour;
     Comb ntscColour;
+	MonoDecoder monoDecoder;
     OutputWriter outputWriter;
 
     // VBI decoders
@@ -223,6 +225,7 @@ private:
     // Chroma decoder configuration
     PalColour::Configuration palConfiguration;
     Comb::Configuration ntscConfiguration;
+	MonoDecoder::MonoConfiguration monoConfiguration;
     OutputWriter::Configuration outputConfiguration;
 
     // Chapter map

--- a/tools/ld-chroma-decoder/CMakeLists.txt
+++ b/tools/ld-chroma-decoder/CMakeLists.txt
@@ -4,6 +4,8 @@
 add_compile_definitions(_USE_MATH_DEFINES)
 
 add_library(lddecode-chroma STATIC
+	decoder.cpp
+	decoderpool.cpp
     comb.cpp
     componentframe.cpp
     framecanvas.cpp
@@ -13,6 +15,7 @@ add_library(lddecode-chroma STATIC
     transformpal.cpp
     transformpal2d.cpp
     transformpal3d.cpp
+	monodecoder.cpp
 )
 
 target_include_directories(lddecode-chroma PUBLIC .)
@@ -31,6 +34,8 @@ add_executable(ld-chroma-decoder
     ntscdecoder.cpp
     paldecoder.cpp
 )
+
+set_target_properties(lddecode-chroma PROPERTIES AUTOMOC ON)
 
 target_include_directories(ld-chroma-decoder PRIVATE ${FFTW_INCLUDE_DIR})
 

--- a/tools/ld-chroma-decoder/comb.h
+++ b/tools/ld-chroma-decoder/comb.h
@@ -54,7 +54,7 @@ public:
         bool phaseCompensation = false;
 
         double cNRLevel = 0.0;
-        double yNRLevel = 1.0;
+        double yNRLevel = 0.0;
 
         qint32 getLookBehind() const;
         qint32 getLookAhead() const;

--- a/tools/ld-chroma-decoder/componentframe.h
+++ b/tools/ld-chroma-decoder/componentframe.h
@@ -66,6 +66,30 @@ public:
     const double *v(qint32 line) const {
         return vData.data() + getLineOffsetUV(line);
     }
+	
+	QVector<double> getY(){
+		return yData;
+	}
+	
+	QVector<double> getU(){
+		return uData;
+	}
+	
+	QVector<double> getV(){
+		return vData;
+	}
+	
+	void setY(QVector<double> _yData){
+		yData = _yData;
+	}
+	
+	void setU(QVector<double> _uData){
+		uData = _uData;
+	}
+	
+	void setV(QVector<double> _vData){
+		vData = _vData;
+	}
 
     qint32 getWidth() const {
         return width;

--- a/tools/ld-chroma-decoder/componentframe.h
+++ b/tools/ld-chroma-decoder/componentframe.h
@@ -67,27 +67,27 @@ public:
         return vData.data() + getLineOffsetUV(line);
     }
 	
-	QVector<double> getY(){
-		return yData;
+	QVector<double>* getY(){
+		return &yData;
 	}
 	
-	QVector<double> getU(){
-		return uData;
+	QVector<double>* getU(){
+		return &uData;
 	}
 	
-	QVector<double> getV(){
-		return vData;
+	QVector<double>* getV(){
+		return &vData;
 	}
 	
-	void setY(QVector<double> _yData){
+	void setY(QVector<double>& _yData){
 		yData = _yData;
 	}
 	
-	void setU(QVector<double> _uData){
+	void setU(QVector<double>& _uData){
 		uData = _uData;
 	}
 	
-	void setV(QVector<double> _vData){
+	void setV(QVector<double>& _vData){
 		vData = _vData;
 	}
 

--- a/tools/ld-chroma-decoder/decoderpool.cpp
+++ b/tools/ld-chroma-decoder/decoderpool.cpp
@@ -37,6 +37,8 @@ DecoderPool::DecoderPool(Decoder &_decoder, QString _inputFileName,
 {
 }
 
+Decoder& DecoderPool::getDecoder() { return decoder; }
+
 bool DecoderPool::process()
 {
     LdDecodeMetaData::VideoParameters videoParameters = ldDecodeMetaData.getVideoParameters();

--- a/tools/ld-chroma-decoder/decoderpool.h
+++ b/tools/ld-chroma-decoder/decoderpool.h
@@ -56,6 +56,8 @@ public:
     OutputWriter &getOutputWriter() {
         return outputWriter;
     }
+	
+	Decoder& getDecoder();
 
     // For worker threads: get the next batch of data from the input file.
     //

--- a/tools/ld-chroma-decoder/main.cpp
+++ b/tools/ld-chroma-decoder/main.cpp
@@ -312,6 +312,7 @@ int main(int argc, char *argv[])
     qint32 maxThreads = QThread::idealThreadCount();
     PalColour::Configuration palConfig;
     Comb::Configuration combConfig;
+    MonoDecoder::MonoConfiguration monoConfig;
     OutputWriter::Configuration outputConfig;
 
     if (parser.isSet(startFrameOption)) {
@@ -385,6 +386,7 @@ int main(int argc, char *argv[])
     if (parser.isSet(lumaNROption)) {
         combConfig.yNRLevel = parser.value(lumaNROption).toDouble();
         palConfig.yNRLevel = parser.value(lumaNROption).toDouble();
+        monoConfig.yNRLevel = parser.value(lumaNROption).toDouble();
 
         if (combConfig.yNRLevel < 0.0) {
             // Quit with error
@@ -501,7 +503,7 @@ int main(int argc, char *argv[])
         combConfig.adaptive = false;
         decoder = std::make_unique<NtscDecoder>(combConfig);
     } else if (decoderName == "mono") {
-        decoder = std::make_unique<MonoDecoder>();
+        decoder = std::make_unique<MonoDecoder>(monoConfig);
     } else {
         qCritical() << "Unknown decoder" << decoderName;
         return -1;

--- a/tools/ld-chroma-decoder/main.cpp
+++ b/tools/ld-chroma-decoder/main.cpp
@@ -233,7 +233,7 @@ int main(int argc, char *argv[])
 
     // Option to set the luma noise reduction level
     QCommandLineOption lumaNROption(QStringList() << "luma-nr",
-                                    QCoreApplication::translate("main", "Luma noise reduction level in dB (default 1.0)"),
+                                    QCoreApplication::translate("main", "Luma noise reduction level in dB (default 0.0)"),
                                     QCoreApplication::translate("main", "number"));
     parser.addOption(lumaNROption);
 

--- a/tools/ld-chroma-decoder/monodecoder.cpp
+++ b/tools/ld-chroma-decoder/monodecoder.cpp
@@ -31,6 +31,15 @@
 #include "deemp.h"
 #include "firfilter.h"
 
+MonoDecoder::MonoDecoder()
+{	
+}
+
+MonoDecoder::MonoDecoder(const MonoDecoder::MonoConfiguration &config)
+{
+    monoConfig = config;
+}
+
 bool MonoDecoder::updateConfiguration(const LdDecodeMetaData::VideoParameters &videoParameters, const MonoDecoder::MonoConfiguration &configuration) {
     // This decoder works for both PAL and NTSC.
 	monoConfig.yNRLevel = configuration.yNRLevel;
@@ -151,7 +160,6 @@ void MonoThread::decodeFrames(const QVector<SourceField>& inputFields,
                               QVector<ComponentFrame>& componentFrames)
 {
     // Delegate to the centralized, public API
-    MonoDecoder d;
-    d.configure(monoConfig.videoParameters);
-    d.decodeFrames(inputFields, startIndex, endIndex, componentFrames);
+    auto &baseDecoder = static_cast<MonoDecoder&>(decoderPool.getDecoder());
+    baseDecoder.decodeFrames(inputFields, startIndex, endIndex, componentFrames);
 }

--- a/tools/ld-chroma-decoder/monodecoder.h
+++ b/tools/ld-chroma-decoder/monodecoder.h
@@ -43,11 +43,22 @@ class DecoderPool;
 // Decoder that passes all input through as luma, for purely monochrome sources
 class MonoDecoder : public Decoder {
 public:
-    bool configure(const LdDecodeMetaData::VideoParameters &videoParameters) override;
+	struct MonoConfiguration {
+		double yNRLevel = 0.0;
+		LdDecodeMetaData::VideoParameters videoParameters;
+	};
+	bool updateConfiguration(const LdDecodeMetaData::VideoParameters &videoParameters, const MonoDecoder::MonoConfiguration &configuration);
+	bool configure(const LdDecodeMetaData::VideoParameters &videoParameters) override;
     QThread *makeThread(QAtomicInt& abort, DecoderPool& decoderPool) override;
+	/// Synchronously decode luma-only frames (no filtering)
+	void decodeFrames(const QVector<SourceField>& inputFields,
+                    qint32 startIndex,
+                    qint32 endIndex,
+                    QVector<ComponentFrame>& componentFrames);
+	void doYNR(ComponentFrame &componentFrame);				
 
 private:
-    Configuration config;
+    MonoConfiguration monoConfig;
 };
 
 class MonoThread : public DecoderThread
@@ -55,7 +66,7 @@ class MonoThread : public DecoderThread
     Q_OBJECT
 public:
     explicit MonoThread(QAtomicInt &abort, DecoderPool &decoderPool,
-                       const MonoDecoder::Configuration &config,
+                       const MonoDecoder::MonoConfiguration &monoConfig,
                        QObject *parent = nullptr);
 
 protected:
@@ -63,10 +74,8 @@ protected:
                       QVector<ComponentFrame> &componentFrames) override;
 
 private:
-    void decodeFrame(const SourceField &firstField, const SourceField &secondField, ComponentFrame &componentFrame);
-
     // Settings
-    const MonoDecoder::Configuration &config;
+    const MonoDecoder::MonoConfiguration &monoConfig;
 };
 
 #endif // MONODECODER

--- a/tools/ld-chroma-decoder/monodecoder.h
+++ b/tools/ld-chroma-decoder/monodecoder.h
@@ -43,10 +43,13 @@ class DecoderPool;
 // Decoder that passes all input through as luma, for purely monochrome sources
 class MonoDecoder : public Decoder {
 public:
+
 	struct MonoConfiguration {
 		double yNRLevel = 0.0;
 		LdDecodeMetaData::VideoParameters videoParameters;
 	};
+	MonoDecoder();
+	MonoDecoder(const MonoDecoder::MonoConfiguration &config);
 	bool updateConfiguration(const LdDecodeMetaData::VideoParameters &videoParameters, const MonoDecoder::MonoConfiguration &configuration);
 	bool configure(const LdDecodeMetaData::VideoParameters &videoParameters) override;
     QThread *makeThread(QAtomicInt& abort, DecoderPool& decoderPool) override;

--- a/tools/ld-chroma-decoder/palcolour.h
+++ b/tools/ld-chroma-decoder/palcolour.h
@@ -51,13 +51,15 @@ public:
         // 2D Transform PAL frequency-domain filter
         transform2DFilter,
         // 3D Transform PAL frequency-domain filter
-        transform3DFilter
+        transform3DFilter,
+		//mono decoder
+		mono
     };
 
     struct Configuration {
         double chromaGain = 1.0;
         double chromaPhase = 0.0;
-        double yNRLevel = 0.5;
+        double yNRLevel = 0.0;
         bool simplePAL = false;
         ChromaFilterMode chromaFilter = palColourFilter;
         double transformThreshold = 0.4;

--- a/tools/library/tbc/lddecodemetadata.cpp
+++ b/tools/library/tbc/lddecodemetadata.cpp
@@ -180,6 +180,7 @@ void LdDecodeMetaData::VideoParameters::read(JsonReader &reader)
         else if (member == "sampleRate") reader.read(sampleRate);
         else if (member == "system") reader.read(systemString);
         else if (member == "white16bIre") reader.read(white16bIre);
+        else if (member == "tapeFormat") reader.read(tapeFormat);
         else reader.discard();
     }
 
@@ -227,6 +228,9 @@ void LdDecodeMetaData::VideoParameters::write(JsonWriter &writer) const
     writer.writeMember("sampleRate", sampleRate);
     writer.writeMember("system", VIDEO_SYSTEM_DEFAULTS[system].name);
     writer.writeMember("white16bIre", white16bIre);
+	if(tapeFormat != "") {
+		writer.writeMember("tapeFormat", tapeFormat);
+	}
 
     writer.endObject();
 }

--- a/tools/library/tbc/lddecodemetadata.h
+++ b/tools/library/tbc/lddecodemetadata.h
@@ -84,6 +84,7 @@ public:
         double sampleRate = -1.0;
 
         bool isMapped = false;
+        QString tapeFormat = "";
 
         QString gitBranch;
         QString gitCommit;


### PR DESCRIPTION
This update reworks diferent par off ld-analyse : 
- the sizing of element of the main windows adapt dynamically.
- the window resize to fit perfectly then content.
- default parameter when loading a source adapt setting for optimal use depending on Y/C vs CVBS.
- luma nr set to 0 by default with checkbox for disabling and comparing quickly the NR
- ld-analyse now have the mono decoder.
- the mono decoder now support luma NR in ld-analyse and in the chroma-decoder
- Support for native Y/C preview and a checkbox for allowing combining or not Y/C to CVBS.