### PR TITLE
move json serialization to process, consolidate fps print function

### DIFF
--- a/lddecode/main.py
+++ b/lddecode/main.py
@@ -386,24 +386,18 @@ def main(args=None):
 
     done = False
 
-    jsondumper = jsondump_thread(ldd, outname)
+    jsondumper = JSONDumper(ldd, outname)
 
     def cleanup():
-        jsondumper.put(ldd.build_json())
         # logger.flush()
+        jsondumper.close()
         ldd.close()
-        jsondumper.put(None)
         if audio_pipe is not None:
             audio_pipe.close()
 
-    # seconddecode is taken so that setup time is not included in FPS calculation
-    firstdecode = time.time()
-    seconddecode = None
     while not done and ldd.fields_written < (req_frames * 2):
         try:
             f = ldd.readfield()
-            if not seconddecode:
-                seconddecode = time.time()
         except KeyboardInterrupt as kbd:
             print("\nTerminated, saving JSON and exiting", file=sys.stderr)
             cleanup()
@@ -424,15 +418,10 @@ def main(args=None):
             done = True
 
         if ldd.fields_written < 100 or ((ldd.fields_written % 500) == 0):
-            jsondumper.put(ldd.build_json())
+            jsondumper.write()
 
     if ldd.fields_written:
-        timeused = time.time() - firstdecode
-        timeused2 = time.time() - seconddecode
-        frames = ldd.fields_written // 2
-        fps = frames / timeused2
- 
-        print(f"\nCompleted: saving JSON and exiting.  Took {timeused:.2f} seconds to decode {frames} frames ({fps:.2f} FPS post-setup)", file=sys.stderr)
+        print(f"\nCompleted: saving JSON and exiting.", file=sys.stderr)
     else:
         print(f"\nCompleted without handling any frames.", file=sys.stderr)
 


### PR DESCRIPTION
* Move the tbc json serialization thread into a process so it doesn't get locked by the GIL.
* Only build and save the json if the write is ready to take place, and one isn't currently happening. This avoids the write queue from getting backed up with stale updates, we just care about the most recent copy.
* Refactor the fps stats message into the lddecode object so it no longer needs to be duplicated in the vhs-decode and cvbs-decode subclasses.