### PR TITLE
fix possible infinite loop at end of file when no frames are decoded

### DIFF
--- a/lddecode/utils.py
+++ b/lddecode/utils.py
@@ -412,7 +412,10 @@ class LoadFFmpeg:
         while sample_bytes > self.position:
             # Seeking forwards - read and discard samples
             count = min(sample_bytes - self.position, self.rewind_size)
-            self._read_data(count)
+            data = self._read_data(count)
+            if len(data) == 0:
+                # EOF
+                return None
 
         if readlen_bytes > 0:
             # Read some new data from ffmpeg
@@ -538,7 +541,10 @@ class LoadLDF:
         while sample_bytes > self.position:
             # Seeking forwards - read and discard samples
             count = min(sample_bytes - self.position, self.rewind_size)
-            self._read_data(count)
+            data = self._read_data(count)
+            if len(data) == 0:
+                # EOF
+                return None
 
         if readlen_bytes > 0:
             # Read some new data from ffmpeg


### PR DESCRIPTION
Pulled from https://github.com/oyvindln/vhs-decode/pull/293/changes/da0720459487056462d2cf02f5c54bfec0e53fb1; https://github.com/oyvindln/vhs-decode/pull/293