### PR TITLE
Revert "Merge pull request #1034 from staffanu/ac3rf-decode"

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -18,43 +18,6 @@
         "type": "github"
       }
     },
-    "ldaudio": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1775267416,
-        "narHash": "sha256-moCkqtTp1D2crJpHFX6ND8UTbpF7zgBKanZPxLLYoAU=",
-        "ref": "refs/heads/master",
-        "rev": "1d976d7e1f095c4c24d02c3dfa3804d4208da628",
-        "revCount": 465,
-        "submodules": true,
-        "type": "git",
-        "url": "https://bitbucket.org/staffanulfberg/ldaudio"
-      },
-      "original": {
-        "submodules": true,
-        "type": "git",
-        "url": "https://bitbucket.org/staffanulfberg/ldaudio"
-      }
-    },
-    "nanobind-src": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1733439979,
-        "narHash": "sha256-9OpDsjFEeJGtbti4Q9HHl78XaGf8M3lG4ukvHCMzyMU=",
-        "ref": "refs/tags/v2.4.0",
-        "rev": "0f9ce749b257fdfe701edb3cf6f7027ba029434a",
-        "revCount": 1015,
-        "submodules": true,
-        "type": "git",
-        "url": "https://github.com/wjakob/nanobind"
-      },
-      "original": {
-        "ref": "refs/tags/v2.4.0",
-        "submodules": true,
-        "type": "git",
-        "url": "https://github.com/wjakob/nanobind"
-      }
-    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1774799055,
@@ -74,8 +37,6 @@
     "root": {
       "inputs": {
         "flake-utils": "flake-utils",
-        "ldaudio": "ldaudio",
-        "nanobind-src": "nanobind-src",
         "nixpkgs": "nixpkgs"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -4,24 +4,13 @@
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.11";
     flake-utils.url = "github:numtide/flake-utils";
-    # Public repo containing ac3rf-decode (C++ library + Python bindings).
-    ldaudio = {
-      url = "git+https://bitbucket.org/staffanulfberg/ldaudio?submodules=1";
-      flake = false;
-    };
-    # nanobind v2.4.0 — pre-fetched as a flake input so CMake's FetchContent
-    # step can run offline inside the Nix sandbox without network access.
-    nanobind-src = {
-      url = "git+https://github.com/wjakob/nanobind?ref=refs/tags/v2.4.0&submodules=1";
-      flake = false;
-    };
   };
 
-  outputs = { self, nixpkgs, flake-utils, ldaudio, nanobind-src }:
+  outputs = { self, nixpkgs, flake-utils }:
     flake-utils.lib.eachDefaultSystem (system:
       let
         pkgs = nixpkgs.legacyPackages.${system};
-
+        
         python = pkgs.python312;
         pythonPackages = python.pkgs;
         
@@ -44,43 +33,6 @@
           ps.mkdocs-awesome-nav
         ]);
 
-        # Build the ac3rf Python extension (nanobind-based C++ module).
-        # The FetchContent step for nanobind is satisfied by pointing CMake at
-        # the pre-fetched nanobind-src flake input so no network is needed.
-        ac3rfPython = python.pkgs.toPythonModule (pkgs.stdenv.mkDerivation {
-          pname = "ac3rf-python";
-          version = "0.1.0";
-
-          src = "${ldaudio}/ac3rf-decode";
-
-          strictDeps = true;
-
-          nativeBuildInputs = [ pkgs.cmake pkgs.ninja ];
-          buildInputs = [ pkgs.eigen python ];
-
-          cmakeFlags = [
-            "-GNinja"
-            "-DCMAKE_BUILD_TYPE=Release"
-            "-DBUILD_PYTHON=ON"
-            "-DBUILD_EXECUTABLE=OFF"
-            "-DPython_EXECUTABLE=${python}/bin/python3"
-            "-DFETCHCONTENT_SOURCE_DIR_NANOBIND=${nanobind-src}"
-            "-DFETCHCONTENT_FULLY_DISCONNECTED=ON"
-          ];
-
-          installPhase = ''
-            runHook preInstall
-            mkdir -p $out/${python.sitePackages}
-            find . -name "ac3rf*.so" -exec cp {} $out/${python.sitePackages}/ \;
-            runHook postInstall
-          '';
-
-          meta = with pkgs.lib; {
-            description = "AC3 RF demodulator Python bindings";
-            license = licenses.gpl3Plus;
-          };
-        });
-
         ld-decode = pythonPackages.buildPythonPackage {
           pname = "ld-decode";
           inherit version;
@@ -101,7 +53,6 @@
             numba
             numpy
             scipy
-            ac3rfPython
           ];
           
           # Write PEP-440 compliant version file with git info
