### PR TITLE
replace cubic scaler with sinc

### DIFF
--- a/lddecode/core.py
+++ b/lddecode/core.py
@@ -26,7 +26,7 @@ from scipy import interpolate
 from . import efm_pll
 from .utils import ac3_pipe, ldf_pipe, traceback
 from .utils import nb_mean, nb_median, nb_round, nb_min, nb_max, nb_abs, nb_absmax, nb_diff, n_orgt, n_orlt
-from .utils import polar2z, sqsum, genwave, dsa_rescale_and_clip, scale, scale_field, rms
+from .utils import polar2z, sqsum, genwave, dsa_rescale_and_clip, scale, scale_field, rms, sinc_lut_future
 from .utils import findpeaks, findpulses, calczc, inrange, roundfloat
 from .utils import LRUupdate, clb_findbursts, angular_mean_helper, phase_distance
 from .utils import build_hilbert, unwrap_hilbert, emphasis_iir, filtfft
@@ -2564,6 +2564,7 @@ class Field:
             dsout,
             interpolated_pixel_locs,
             wowfactors,
+            sinc_lut_future.result(),
             self.lineoffset,
             outwidth,
             wow_level_adjust_smoothing=self.wow_level_adjust_smoothing

--- a/lddecode/utils.py
+++ b/lddecode/utils.py
@@ -12,6 +12,7 @@ import signal
 
 import threading
 from queue import Queue
+from concurrent.futures import ProcessPoolExecutor
 
 from numba import jit, njit
 import numba
@@ -19,7 +20,7 @@ import numba
 # standard numeric/scientific libraries
 import numpy as np
 import scipy.signal as sps
-from scipy import interpolate
+from scipy.special import i0
 
 # Try to make sure ffmpeg is available
 try:
@@ -71,19 +72,67 @@ def scale(buf, begin, end, tgtlen, mult=1):
     return output
 
 
-# Scales and compensates for wow-induced playback-speed variations
-@njit(nogil=True, cache=True, fastmath=True)
-def scale_field(buf, dsout, interpolated_pixel_locs, wowfactors, lineoffset, outwidth, wow_level_adjust_smoothing = 0, level_adjust_threshold = 15):
-    # Constants preserved as float32
-    point_5 = np.float32(0.5)
-    two = np.float32(2)
-    three = np.float32(3)
-    four = np.float32(4)
-    five = np.float32(5)
+@njit
+def sinc(x):
+    if x == 0.0:
+        return 1.0
+    x_pi = np.pi * x
+    return math.sin(x_pi) / x_pi
 
-    lineoffset += 1
-    lineoffset_out_samples = outwidth * lineoffset
 
+def kaiser_window(x, a, beta, i0_beta):
+    r = x / a
+    if r < -1.0 or r > 1.0:
+        return 0.0
+
+    t = math.sqrt(1.0 - r * r)
+    return i0(beta * t) / i0_beta
+
+
+# https://ccrma.stanford.edu/~jos/sasp/Kaiser_Windows_Transforms.html
+def build_kaiser_lut(beta, taps, phases):
+    a = taps // 2
+
+    offsets = np.arange(a - 1, -a - 1, -1)
+    offsets_len = len(offsets)
+
+    table = np.zeros((phases + 1, taps), dtype=np.float32)
+    weights = np.empty(offsets_len, dtype=np.float32)
+    i0_beta = i0(beta)
+
+    for i in range(phases):
+        phase = i / phases
+
+        s = 0.0
+        for j in range(offsets_len):
+            x = offsets[j] + phase
+            weight = sinc(x) * kaiser_window(x, a, beta, i0_beta)
+
+            weights[j] = weight
+            s += weight
+
+        table[i, :] = weights / s
+
+    # copy the last phase to avoid bounds checking later on when we do linear interpolation
+    table[phases] = table[phases - 1]
+
+    return table
+
+# Kaiser Beta parameter controls trade-off between sharpness and ringing
+# Small Beta = more sharpness / more ringing (narrow main lobe (more sharp), less side lobe cutoff (more ringing))
+# Large Beta = less sharpness / less ringing (wide main lobe (less sharp), more side lobe cutoff (less ringing))
+kaiser_beta = 5
+sinc_tap_count = 16 # must be multiple of 2
+sinc_phase_count = 2**16
+
+# compute sinc table in a process to so it doesn't block other startup tasks
+sinc_lut_future = ProcessPoolExecutor().submit(
+    build_kaiser_lut, kaiser_beta, sinc_tap_count, sinc_phase_count
+)
+
+
+@njit(nogil=True, fastmath=True)
+def scale_field(buf, dsout, interpolated_pixel_locs, wowfactors, sinc_lut, lineoffset, outwidth, wow_level_adjust_smoothing = 0, level_adjust_threshold = 15):
     # average out any unusual spikes in wow that happen on a per line basis
     # this indicates an hsync tbc error vs. being normal wow from playback speed variations
     # in this case for level adjusting we just want to fallback to the average wow to avoid a bright or dark line
