### PR TITLE
Fix for issue #970

### DIFF
--- a/tools/ld-json-converter/lddecodemetadata.cpp
+++ b/tools/ld-json-converter/lddecodemetadata.cpp
@@ -947,7 +947,10 @@ void LdDecodeMetaData::clearFieldDropOuts(qint32 sequentialFieldNumber)
 // This method appends a new field to the existing metadata
 void LdDecodeMetaData::appendField(const LdDecodeMetaData::Field &field)
 {
-    fields.append(field);
+    // Ensure appended fields receive contiguous sequential numbering
+    LdDecodeMetaData::Field fieldCopy = field;
+    fieldCopy.seqNo = fields.size() + 1;
+    fields.append(fieldCopy);
 
     videoParameters.numberOfSequentialFields = fields.size();
 }

--- a/tools/library/tbc/lddecodemetadata.cpp
+++ b/tools/library/tbc/lddecodemetadata.cpp
@@ -900,7 +900,10 @@ void LdDecodeMetaData::clearFieldDropOuts(qint32 sequentialFieldNumber)
 // This method appends a new field to the existing metadata
 void LdDecodeMetaData::appendField(const LdDecodeMetaData::Field &field)
 {
-    fields.append(field);
+    // Ensure sequential numbering stays contiguous when writing out
+    LdDecodeMetaData::Field fieldCopy = field;
+    fieldCopy.seqNo = fields.size() + 1;
+    fields.append(fieldCopy);
 
     videoParameters.numberOfSequentialFields = fields.size();
 }


### PR DESCRIPTION
Bug:
The SQLite rewrite used seqNo directly for field_id, but appendField was not assigning seqNo when creating new fields during disc mapping. Some fields were appended with the default seqNo=0, which translated to field_id=-1 after the seqNo-1 conversion. Because (capture_id, field_id) is a primary key, the -1 rows collided, causing dropped/overwritten rows, shrinking field_record (missing fields) and triggering out-of-bounds errors in consumers like ld-analyse. JSON output was fine because it didn’t rely on field_id PKs.

Fix:
Ensure every appended field receives a contiguous seqNo (fields.size()+1) before being stored. Applied in both the TBC library (lddecodemetadata.cpp) and the json-converter copy (lddecodemetadata.cpp). This guarantees field_id stays 0..N-1 with no negatives or duplicates, so all fields persist in SQLite and downstream tools no longer see missing/invalid field numbers.