@@ -132,7 +83,6 @@
             buildPhase = ''mkdocs build'';
             installPhase = ''cp -r site $out'';
           };
-          ac3rf-python = ac3rfPython;
         };
         
         apps = {
@@ -166,7 +116,6 @@
             pythonPackages.pytest
             pythonPackages.pytest-cov
             docsEnv
-            ac3rfPython
           ];
           
           shellHook = ''

--- a/lddecode/core.py
+++ b/lddecode/core.py
@@ -25,12 +25,7 @@ from scipy import interpolate
 # internal libraries
 
 from . import efm_pll
-from .utils import ldf_pipe, traceback
-
-try:
-    import ac3rf as _ac3rf
-except ImportError:
-    _ac3rf = None
+from .utils import ac3_pipe, ldf_pipe, traceback
 from .utils import nb_mean, nb_median, nb_round, nb_min, nb_max, nb_abs, nb_absmax, nb_diff, n_orgt, n_orlt
 from .utils import polar2z, sqsum, genwave, dsa_rescale_and_clip, scale, scale_field, rms
 from .utils import findpeaks, findpulses, calczc, inrange, roundfloat
@@ -398,6 +393,26 @@ class RFDecode:
 
         if self.decode_digital_audio:
             self.computeefmfilter()
+
+        if self.SysParams['AC3']:
+            apass = 288000 * .5
+
+            fpass = lambda apass: [(self.SysParams['audio_rfreq_AC3'] - apass) / self.freq_hz_half,
+                                   (self.SysParams['audio_rfreq_AC3'] + apass) / self.freq_hz_half]
+
+            # This analog audio bandpass filter is an approximation of
+            # http://sim.okawa-denshi.jp/en/RLCtool.php with resistor 2200ohm,
+            # inductor 180uH, and cap 27pF (taken from Pioneer service manuals)
+            # self.Filters['AC3_iir'] = sps.butter(5, [1.48/20, 3.45/20], btype='bandpass')
+
+            # However, the above didn't work, and we wound up with two IIR filters
+            self.Filters['AC3_bp1'] = sps.butter(3, [(2.88-.5)/20, (2.88+.5)/20], btype='bandpass')
+            self.Filters['AC3_bp2'] = sps.butter(3, fpass(apass), btype='bandpass')
+
+            filt1 = filtfft(self.Filters['AC3_bp1'], self.blocklen)
+            filt2 = filtfft(self.Filters['AC3_bp2'], self.blocklen)
+
+            self.Filters['AC3'] = filt1 * filt2
 
         self.computedelays()
 
@@ -3425,10 +3440,7 @@ class LDdecode:
         self.outfile_audio = None
         self.outfile_efm = None
         self.outfile_pre_efm = None
-        self.outfile_ac3sym = None
-        self.ac3_demodulator = None
-        self.ac3_collector = None
-        self.ac3_processed_samples = 0
+        self.outfile_ac3 = None
         self.ffmpeg_rftbc, self.outfile_rftbc = None, None
         self.do_rftbc = False
 
@@ -3444,6 +3456,10 @@ class LDdecode:
                     self.outfile_pre_efm = open(fname_out + ".prefm", "wb")
             if self.write_rf_tbc:
                 self.ffmpeg_rftbc, self.outfile_rftbc = ldf_pipe(fname_out + ".tbc.ldf")
