### PR TITLE
Avoid processexecutor causing crash on startup

### DIFF
--- a/lddecode/core.py
+++ b/lddecode/core.py
@@ -25,13 +25,13 @@ from scipy import interpolate
 
 from . import efm_pll
 from .utils import ac3_pipe, ldf_pipe, traceback
-from .utils import nb_mean, nb_median, nb_round, nb_min, nb_max, nb_abs, nb_absmax, nb_diff, n_orgt, n_orlt
+from .utils import nb_mean, nb_median, nb_round, nb_min, nb_max, nb_abs, nb_absmax, n_orgt
 from .utils import polar2z, sqsum, genwave, dsa_rescale_and_clip, scale, scale_field, rms, sinc_lut_future
 from .utils import findpeaks, findpulses, calczc, inrange, roundfloat
 from .utils import LRUupdate, clb_findbursts, angular_mean_helper, phase_distance
 from .utils import build_hilbert, unwrap_hilbert, emphasis_iir, filtfft
 from .utils import fft_do_slice, fft_determine_slices, StridedCollector, hz_to_output_array
-from .utils import Pulse, nb_std, nb_gt, n_ornotrange, nb_concatenate, gen_bpf_supergauss, FieldInfo
+from .utils import Pulse, nb_std, n_ornotrange, nb_concatenate, gen_bpf_supergauss, FieldInfo
 
 try:
     # If Anaconda's numpy is installed, mkl will use all threads for fft etc
@@ -44,8 +44,8 @@ except ImportError:
     pass
 
 # Uncomment (and add to) to get full traces of numpy warnings
-#import warnings
-#warnings.filterwarnings('error', "Mean of empty slice.")
+# import warnings
+# warnings.filterwarnings('error', "Mean of empty slice.")
 
 # This allows ld-decode to set up one logger for the entire program
 logger = None
@@ -103,6 +103,7 @@ SysParams_NTSC = {
     # (in case VITS white test areas are not present)
     "LD_VITS_code_slices": [(16, 12, 48, 85), (17, 12, 48, 85), (10, 13, 39, 85)],
 }
+
 
 # Calculate the exact line length for a given situation (such as
 # 4FSC)

--- a/lddecode/utils.py
+++ b/lddecode/utils.py
@@ -12,7 +12,7 @@ import signal
 
 import threading
 from queue import Queue
-from concurrent.futures import ProcessPoolExecutor
+from concurrent.futures import ThreadPoolExecutor
 
 from numba import jit, njit
 import numba
@@ -126,7 +126,7 @@ sinc_tap_count = 16 # must be multiple of 2
 sinc_phase_count = 2**16
 
 # compute sinc table in a process to so it doesn't block other startup tasks
-sinc_lut_future = ProcessPoolExecutor().submit(
+sinc_lut_future = ThreadPoolExecutor().submit(
     build_kaiser_lut, kaiser_beta, sinc_tap_count, sinc_phase_count
 )
 

--- a/lddecode/utils.py
+++ b/lddecode/utils.py
@@ -8,7 +8,6 @@ import os
 import subprocess
 import sys
 import traceback
-import signal
 
 import threading
 from queue import Queue
@@ -117,6 +116,7 @@ def build_kaiser_lut(beta, taps, phases):
     table[phases] = table[phases - 1]
 
     return table
+
 
 # Kaiser Beta parameter controls trade-off between sharpness and ringing
 # Small Beta = more sharpness / more ringing (narrow main lobe (more sharp), less side lobe cutoff (more ringing))
@@ -1017,9 +1017,8 @@ def hz_to_output_array(input, ire0, hz_ire, outputZero, vsync_ire, out_scale):
     ).astype(np.uint16)
 
 
-
 # Something like this should be a numpy function, but I can't find it.
