### PR TITLE
Add missing documentation deployment action

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -1,0 +1,46 @@
+name: Deploy Docs to GitHub Pages
+
+on:
+  push:
+    branches:
+      - master
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  deploy-docs:
+    name: Deploy Docs
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Install MkDocs dependencies
+        run: pip install mkdocs-material mkdocs-awesome-nav-plugin
+
+      - name: Build docs
+        run: mkdocs build --strict
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: site/
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
### Checklist

- [ ] I have searched the open pull requests to confirm this change has not already been submitted.
- [ ] My branch is up to date with the target branch.
- [ ] I have tested my changes and all existing tests pass.
- [x] I have updated documentation where necessary.
- [x] My code follows the project's coding standards (see CONTRIBUTING.md).

### Description

Adds a GitHub Actions workflow to automatically build and deploy the MkDocs documentation to GitHub Pages on every push to `master`.

### Motivation

The project has a MkDocs documentation site configured in mkdocs.yml but no CI/CD automation to publish it. This change ensures the hosted docs at `https://happycube.github.io/ld-decode` are always kept up to date without requiring manual deployment.

### Related Issues

N/A

### Changes Made

- Added deploy-docs.yml — builds the MkDocs site using `mkdocs-material` and `mkdocs-awesome-nav-plugin`, then deploys it to GitHub Pages using the official `actions/upload-pages-artifact` and `actions/deploy-pages` actions.

### Testing

- [ ] All existing tests pass (`pytest --output-on-failure`)
- [x] Tested manually with: YAML syntax validated locally
- [ ] New tests added for: N/A

### Screenshots (if applicable)

N/A

### Additional Notes

GitHub Pages must be configured in the repository settings to use **GitHub Actions** as the source (**Settings → Pages → Source → GitHub Actions**) for the deployment to work.

The deploy job runs independently of the build/test jobs. If docs should only deploy when tests pass, the `deploy-docs` job can be moved into build-and-test.yml with `needs: functional-tests`.
