### PR TITLE
Fixes following #926

### DIFF
--- a/scripts/test-decode
+++ b/scripts/test-decode
@@ -68,6 +68,19 @@ def run_command(cmd, **kwopts):
     if rc != 0:
         die(cmd[0], 'failed with exit code', rc)
 
+def run_decode_command(cmd):
+    """Run an ld-cut/ld-decode command, setting PATH so that helper programs
+    can be found."""
+
+    env = os.environ.copy()
+    env['PATH'] = ':'.join([
+        build_dir,
+        build_dir + '/tools/ld-ldf-reader',
+        source_dir,
+        env['PATH'],
+        ])
+    run_command(cmd, env=env)
+
 def run_ld_cut(args):
     """Run ld-cut."""
 
@@ -87,10 +100,7 @@ def run_ld_cut(args):
     cmd += ['-l', str(args.cutlength)]
     cmd += [args.infile, cutfile]
 
-    # Set PATH so it can invoke helper programs
-    env = os.environ.copy()
-    env['PATH'] = build_dir + ':' + source_dir + ':' + env['PATH']
-    run_command(cmd, env=env)
+    run_decode_command(cmd)
 
     # Use the output as the input for the rest of the decoding process
     args.infile = cutfile
@@ -109,11 +119,8 @@ def run_ld_decode(args):
 
     cmd += [args.infile, args.output]
 
-    # Set PATH so it can invoke helper programs
-    env = os.environ.copy()
-    env['PATH'] = build_dir + ':' + source_dir + ':' + env['PATH']
-    run_command(cmd, env=env)
-    
+    run_decode_command(cmd)
+
     # If doing AC3, check that there are enough output samples
     if (args.expect_ac3_bytes is not None) and (not dry_run):
         ac3_file = args.output + '.ac3'

--- a/tools/efm-decoder/libs/efm/include/logging.h
+++ b/tools/efm-decoder/libs/efm/include/logging.h
@@ -32,8 +32,8 @@
 #include <QCommandLineParser>
 
 #ifdef _WIN32
-#  include <io.h>
-#  include <fcntl.h>
+#include <io.h>
+#include <fcntl.h>
 #endif
 
 // Prototypes

--- a/tools/efm-decoder/libs/efm/src/logging.cpp
+++ b/tools/efm-decoder/libs/efm/src/logging.cpp
@@ -127,6 +127,7 @@ void setQuiet(bool state)
     quietDebug = state;
 }
 
