### PR TITLE
ld-ldf-reader Windows compatibility

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -148,21 +148,8 @@ if(BUILD_TESTING)
     include(LdDecodeTests)
 endif()
 
-# ld-ldf-reader
-
 if(BUILD_LDF_READER)
-    pkg_check_modules(FFMPEG REQUIRED IMPORTED_TARGET
-        libavcodec
-        libavformat
-        libavutil
-    )
-
-    add_executable(ld-ldf-reader
-      ld-ldf-reader.c)
-
-    target_link_libraries(ld-ldf-reader PkgConfig::FFMPEG)
-
-    install(TARGETS ld-ldf-reader)
+    add_subdirectory(tools/ld-ldf-reader)
 endif()
 
 # Python library and tools

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,13 +25,10 @@ set(USE_QT_VERSION "" CACHE STRING
     "Version of Qt to use, 5 or 6 (Which is used by default can vary due to how cmake find functions work, but will often default to Qt6)"
 )
 
-# Not working on Windows as of yet. The decoders are able to use ffmpeg binaries instead if needed.
-if(NOT WIN32)
-    option(BUILD_LDF_READER
-        "build ld_ldf_reader"
-        ON
-    )
-endif()
+option(BUILD_LDF_READER
+    "build ld_ldf_reader"
+    ON
+)
 
 option(BUILD_PYTHON
     "Build and install ld-decode's Python library and tools"
@@ -154,7 +151,7 @@ endif()
 # ld-ldf-reader
 
 if(BUILD_LDF_READER)
-    pkg_check_modules(LIBAV REQUIRED IMPORTED_TARGET
+    pkg_check_modules(FFMPEG REQUIRED IMPORTED_TARGET
         libavcodec
         libavformat
         libavutil
@@ -163,7 +160,7 @@ if(BUILD_LDF_READER)
     add_executable(ld-ldf-reader
       ld-ldf-reader.c)
 
-    target_link_libraries(ld-ldf-reader PkgConfig::LIBAV)
+    target_link_libraries(ld-ldf-reader PkgConfig::FFMPEG)
 
     install(TARGETS ld-ldf-reader)
 endif()

--- a/ld-ldf-reader.c
+++ b/ld-ldf-reader.c
@@ -29,7 +29,6 @@
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <unistd.h>
 #include <libavutil/samplefmt.h>
 #include <libavutil/timestamp.h>
 #include <libavcodec/avcodec.h>
@@ -87,7 +86,7 @@ static int decode_packet(AVCodecContext *dec, const AVPacket *pkt)
         size_t length = (frame->nb_samples * bytes_per_sample) - offset;
 
         // Write the raw audio data samples to stdout
-        size_t rv = write(1, frame->extended_data[0] + offset, length);
+        size_t rv = fwrite(frame->extended_data[0] + offset, sizeof(uint8_t), length, stdout);
         if (rv != length) {
             fprintf(stderr, "write error %ld", offset);
             return -1;
@@ -245,8 +244,8 @@ end:
     av_packet_free(&pkt);
     av_frame_free(&frame);
 
-    // Send an EOF on stdout
-    close(1);
+    // flush any remaining data
+    fflush(stdout);
 
     return ret < 0;
 }

--- a/tools/ld-ldf-reader/CMakeLists.txt
+++ b/tools/ld-ldf-reader/CMakeLists.txt
@@ -1,0 +1,12 @@
+pkg_check_modules(FFMPEG REQUIRED IMPORTED_TARGET
+    libavcodec
+    libavformat
+    libavutil
+)
+
+add_executable(ld-ldf-reader
+  ld-ldf-reader.c)
+
+target_link_libraries(ld-ldf-reader PkgConfig::FFMPEG)
+
+install(TARGETS ld-ldf-reader)

--- a/tools/ld-ldf-reader/ld-ldf-reader.c
+++ b/tools/ld-ldf-reader/ld-ldf-reader.c
@@ -88,7 +88,7 @@ static int decode_packet(AVCodecContext *dec, const AVPacket *pkt)
         // Write the raw audio data samples to stdout
         size_t rv = fwrite(frame->extended_data[0] + offset, sizeof(uint8_t), length, stdout);
         if (rv != length) {
-            fprintf(stderr, "write error %ld", offset);
+            fprintf(stderr, "write error %lld", (long long)offset);
             return -1;
         }
 
@@ -204,7 +204,7 @@ int main (int argc, char **argv)
 
     fprintf(stderr, "RATE:%d\n", audio_dec_ctx->sample_rate);
     // From fmt_ctx, this is the approximate length in ms.  (divide by 1000 for actual time)
-    fprintf(stderr, "DURATION:%ld\n", fmt_ctx->duration);
+    fprintf(stderr, "DURATION:%lld\n", (long long)fmt_ctx->duration);
 
     frame = av_frame_alloc();
     if (!frame) {


### PR DESCRIPTION
* Enable Windows compatibility for ld-ldf-reader.
* This will be pulled into vhs-decode, so ld-ldf-reader can be used internally by hifi-decode for ldf files.
  * Should be pulled into vhs-decode after oyvindln/vhs-decode#221
  * Ready to merge into ld-decode any time.