### PR TITLE
Added NTSC 3D Adaptive Threshold CLI options, updated README.md also

### DIFF
--- a/tools/ld-chroma-decoder/README.md
+++ b/tools/ld-chroma-decoder/README.md
@@ -52,6 +52,11 @@ ld-chroma-decoder [options] <input.tbc> <output.rgb>
 - `--luma-nr <number>`: Luma noise reduction level in dB (default 0.0)
 - `--ntsc-phase-comp`: NTSC: Adjust phase per-line using burst phase
 
+#### NTSC-Specific 3D Options for Adaptive Threshold:
+- `-f ntsc3d`:  Default behavior (threshold = 1.0)
+- `-f ntsc3d --adapt-threshold 1.5`: More aggressive 3D filtering (less fallback to 2D/1D)
+- `-f ntsc3d --adapt-threshold 0.1`: More conservative (more likely to use 2D/1D on motion)
+
 #### Transform Decoder Options
 - `--simple-pal`: Transform: Use 1D UV filter (default 2D)
 - `--transform-threshold <number>`: Transform: Uniform similarity threshold (default 0.4)

--- a/tools/ld-chroma-decoder/comb.cpp
+++ b/tools/ld-chroma-decoder/comb.cpp
@@ -429,9 +429,10 @@ void Comb::FrameBuffer::getBestCandidate(qint32 lineNumber, qint32 h,
     Candidate candidates[8];
 
     // Bias the comparison so that we prefer 3D results, then 2D, then 1D
-    static constexpr double LINE_BONUS = -2.0;
-    static constexpr double FIELD_BONUS = LINE_BONUS - 2.0;
-    static constexpr double FRAME_BONUS = FIELD_BONUS - 2.0;
+    // adaptThreshold scales these bonuses: higher = stronger 3D preference
+    const double LINE_BONUS = -2.0 * configuration.adaptThreshold;
+    const double FIELD_BONUS = LINE_BONUS - (2.0 * configuration.adaptThreshold);
+    const double FRAME_BONUS = FIELD_BONUS - (2.0 * configuration.adaptThreshold);
 
     // 1D: Same line, 2 samples left and right
     candidates[CAND_LEFT]  = getCandidate(lineNumber, h, *this, lineNumber, h - 2, 0);

--- a/tools/ld-chroma-decoder/comb.h
+++ b/tools/ld-chroma-decoder/comb.h
@@ -56,6 +56,10 @@ public:
         double cNRLevel = 0.0;
         double yNRLevel = 0.0;
 
+        // Adaptation sensitivity for 3D filter (higher = prefer 3D, lower = prefer 1D/2D)
+        // Default 1.0, range typically 0.5-2.0
+        double adaptThreshold = 1.0;
+
         qint32 getLookBehind() const;
         qint32 getLookAhead() const;
     };

--- a/tools/ld-chroma-decoder/main.cpp
+++ b/tools/ld-chroma-decoder/main.cpp
@@ -243,6 +243,12 @@ int main(int argc, char *argv[])
                                            QCoreApplication::translate("main", "NTSC: Adjust phase per-line using burst phase"));
     parser.addOption(ntscPhaseCompOption);
 
+    // Option to set the 3D adaptive filter threshold
+    QCommandLineOption adaptThresholdOption(QStringList() << "adapt-threshold",
+                                            QCoreApplication::translate("main", "NTSC: 3D adaptive filter threshold (default 1.0, higher = more 3D)"),
+                                            QCoreApplication::translate("main", "number"));
+    parser.addOption(adaptThresholdOption);
+
     // -- PAL decoder options --
 
     // Option to use Simple PAL UV filter
@@ -398,6 +404,15 @@ int main(int argc, char *argv[])
 
     if (parser.isSet(ntscPhaseCompOption)) {
         combConfig.phaseCompensation = true;
+    }
+
+    if (parser.isSet(adaptThresholdOption)) {
+        combConfig.adaptThreshold = parser.value(adaptThresholdOption).toDouble();
+
+        if (combConfig.adaptThreshold <= 0.0) {
+            qCritical("Adapt threshold must be greater than 0");
+            return -1;
+        }
     }
 
     if (parser.isSet(simplePALOption)) {


### PR DESCRIPTION
Adding this CLI adjustment might help address #559 since it gives users more flexibility with altering the filter options without needing to recompile the software.

This has been quite for DS9 LD especially when using extreme multipliers like 0.1 and 2.0.