### PR TITLE
Fix for issue #1023 - correct the windows portable zip package

### DIFF
--- a/.github/workflows/windows-zip.yml
+++ b/.github/workflows/windows-zip.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Install Python dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install numpy scipy matplotlib numba av
+          pip install numpy scipy matplotlib numba av static-ffmpeg
 
       - name: Prepare installation files
         shell: pwsh

--- a/lddecode/core.py
+++ b/lddecode/core.py
@@ -477,7 +477,7 @@ class RFDecode:
         DP = self.DecoderParams
 
         # This high pass filter is intended to detect RF dropouts
-        Frfhpf = sps.butter(1, [10 / self.freq_half], btype="highpass")
+        Frfhpf = sps.butter(1, 10 / self.freq_half, btype="highpass")
         self.Filters["Frfhpf"] = filtfft(Frfhpf, self.blocklen)
 
         # First phase FFT filtering

--- a/lddecode/utils.py
+++ b/lddecode/utils.py
@@ -23,6 +23,7 @@ from scipy import interpolate
 # Try to make sure ffmpeg is available
 try:
     import static_ffmpeg
+    static_ffmpeg.add_paths()  # adds static ffmpeg/ffprobe binaries to PATH
 except ImportError:
     pass
 
@@ -509,10 +510,20 @@ class LoadLDF:
     def _open(self, sample):
         self._close()
 
-        command = [self._find_ldf_reader(), "--quiet", "--start-offset", str(sample), self.filename]
+        if sys.platform == "win32":
+            # On Windows, .bat wrappers cannot be launched directly by CreateProcess.
+            # Use the current Python interpreter to run ldf_reader as a module instead.
+            # sys.executable is always valid, and the subprocess inherits PYTHONHOME/
+            # PYTHONPATH from the parent process so lddecode is importable.
+            command = [
+                sys.executable, "-m", "lddecode.ldf_reader",
+                "--quiet", "--start-offset", str(sample), self.filename,
+            ]
+        else:
+            command = [self._find_ldf_reader(), "--quiet", "--start-offset", str(sample), self.filename]
 
         ldfreader = subprocess.Popen(
-            command, stdout=subprocess.PIPE, stderr=subprocess.PIPE
+            command, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
         )
         self.position = sample * 2
         self.rewind_buf = b""


### PR DESCRIPTION
FIx for #1023 - needed to include ffmpeg, improve the path handling (due to the .bat extensions) and fix a scipy issue (windows was using a newer version with a stricter check).