+// Ensure the stdout/stdin file descriptors are in binary mode
 void setBinaryMode(void)
 {
 #ifdef _WIN32

--- a/tools/efm-decoder/tools/efm-decoder-audio/src/main.cpp
+++ b/tools/efm-decoder/tools/efm-decoder-audio/src/main.cpp
@@ -33,8 +33,9 @@
 
 int main(int argc, char *argv[])
 {
-    // Set 'binary mode' for stdin and stdout on windows
+    // Set 'binary mode' for stdin and stdout on Windows
     setBinaryMode();
+
     // Install the local debug message handler
     setDebug(true);
     qInstallMessageHandler(debugOutputHandler);

--- a/tools/efm-decoder/tools/efm-decoder-d24/src/main.cpp
+++ b/tools/efm-decoder/tools/efm-decoder-d24/src/main.cpp
@@ -33,8 +33,9 @@
 
 int main(int argc, char *argv[])
 {
-    // Set 'binary mode' for stdin and stdout on windows
+    // Set 'binary mode' for stdin and stdout on Windows
     setBinaryMode();
+
     // Install the local debug message handler
     setDebug(true);
     qInstallMessageHandler(debugOutputHandler);

--- a/tools/efm-decoder/tools/efm-decoder-data/src/main.cpp
+++ b/tools/efm-decoder/tools/efm-decoder-data/src/main.cpp
@@ -33,8 +33,9 @@
 
 int main(int argc, char *argv[])
 {
-    // Set 'binary mode' for stdin and stdout on windows
+    // Set 'binary mode' for stdin and stdout on Windows
     setBinaryMode();
+
     // Install the local debug message handler
     setDebug(true);
     qInstallMessageHandler(debugOutputHandler);

--- a/tools/efm-decoder/tools/efm-decoder-f2/src/main.cpp
+++ b/tools/efm-decoder/tools/efm-decoder-f2/src/main.cpp
@@ -33,8 +33,9 @@
 
 int main(int argc, char *argv[])
 {
-    // Set 'binary mode' for stdin and stdout on windows
+    // Set 'binary mode' for stdin and stdout on Windows
     setBinaryMode();
+
     // Install the local debug message handler
     setDebug(true);
     qInstallMessageHandler(debugOutputHandler);

--- a/tools/efm-decoder/tools/efm-stacker-f2/src/main.cpp
+++ b/tools/efm-decoder/tools/efm-stacker-f2/src/main.cpp
@@ -34,8 +34,9 @@
 
 int main(int argc, char *argv[])
 {
-    // Set 'binary mode' for stdin and stdout on windows
+    // Set 'binary mode' for stdin and stdout on Windows
     setBinaryMode();
+
     // Install the local debug message handler
     setDebug(true);
     qInstallMessageHandler(debugOutputHandler);

--- a/tools/efm-decoder/tools/vfs-verifier/src/main.cpp
+++ b/tools/efm-decoder/tools/vfs-verifier/src/main.cpp
@@ -33,8 +33,9 @@
 
 int main(int argc, char *argv[])
 {
-    // Set 'binary mode' for stdin and stdout on windows
+    // Set 'binary mode' for stdin and stdout on Windows
     setBinaryMode();
+
     // Install the local debug message handler
     setDebug(true);
     qInstallMessageHandler(debugOutputHandler);

--- a/tools/ld-chroma-decoder/encoder/main.cpp
+++ b/tools/ld-chroma-decoder/encoder/main.cpp
@@ -29,11 +29,6 @@
 #include <QCommandLineParser>
 #include <cstdio>
 
-#ifdef _WIN32
-	#include <io.h>
-	#include <fcntl.h>
-#endif
-
 #include "lddecodemetadata.h"
 #include "logging.h"
 
@@ -42,10 +37,9 @@
 
 int main(int argc, char *argv[])
 {
-	#ifdef _WIN32
-	_setmode(_fileno(stdout), O_BINARY);
-	_setmode(_fileno(stdin), O_BINARY);	
-	#endif
+    // Set 'binary mode' for stdin and stdout on Windows
+    setBinaryMode();
+
     // Install the local debug message handler
     setDebug(true);
     qInstallMessageHandler(debugOutputHandler);

--- a/tools/ld-chroma-decoder/main.cpp
+++ b/tools/ld-chroma-decoder/main.cpp
@@ -97,8 +97,9 @@ static bool loadTransformThresholds(QCommandLineParser &parser, QCommandLineOpti
 
 int main(int argc, char *argv[])
 {
-    //set 'binary mode' for stdin and stdout on windows
+    // Set 'binary mode' for stdin and stdout on Windows
     setBinaryMode();
+
     // Install the local debug message handler
     setDebug(true);
     qInstallMessageHandler(debugOutputHandler);

--- a/tools/ld-disc-stacker/main.cpp
+++ b/tools/ld-disc-stacker/main.cpp
@@ -37,8 +37,9 @@
 
 int main(int argc, char *argv[])
 {
-    //set 'binary mode' for stdin and stdout on windows
+    // Set 'binary mode' for stdin and stdout on Windows
     setBinaryMode();
+
     // Install the local debug message handler
     setDebug(true);
     qInstallMessageHandler(debugOutputHandler);

--- a/tools/ld-discmap/main.cpp
+++ b/tools/ld-discmap/main.cpp
@@ -33,8 +33,9 @@
 
 int main(int argc, char *argv[])
 {
-    //set 'binary mode' for stdin and stdout on windows
+    // Set 'binary mode' for stdin and stdout on Windows
     setBinaryMode();
+
     // Install the local debug message handler
     setDebug(true);
     qInstallMessageHandler(debugOutputHandler);

--- a/tools/ld-dropout-correct/main.cpp
+++ b/tools/ld-dropout-correct/main.cpp
@@ -35,8 +35,9 @@
 
 int main(int argc, char *argv[])
 {
-    //set 'binary mode' for stdin and stdout on windows
+    // Set 'binary mode' for stdin and stdout on Windows
     setBinaryMode();
+
     // Install the local debug message handler
     setDebug(true);
     qInstallMessageHandler(debugOutputHandler);

--- a/tools/ld-export-metadata/main.cpp
+++ b/tools/ld-export-metadata/main.cpp
@@ -38,8 +38,9 @@
 
 int main(int argc, char *argv[])
 {
-    //set 'binary mode' for stdin and stdout on windows
+    // Set 'binary mode' for stdin and stdout on Windows
     setBinaryMode();
+
     // Install the local debug message handler
     setDebug(true);
     qInstallMessageHandler(debugOutputHandler);

--- a/tools/ld-ldf-reader/ld-ldf-reader.c
+++ b/tools/ld-ldf-reader/ld-ldf-reader.c
@@ -35,8 +35,8 @@
 #include <libavformat/avformat.h>
 
 #ifdef _WIN32
-  #include <io.h>
-  #include <fcntl.h>
+#include <io.h>
+#include <fcntl.h>
 #endif
 
 static AVFormatContext *fmt_ctx = NULL;
@@ -170,16 +170,16 @@ int main (int argc, char **argv)
         seekto = atoll(argv[2]);
     }
 
-    #ifdef _WIN32
-      if (_setmode(_fileno(stdout), _O_BINARY) == -1) {
+#ifdef _WIN32
+    if (_setmode(_fileno(stdout), _O_BINARY) == -1) {
         fprintf(stderr, "Could not set stdout to binary mode\n");
         exit(1);
-      }
-      if (_setmode(_fileno(stdin), _O_BINARY) == -1) {
+    }
+    if (_setmode(_fileno(stdin), _O_BINARY) == -1) {
         fprintf(stderr, "Could not set stdin to binary mode\n");
         exit(1);
-      }
-    #endif
+    }
+#endif
 
 #if LIBAVFORMAT_VERSION_INT < AV_VERSION_INT(58, 7, 100)
     av_register_all();

--- a/tools/ld-lds-converter/main.cpp
+++ b/tools/ld-lds-converter/main.cpp
@@ -32,8 +32,9 @@
 
 int main(int argc, char *argv[])
 {
-    //set 'binary mode' for stdin and stdout on windows
+    // Set 'binary mode' for stdin and stdout on Windows
     setBinaryMode();
+
     // Install the local debug message handler
     setDebug(true);
     qInstallMessageHandler(debugOutputHandler);

--- a/tools/ld-process-ac3/decode/main.cpp
+++ b/tools/ld-process-ac3/decode/main.cpp
@@ -29,8 +29,8 @@
 #include <cstring>
 
 #ifdef _WIN32
-    #include <io.h>
-    #include <fcntl.h>
+#include <io.h>
+#include <fcntl.h>
 #endif
 
 #include "../logger.hpp"
@@ -54,10 +54,12 @@ void doHelp(const std::string &app) {
 }
 
 int main(int argc, char *argv[]) {
-    #ifdef _WIN32
+#ifdef _WIN32
+    // Set 'binary mode' for stdin and stdout on Windows
     _setmode(_fileno(stdout), O_BINARY);
     _setmode(_fileno(stdin), O_BINARY);	
-    #endif	
+#endif
+
     while (true) {
         switch (getopt(argc, argv, "v:h?")) {
             // could have stdin/stdout as defaults, with switches to change them

--- a/tools/ld-process-ac3/demodulate/main.cpp
+++ b/tools/ld-process-ac3/demodulate/main.cpp
@@ -30,8 +30,8 @@
 #include <cassert>
 
 #ifdef _WIN32
-	#include <io.h>
-	#include <fcntl.h>
+#include <io.h>
+#include <fcntl.h>
 #endif
 
 #include "../logger.hpp"
@@ -57,11 +57,12 @@ void doHelp(const std::string &app) {
 
 
 int main(int argc, char *argv[]) {
+#ifdef _WIN32
+    // Set 'binary mode' for stdin and stdout on Windows
+    _setmode(_fileno(stdout), O_BINARY);
+    _setmode(_fileno(stdin), O_BINARY);	
+#endif
 
-	#ifdef _WIN32
-	_setmode(_fileno(stdout), O_BINARY);
-	_setmode(_fileno(stdin), O_BINARY);	
-	#endif
     int slidingAvgLength = 1e3;
 
     // todo 8/16bit and little-/big-endian switches? leave it to sox?

--- a/tools/ld-process-efm/main.cpp
+++ b/tools/ld-process-efm/main.cpp
@@ -33,8 +33,9 @@
 
 int main(int argc, char *argv[])
 {
-    //set 'binary mode' for stdin and stdout on windows
+    // Set 'binary mode' for stdin and stdout on Windows
     setBinaryMode();
+
     // Install the local debug message handler
     setDebug(true);
     qInstallMessageHandler(debugOutputHandler);

--- a/tools/ld-process-vbi/main.cpp
+++ b/tools/ld-process-vbi/main.cpp
@@ -33,8 +33,9 @@
 
 int main(int argc, char *argv[])
 {
-    //set 'binary mode' for stdin and stdout on windows
+    // Set 'binary mode' for stdin and stdout on Windows
     setBinaryMode();
+
     // Install the local debug message handler
     setDebug(true);
     qInstallMessageHandler(debugOutputHandler);

--- a/tools/ld-process-vits/main.cpp
+++ b/tools/ld-process-vits/main.cpp
@@ -37,8 +37,9 @@
 
 int main(int argc, char *argv[])
 {
-    //set 'binary mode' for stdin and stdout on windows
+    // Set 'binary mode' for stdin and stdout on Windows
     setBinaryMode();
+
     // Install the local debug message handler
     setDebug(true);
     qInstallMessageHandler(debugOutputHandler);

--- a/tools/library/tbc/logging.cpp
+++ b/tools/library/tbc/logging.cpp
@@ -122,12 +122,13 @@ void setQuiet(bool state)
     quietDebug = state;
 }
 
+// Ensure the stdout/stdin file descriptors are in binary mode
 void setBinaryMode(void)
 {
-    #ifdef _WIN32
-   _setmode(_fileno(stdout), O_BINARY);
-   _setmode(_fileno(stdin), O_BINARY);	
-    #endif
+#ifdef _WIN32
+    _setmode(_fileno(stdout), O_BINARY);
+    _setmode(_fileno(stdin), O_BINARY);	
+#endif
 }
 
 // Method to add the standard debug options to the command line parser

--- a/tools/library/tbc/logging.h
+++ b/tools/library/tbc/logging.h
@@ -32,8 +32,8 @@
 #include <QCommandLineParser>
 
 #ifdef _WIN32
-    #include <io.h>
-    #include <fcntl.h>
+#include <io.h>
+#include <fcntl.h>
 #endif
 
 // Prototypes


### PR DESCRIPTION
Two relatively straightforward fixes after #926:

- The testsuite broke, since the `ld-ldf-reader` binary is now in a different directory. Fix it.
- The `setBinaryMode` code wasn't formatted in our normal way in a few places - tidy it up.