### PR TITLE
Prevent dropout correction data from half-line between fields

### DIFF
--- a/tools/ld-dropout-correct/dropoutcorrect.cpp
+++ b/tools/ld-dropout-correct/dropoutcorrect.cpp
@@ -420,9 +420,9 @@ void DropOutCorrect::findPotentialReplacementLine(const QVector<QVector<DropOutL
         return;
     }
 
-    // Hunt for a replacement
+    // Hunt for a replacement, stopping at the last full line before the half-line between fields
     while ((sourceLine - 1) >= videoParameters[sourceNo].firstActiveFieldLine
-           && (sourceLine - 1) < videoParameters[sourceNo].lastActiveFieldLine) {
+           && sourceLine < videoParameters[sourceNo].lastActiveFieldLine) {
         // Is there a dropout that overlaps the one we're trying to replace?
         bool hasOverlap = false;
         for (qint32 sourceIndex = 0; sourceIndex < sourceDropouts[sourceNo].size(); sourceIndex++) {


### PR DESCRIPTION
This change limits dropout correction data to only come from the full visible lines in a field (i.e. `lastActiveFieldLine - 1`). Previously, dropouts could be be corrected using the half line that is split between the current and next field. The second half of this line is the start of the vsync pulse, and if used to fill dropouts, will just fill it with black.