-@jit(cache=True, nopython=True)
+@njit(cache=True)
 def findareas(array, cross):
     """ Find areas where `array` is <= `cross`
 
@@ -1099,6 +1098,7 @@ def findpulses(sync_ref, _, high):
     )
     return _to_pulses_list(pulses_starts, pulses_lengths)
 
+
 if False:
     @njit(cache=True,nogil=True)
     def numba_pulse_qualitycheck(prevpulse: Pulse, pulse: Pulse, inlinelen: int):
@@ -1171,11 +1171,13 @@ def LRUupdate(l, k):
 
 # Lambdas used to shorten filter-building functions
 
+
 # Split out the frequency list given to the filter builder
 freqrange = lambda f1, f2: [
     f1 / self.freq_hz_half,
     f2 / self.freq_hz_half,
 ]
+
 
 # Like freqrange, but for notch filters
 notchrange = lambda f, notchwidth, hz: [
@@ -1183,11 +1185,12 @@ notchrange = lambda f, notchwidth, hz: [
     (f + notchwidth) / self.freq_hz_half if hz else self.freq_half,
 ]
 
-# numba jit functions, used to numba-ify parts of more complex functions
 
+# numba jit functions, used to numba-ify parts of more complex functions
 @njit(cache=True,nogil=True)
 def nb_median(m):
     return np.median(m)
+
 
 # Enabling nogil here kills performance - cache issues?
 @njit(cache=True,nogil=False)
@@ -1202,72 +1205,73 @@ def nb_concatenate(m):
 
     return out
 
-@njit(cache=True,nogil=True)
+
+@njit(cache=True, nogil=True)
 def nb_round(m):
     return int(np.round(m))
 
 
-@njit(cache=True,nogil=True)
+@njit(cache=True, nogil=True)
 def nb_mean(m):
     return np.mean(m)
 
 
-@njit(cache=True,nogil=True)
+@njit(cache=True, nogil=True)
 def nb_min(m):
     return np.min(m)
 
 
-@njit(cache=True,nogil=True)
+@njit(cache=True, nogil=True)
 def nb_max(m):
     return np.max(m)
 
 
-@njit(cache=True,nogil=True)
+@njit(cache=True, nogil=True)
 def nb_abs(m):
     return np.abs(m)
 
 
-@njit(cache=True,nogil=True)
+@njit(cache=True, nogil=True)
 def nb_absmax(m):
     return np.max(np.abs(m))
 
 
-@njit(cache=True,nogil=True)
+@njit(cache=True, nogil=True)
 def nb_std(m):
     return np.std(m)
 
 
-@njit(cache=True,nogil=True)
+@njit(cache=True, nogil=True)
 def nb_diff(m):
     return np.diff(m)
 
 
-@njit(cache=True,nogil=True)
+@njit(cache=True, nogil=True)
 def nb_mul(x, y):
     return x * y
 
 
-@njit(cache=True,nogil=True)
+@njit(cache=True, nogil=True)
 def nb_where(x):
     return np.where(x)
 
 
-@njit(cache=True,nogil=True)
+@njit(cache=True, nogil=True)
 def nb_gt(x, y):
     return (x > y)
 
 
-@njit(cache=True,nogil=True)
+@njit(cache=True, nogil=True)
 def n_orgt(a, x, y):
     a |= (x > y)
 
 
-@njit(cache=True,nogil=True)
+@njit(cache=True, nogil=True)
 def n_orlt(a, x, y):
     a |= (x < y)
 
 
-@njit(cache=True,nogil=True)
+@njit(cache=True, nogil=True)
 def n_ornotrange(a, x, y, z):
     a |= (x < y) | (x > z)
 
@@ -1287,6 +1291,7 @@ def angular_mean_helper(x, cycle_len=1.0, zero_base=True):
     angles = [np.e ** (1j * f * np.pi * 2 / cycle_len) for f in x2]
 
     return angles
+
 
 @njit(cache=True)
 def phase_distance(x, c=0.75):
@@ -1323,7 +1328,7 @@ def dsa_rescale_and_clip(infloat):
 # removed so that they can be JIT'd
 
 
-@njit(cache=True,nogil=True)
+@njit(cache=True, nogil=True)
 def clb_findbursts(isrising, zcs, burstarea, i, endburstarea, threshold, bstart, s_rem, zcburstdiv, phase_adjust):
     zc_count = 0
     rising_count = 0
@@ -1354,6 +1359,7 @@ def clb_findbursts(isrising, zcs, burstarea, i, endburstarea, threshold, bstart,
 
     return zc_count, phase_adjust, rising_count
 
+
 @njit(cache=True)
 def distance_from_round(x):
     # Yes, this was a hotspot.
@@ -1376,8 +1382,9 @@ def init_opencl(cl, name = None):
                 break
             if ctx is not None:
                 break
-    #queue = cl.CommandQueue(ctx)
+    # queue = cl.CommandQueue(ctx)
     return ctx
+
 
 class FieldInfo:
     def __init__(self, field_history_size=3):
@@ -1389,7 +1396,7 @@ class FieldInfo:
 
     def __len__(self):
         return self._len
-    
+
     # called like a normal python list, where -1 is the last element, -2 the one before that, etc.
     # using [0] is not allowed since this only stores the end of the list
     def __getitem__(self, key):
@@ -1401,11 +1408,12 @@ class FieldInfo:
         unsent = self._fieldinfo_unsent
         self._fieldinfo_unsent = []
         return unsent
-    
+
     def append(self, value):
         self._fieldinfo[self._len % self._field_history_size] = value
         self._fieldinfo_unsent.append(value)
         self._len += 1
+
 
 class JSONDumper:
     def __init__(self, ldd, outname):
@@ -1499,6 +1507,7 @@ class JSONDumper:
             os.replace(outname + ".tbc.json.tmp", outname + ".tbc.json")
 
             ready.clear()
+
 
 class StridedCollector:
     # This keeps a numpy buffer and outputs an fft block and keeps the overlap

--- a/lddecode/utils.py
+++ b/lddecode/utils.py
@@ -13,7 +13,7 @@ import threading
 from queue import Queue
 from concurrent.futures import ThreadPoolExecutor
 
-from numba import jit, njit
+from numba import njit
 import numba
 
 # standard numeric/scientific libraries
@@ -34,6 +34,7 @@ try:
 except:
     def profile(fn):
         return fn
+
 
 # This runs a cubic scaler on a line.
 # originally from https://www.paulinternet.nl/?page=bicubic
@@ -1187,13 +1188,13 @@ notchrange = lambda f, notchwidth, hz: [
 
 
 # numba jit functions, used to numba-ify parts of more complex functions
-@njit(cache=True,nogil=True)
+@njit(cache=True, nogil=True)
 def nb_median(m):
     return np.median(m)
 
 
 # Enabling nogil here kills performance - cache issues?
-@njit(cache=True,nogil=False)
+@njit(cache=True, nogil=False)
 def nb_concatenate(m):
     tlen = sum([len(i) for i in m])
 
@@ -1364,26 +1365,6 @@ def clb_findbursts(isrising, zcs, burstarea, i, endburstarea, threshold, bstart,
 def distance_from_round(x):
     # Yes, this was a hotspot.
     return np.round(x) - x
-
-
-def init_opencl(cl, name = None):
-    # Create some context on the first available GPU
-    if 'PYOPENCL_CTX' in os.environ:
-        ctx = cl.create_some_context()
-    else:
-        ctx = None
-        # Find the first OpenCL GPU available and use it, unless
-        for p in cl.get_platforms():
-            for d in p.get_devices():
-                if d.type & cl.device_type.GPU == 1:
-                    continue
-                print("Selected device: ", d.name)
-                ctx = cl.Context(devices=(d,))
-                break
-            if ctx is not None:
-                break
-    # queue = cl.CommandQueue(ctx)
-    return ctx
 
 
 class FieldInfo:


### PR DESCRIPTION
I'm not sure why this isn't happening with the nix build setup, maybe something changed between python versions.


On my setup and on some of the vhs-decode builders at least ld-decode etc crashes on startup when trying to submit the kaiser lut generator function to the ProcessPoolExecutor. I changed it to a ThreadPoolExecutor instead as a quick workaround since that just uses python threads and avoids any new context mess though not sure if it's an optimal solution.


Also did some minor formatting/cleanup while at it.