+                self.do_rftbc = True
+            if self.ac3:
+                self.AC3Collector = StridedCollector(cut_begin=1024, cut_end=0)
+                self.ac3_processes, self.outfile_ac3 = ac3_pipe(fname_out + ".ac3")
                 self.do_rftbc = True
 
             if os.path.exists(fname_out + '.tbc.db'):
@@ -3473,18 +3489,6 @@ class LDdecode:
         }
 
         self.rf = RFDecode(**self.rf_opts)
-
-        if fname_out is not None and self.ac3:
-            if _ac3rf is None:
-                raise RuntimeError("ac3rf Python module not found; rebuild ac3rf-decode with BUILD_PYTHON=ON")
-            block_size = 32768
-            ac3_log = _ac3rf.StreamLogger(_ac3rf.StreamLogger.LOG_WARN)
-            self.ac3_demodulator = _ac3rf.Ac3RfDemodulator(
-                ac3_log, self.rf.freq_hz, block_size, _ac3rf.simd_supported()
-            )
-            assert block_size % self.ac3_demodulator.input_sample_alignment() == 0
-            self.ac3_collector = StridedCollector(blocklen=block_size, cut_begin=0, cut_end=0)
-            self.outfile_ac3sym = open(fname_out + ".ac3sym", "wb")
 
         if system == "PAL":
             self.FieldClass = FieldPAL
@@ -3553,7 +3557,7 @@ class LDdecode:
             "outfile_json",
             "outfile_efm",
             "outfile_rftbc",
-            "outfile_ac3sym",
+            "outfile_ac3",
         ]:
             setattr(self, outfiles, None)
 
@@ -3611,7 +3615,6 @@ class LDdecode:
                 decode_faults INTEGER,
                 disk_loc REAL,
                 efm_t_values INTEGER,
-                ac3_symbols INTEGER,
                 field_phase_id INTEGER,
                 file_loc INTEGER,
                 is_first_field INTEGER CHECK (is_first_field IN (0,1)),
@@ -3761,25 +3764,19 @@ class LDdecode:
 
         return m_synchz, m_ire0hz, m_ire100hz
 