@@ -104,9 +153,13 @@ def scale_field(buf, dsout, interpolated_pixel_locs, wowfactors, lineoffset, out
         one_minus_alpha = 1 - alpha
 
         for i in range(1, len(level_adjusts)):
-            level_adjusts[i] = alpha * level_adjusts[i] + one_minus_alpha * level_adjusts[i-1]       
+            level_adjusts[i] = alpha * level_adjusts[i] + one_minus_alpha * level_adjusts[i-1]
 
-    for i in range(lineoffset_out_samples, len(dsout) + lineoffset_out_samples):
+    half_taps_m1 = (sinc_tap_count // 2) - 1
+
+    dsout_start = outwidth * (lineoffset + 1)
+    dsout_end = len(dsout) + dsout_start
+    for i in range(dsout_start, dsout_end):
         # compensates for the amplitude/frequency shift caused by FM demodulation under varying playback speed.
         level_adjust = level_adjusts[i]
 
@@ -114,18 +167,27 @@ def scale_field(buf, dsout, interpolated_pixel_locs, wowfactors, lineoffset, out
         coord = np.float32(interpolated_pixel_locs[i])
         coord_int = int(coord)
 
-        # get the data from the buffer that aligns to the wow factor index
-        p0 = buf[coord_int - 1]
-        p1 = buf[coord_int]
-        p2 = buf[coord_int + 1]
-        p3 = buf[coord_int + 2]
-        x = np.float32(coord - coord_int)
+        # fractional phase
+        frac = coord - coord_int
 
-        # perform cubic scaling
-        a = p2 - p0
-        b = two * p0 - five * p1 + four * p2 - p3
-        c = three * (p1 - p2) + p3 - p0
-        dsout[i-lineoffset_out_samples] = level_adjust * (p1 + point_5 * x * (a + x * (b + x * c)))
+        phase_pos = frac * sinc_phase_count
+        phase_start = int(phase_pos)
+        phase_end = phase_start + 1
+
+        alpha = np.float32(phase_pos - phase_start)
+
+        w_start = sinc_lut[phase_start]
+        w_end = sinc_lut[phase_end]
+
+        start = coord_int - half_taps_m1
+
+        result = 0.0
+        for t in range(sinc_tap_count):
+            # do linear interpolation between pre-computed phases
+            ws = w_start[t]
+            result += buf[start + t] * (ws + alpha * (w_end[t] - ws))
+
+        dsout[i - dsout_start] = level_adjust * result
 
 
 frequency_suffixes = [


### PR DESCRIPTION
### Checklist

<!--
✅ Please make sure that you have completed the following steps before submitting the pull request:
-->

- [x] I have searched the open pull requests to confirm this change has not already been submitted.
- [x] My branch is up to date with the target branch.
- [x] I have tested my changes and all existing tests pass.
- [x] I have updated documentation where necessary.
- [x] My code follows the project's coding standards (see [CONTRIBUTING.md](CONTRIBUTING.md)).

### Description

Replaces the existing cubic downscaler with Kaiser windowed sinc interpolation downscaler.

Performance is mostly unchanged since the sinc phases are pre-calculated and stored in a look up table.

### Motivation

This change is targeted towards CVBS; however, it should also benefit LD and tape sources. This reduces scaling errors and aliasing from noise and harmonics over the existing cubic method. This change is very subtle visually; however, it will help with other measurements that happen after downscaling, like color burst phase, which influences TBC quality and color accuracy.

### Related Issues

Moved from https://github.com/oyvindln/vhs-decode/pull/309

### Changes Made

<!--
List the key changes made in this pull request.
-->

- Remove the cubic scaler and replaces it with a scaler based on sinc interpolation
- Precalculate the sinc table at startup in a separate process (so as to not hang up the GIL)

### Screenshots

This is a high frequency CVBS sweep that contains frequency information above the sample rate of the TBC format. Aliasing is visible on the right side of the cubic example and is not present on the sinc example.
* Note: The sweep is not perfect and drifts a bit as the lines progress. It's just meant to demonstrate the difference in aliasing between cubic / sinc
* https://compare.promptingpixels.com/a/5RMPCuF

#### Cubic scaler
<img width="910" height="525" alt="sweep_cubic" src="https://github.com/user-attachments/assets/bcbf2dcd-5ac8-4347-9533-34cb42ac5320" />

#### Sinc scaler
<img width="910" height="525" alt="sweep_sinc" src="https://github.com/user-attachments/assets/b15dc16e-2b0d-4885-866a-2c0628483df0" />

```sh
$ odiff -t 0.005 sweep_cubic.png sweep_sinc.png diff.png
Found 60139 different pixels (12.59%)
```
<img width="910" height="525" alt="diff" src="https://github.com/user-attachments/assets/b51d274a-8373-41dd-ac9c-b62479dcdfbc" />

### HackTV Example (cvbs-decode)
#### Cubic (left) vs. Kaiser Windowed Sinc (right)

The cubic scaler (left) has a subtle rolling brightness variation in solid area of the bars (most visible in the yellow and cyan bars). This artifact is not visible using the sinc scaler (right).

https://github.com/user-attachments/assets/334ffb6b-9aa2-4964-9a46-6082a8ea675b

This example can be reproduced with the below commands:
* Hack TV command
  * `hacktv -o hack_pal_16.s16 -m pal --vits -r test`
* `cvhs-decode` commands
  * `cvbs-decode -l 250 -p -f 16 -t 3 hack_pal_16.s16 cubic` (done with vhs_decode branch)
  * `cvbs-decode -l 250 -p -f 16 -t 3 hack_pal_16.s16 kaiser` (done with this branch)
* `tbc-video-export` commands
  * `tbc-video-export --yuv444 --8bit -t 16 --video-system pal cubic.tbc cubic.mkv`
  * `tbc-video-export --yuv444 --8bit -t 16 --video-system pal kaiser.tbc kaiser.mkv`
* Side by side video command
  * `ffmpeg -i cubic.mkv -i kaiser.mkv -filter_complex hstack -c:v libx265 -x265-params lossless=1 -preset veryslow -pix_fmt yuv420p -t 8 cubic_vs_kaiser_sinc.mp4`

### Additional Notes

* It may be possible to replace this with soxr, which is an existing audio resampling library that uses this same method; however, it will require some work to properly implement the wow correction using soxr variable sample rates.
* If ld-decode moves to or introduces support for more capable languages, the table computation and scaling would be much more performant if written using SIMD intrinsics.