-    def AC3demodulate(self, f):
-        raw = f.rawdata
-        block_start = (f.readloc // self.demodcache.blocksize) * self.demodcache.blocksize
-        new_start = max(0, self.ac3_processed_samples - block_start)
-        self.ac3_processed_samples = block_start + len(raw)
+    def AC3filter(self, rftbc):
+        self.AC3Collector.add(rftbc)
 
-        sym_before = self.outfile_ac3sym.tell()
+        blk = self.AC3Collector.get_block()
+        while blk is not None:
+            fftdata = np.fft.fft(blk)
+            filtdata = np.fft.ifft(fftdata * self.rf.Filters['AC3']).real
+            odata = self.AC3Collector.cut(filtdata)
+            odata = np.clip(odata / 64, -100, 100)
 
-        if new_start < len(raw):
-            self.ac3_collector.add(raw[new_start:])
-            blk = self.ac3_collector.get_block()
-            while blk is not None:
-                symbols = self.ac3_demodulator.demodulate_to_symbols(
-                    blk.astype(np.float32)
-                )
-                self.outfile_ac3sym.write(symbols)
-                blk = self.ac3_collector.get_block()
+            self.outfile_ac3.write(np.int8(odata))
 
-        return self.outfile_ac3sym.tell() - sym_before
+            blk = self.AC3Collector.get_block()
 
     def writeout(self, dataset):
         f, fi, picture, audio, efm = dataset
@@ -3792,11 +3789,6 @@ class LDdecode:
 
         fi["audioSamples"] = 0 if audio is None else int(len(audio) / 2)
         fi["efmTValues"] = len(efm_out) if self.digital_audio else 0
-
-        if self.outfile_ac3sym is not None:
-            fi["ac3Symbols"] = self.AC3demodulate(f)
-        else:
-            fi["ac3Symbols"] = 0
 
         self.fieldinfo.append(fi)
 
@@ -3812,13 +3804,13 @@ class LDdecode:
         # We cast booleans to int because of the CHECK (val IN (0,1)) constraint
         self.dbconn.execute('''
             INSERT INTO field_record (
-                capture_id, field_id, is_first_field, sync_conf, disk_loc,
-                file_loc, median_burst_ire, field_phase_id, decode_faults,
-                audio_samples, efm_t_values, ac3_symbols, pad
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)''',
-            (c_id, f_id, int(fi['isFirstField']), fi['syncConf'], fi['diskLoc'],
-                fi['fileLoc'], fi['medianBurstIRE'], fi['fieldPhaseID'], decodeFaults,
-                fi['audioSamples'], fi['efmTValues'], fi['ac3Symbols'], 0))
+                capture_id, field_id, is_first_field, sync_conf, disk_loc, 
+                file_loc, median_burst_ire, field_phase_id, decode_faults, 
+                audio_samples, efm_t_values, pad
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)''', 
+            (c_id, f_id, int(fi['isFirstField']), fi['syncConf'], fi['diskLoc'], 
+                fi['fileLoc'], fi['medianBurstIRE'], fi['fieldPhaseID'], decodeFaults, 
+                fi['audioSamples'], fi['efmTValues'], 0))
 
         w_snr = fi['vitsMetrics'].get('wSNR', 0)
         b_psnr = fi['vitsMetrics'].get('bPSNR', 0)
@@ -3871,6 +3863,9 @@ class LDdecode:
 
             if self.outfile_rftbc is not None:
                 self.outfile_rftbc.write(rftbc)
+
+            if self.outfile_ac3 is not None:
+                self.AC3filter(rftbc)
 
             if self.pipe_rftbc is not None:
                 self.pipe_rftbc.send(rftbc)

--- a/lddecode/utils.py
+++ b/lddecode/utils.py
@@ -659,6 +659,30 @@ def ldf_pipe(outname: str, compression_level: int = 6):
     return ffmpeg_pipe(outname, f"-acodec flac -f ogg -compression_level {compression_level}")
 
 
+def ac3_pipe(outname: str):
+    processes = []
+
+    cmd1 = "sox -r 40000000 -b 8 -c 1 -e signed -t raw - -b 8 -r 46080000 -e unsigned -c 1 -t raw -".split()
+    cmd2 = "ld-ac3-demodulate -v 3 - -".split()
+    cmd3 = ["ld-ac3-decode", "-", outname]
+
+    logfp = open(outname + '.log', 'w')
+
+    # This is done in reverse order to allow for pipe building
+    processes.append(subprocess.Popen(cmd3,
+                                      stdin=subprocess.PIPE,
+                                      stdout=logfp,
+                                      stderr=subprocess.STDOUT))
+
+    processes.append(subprocess.Popen(cmd2,
+                                      stdin=subprocess.PIPE,
+                                      stdout=processes[-1].stdin))
+
+    processes.append(subprocess.Popen(cmd1,
+                                      stdin=subprocess.PIPE,
+                                      stdout=processes[-1].stdin))
+
+    return processes, processes[-1].stdin
 
 
 # Essential (or at least useful) standalone routines and lambdas


### PR DESCRIPTION
This reverts commit 59ea8e25bd2eb438b71d23e88c79b4bff0752343, reversing changes made to 44f2528dda10bacc292ab0c7386a3203e3071a07.


It looks as if the AC3 PR is pulling in code built on nix-unstable (the main repo is nix-25.11). This caused a compilation error:

```
       Reason: builder failed with exit code 1.
       Output paths:
         /nix/store/nsn70wpi2a8kdiqgmp1nyny4qigr886s-ac3rf-python-0.1.0
       Last 25 log lines:
       >       |                                         ^~~~~~
       > /build/ac3rf-decode/efm/EfmDecoder.cpp:252:68: error: 'std::chrono' has not been declared
       >   252 |     m_total_time_us_last_second += std::chrono::duration_cast<std::chrono::microseconds>(t1 - t0).count();
       >       |    
```

Since CI/CD wasn't run on the PR it wasn't flagged until after merge (when the PR was merged along with another unrelated PR).

I have (hopefully) removed the AC3 PR leaving the other unrelated PR in place.  The AC3 PR will need to be corrected and resubmitted.