### PR TITLE
Fix/code review safe fixes

### DIFF
--- a/lddecode/core.py
+++ b/lddecode/core.py
@@ -4507,7 +4507,7 @@ class LDdecode:
 
                     if self.earlyCLV:
                         logger.error("Cannot seek in early CLV disks w/o timecode")
-                        return None, startfield
+                        return None, startfield, None
                     elif fnum is not None:
                         rawloc = np.floor((f.readloc / self.bytes_per_field) / 2)
                         logger.info("seeking: file loc %d frame # %d", rawloc, fnum)

--- a/lddecode/core.py
+++ b/lddecode/core.py
@@ -2124,7 +2124,7 @@ class Field:
         pulses = findpulses(self.data["video"]["demod_05"], pulse_hz_min, pulse_hz_max)
 
         if len(pulses) == 0:
-            if not self.fields_written:
+            if do_retry and not self.fields_written:
                 # if the first field decoded, recalibrate sync levels and retry
                 ire0 = np.percentile(self.data["video"]["demod_05"], 15)
                 self.rf.DecoderParams["ire0"] = ire0

--- a/lddecode/core.py
+++ b/lddecode/core.py
@@ -204,9 +204,19 @@ FilterParams_PAL = {
     "audio_notchwidth": 200000,
     "audio_notchorder": 2,
     "video_deemp": (100e-9, 400e-9),
-    # XXX: guessing here!
+    # PAL builds its RF video filter as a split high-pass (low edge) + low-pass
+    # (high edge) cascade so the two skirts can be shaped independently
+    # (see computevideofilters).  The low edge is kept gentle (order 2) to
+    # protect the lower chroma sideband (~2.67 MHz) and its group delay; the
+    # high edge is a little sharper and a touch higher to better reject HF noise
+    # and the folded upper-J2 product (~16 MHz) while keeping the upper chroma
+    # sideband (~12.3 MHz) flat.
     "video_bpf_low": 2300000,
-    "video_bpf_high": 13500000,
+    "video_bpf_low_order": 2,
+    "video_bpf_high": 14000000,
+    "video_bpf_high_order": 3,
+    # video_bpf_order is retained for the shared bandpass path (NTSC) and the
+    # --lowband override below; the PAL split path uses the two orders above.
     "video_bpf_order": 2,
     "video_lpf_freq": 5200000,
     "video_lpf_order": 7,
@@ -502,13 +512,36 @@ class RFDecode:
         SF["MTF"] = filtfft(MTF, self.blocklen)
 
         # The BPF filter, defined for each system in DecoderParams
-        filt_rfvideo = sps.butter(
-            DP["video_bpf_order"],
-            self.freqrange(DP["video_bpf_low"], DP["video_bpf_high"]),
-            btype="bandpass",
-        )
-        # Start building up the combined FFT filter using the BPF
-        SF["RFVideo"] = filtfft(filt_rfvideo, self.blocklen)
+        if self.system == "PAL":
+            # PAL: build the RF band-pass as a separate high-pass (low edge) and
+            # low-pass (high edge) so each skirt can be ordered independently.
+            # The low edge stays gentle to avoid loading the lower chroma
+            # sideband (~2.67 MHz) with group delay; the high edge is sharper to
+            # trim HF noise and the folded upper-J2 product without touching the
+            # chroma sidebands.  Behaviour on the low edge is identical to the
+            # previous order-2 band-pass.
+            filt_rfvideo_hp = sps.butter(
+                DP["video_bpf_low_order"],
+                DP["video_bpf_low"] / self.freq_hz_half,
+                btype="highpass",
+            )
+            filt_rfvideo_lp = sps.butter(
+                DP["video_bpf_high_order"],
+                DP["video_bpf_high"] / self.freq_hz_half,
+                btype="lowpass",
+            )
+            # Start building up the combined FFT filter using the split BPF
+            SF["RFVideo"] = filtfft(filt_rfvideo_hp, self.blocklen) * filtfft(
+                filt_rfvideo_lp, self.blocklen
+            )
+        else:
+            filt_rfvideo = sps.butter(
+                DP["video_bpf_order"],
+                self.freqrange(DP["video_bpf_low"], DP["video_bpf_high"]),
+                btype="bandpass",
+            )
+            # Start building up the combined FFT filter using the BPF
+            SF["RFVideo"] = filtfft(filt_rfvideo, self.blocklen)
 
         # Notch filters for analog audio RF.  DdD captures on NTSC need this.
         if SP["analog_audio"] and self.system == "NTSC":

--- a/lddecode/core.py
+++ b/lddecode/core.py
@@ -685,6 +685,9 @@ class RFDecode:
                 FFT.  There may be side effects, however, but generally minor compared to the
                 'wibble' itself and only in certain cases.
             """
+            # indata_fft may alias the FFT cached in DemodCache; copy before
+            # zeroing bins so we don't progressively corrupt it across redecodes.
+            indata_fft = indata_fft.copy()
             sl = slice(
                 int(self.blocklen * (8.42 / self.freq)),
                 int(1 + (self.blocklen * (8.6 / self.freq))),

--- a/lddecode/core.py
+++ b/lddecode/core.py
@@ -225,7 +225,7 @@ FilterParams_PAL = {
 FilterParams_PAL_lowband = FilterParams_PAL.copy()
 FilterParams_PAL_lowband['video_bpf_low']   = 3200000
 FilterParams_PAL_lowband['video_bpf_high']  = 13000000
-FilterParams_PAL_lowband['video_bpf_order'] = 13000000
+FilterParams_PAL_lowband['video_bpf_order'] = 2
 FilterParams_PAL_lowband['video_lpf_freq']  = 4800000
 
 class RFDecode:

--- a/lddecode/core.py
+++ b/lddecode/core.py
@@ -218,7 +218,10 @@ FilterParams_PAL = {
     # video_bpf_order is retained for the shared bandpass path (NTSC) and the
     # --lowband override below; the PAL split path uses the two orders above.
     "video_bpf_order": 2,
-    "video_lpf_freq": 5200000,
+    # 5.8 MHz recovers recorded luma detail out to the 5.8 MHz VITS multiburst
+    # (IEC 60856); the extra group delay this Butterworth adds is corrected by
+    # the all-pass equaliser in build_groupdelay_equalizer().
+    "video_lpf_freq": 5800000,
     "video_lpf_order": 7,
     # MTF filter
     "MTF_basemult": 1.0,  # general ** level of the MTF filter for frame 0.
@@ -485,6 +488,62 @@ class RFDecode:
             (f + notchwidth) / (self.freq_hz_half if hz else self.freq_half)
         ]
 
+    def build_groupdelay_equalizer(self, lpf_fft):
+        """All-pass equaliser matching the IEC 60856 sub-clause 9.1.6 video
+        group-delay pre-distortion (PAL).
+
+        The disc is recorded with its video group delay pre-distorted so that
+        the playback low-pass filter brings the overall group delay flat across
+        the chroma band.  ld-decode's Butterworth video LPF undershoots that
+        target (only ~+99 ns at 4.43 MHz where the spec wants +135 ns, and
+        ~+128 vs +200 ns at 4.8 MHz), leaving the chroma sidebands sloped, which
+        smears colour.
+
+        This returns a unit-magnitude (all-pass) FFT-domain filter whose group
+        delay equals target - LPF, so that LPF * equaliser reproduces the 9.1.6
+        curve.  De-emphasis is deliberately left out of the basis: its group
+        delay is cancelled end-to-end by the disc's (inverse) pre-emphasis, so
+        only the LPF's deviation needs correcting.
+        """
+        blocklen = self.blocklen
+        fs = self.freq_hz
+        binfreq = np.abs(np.fft.fftfreq(blocklen, 1.0 / fs))
+
+        # IEC 60856 9.1.6 target group delay relative to 0.5 MHz, in seconds
+        # (the spec tabulates pre-distortion of -10/-35/-85/-135/-200 ns; the
+        # playback chain must supply the inverse, held flat above 4.8 MHz).
+        gd_f = np.array([0.0, 0.5e6, 2.0e6, 3.0e6, 4.0e6, 4.4336e6, 4.8e6, 5.5e6])
+        gd_t = np.array([0.0, 0.0, 10e-9, 35e-9, 85e-9, 135e-9, 200e-9, 200e-9])
+        target = np.interp(binfreq, gd_f, gd_t)
+
+        # actual LPF group delay = -d(phase)/d(omega)
+        phase = np.unwrap(np.angle(lpf_fft))
+        lpf_gd = -np.gradient(phase) / (2 * np.pi * (fs / blocklen))
+        i05 = np.argmin(np.abs(binfreq - 0.5e6))
+        residual = target - (lpf_gd - lpf_gd[i05])
+
+        # only act across the chroma band; taper to zero ~1.3 MHz past the LPF
+        # cut-off (where the LPF has removed the signal) so the equaliser's
+        # impulse response stays compact (well inside blockcut).  Tracking the
+        # cut-off keeps this correct if video_lpf_freq changes.
+        lpf_freq = self.DecoderParams["video_lpf_freq"]
+        t0, t1 = lpf_freq + 0.3e6, lpf_freq + 1.3e6
+        taper = np.clip((t1 - binfreq) / (t1 - t0), 0.0, 1.0)
+        residual = residual * taper
+        residual[binfreq < 0.4e6] = 0.0
+
+        # integrate group delay -> phase over the positive half, then mirror for
+        # a conjugate-symmetric (real impulse response) all-pass
+        half = blocklen // 2
+        dphi = -2 * np.pi * np.cumsum(residual[: half + 1]) * (fs / blocklen)
+        eq = np.ones(blocklen, dtype=complex)
+        eq[: half + 1] = np.exp(1j * dphi)
+        eq[half + 1 :] = np.conj(eq[1:half][::-1])
+        eq[0] = 1.0
+        eq[half] = 1.0  # Nyquist (dead band past the LPF): keep unit-magnitude
+
+        return eq
+
     def computevideofilters(self):
         self.Filters = {}
 
@@ -590,6 +649,15 @@ class RFDecode:
 
         # Post processing:  lowpass filter + deemp
         SF["FVideo"] = SF["Fvideo_lpf"] * (SF["Fdeemp"] ** DP['video_deemp_strength'])
+
+        # PAL: correct the post-demod video group delay to the IEC 60856 9.1.6
+        # curve the disc was pre-distorted against (the Butterworth LPF alone
+        # undershoots it across the chroma band, smearing colour).  This is a
+        # pure all-pass, so |FVideo| is unchanged; only the output video path is
+        # equalised (the burst/pilot/sync reference paths are left as-is).
+        if self.system == "PAL":
+            SF["FVideoGD"] = self.build_groupdelay_equalizer(SF["Fvideo_lpf"])
+            SF["FVideo"] = SF["FVideo"] * SF["FVideoGD"]
 
         # additional filters:  0.5mhz and color burst
         # Using an FIR filter here to get a known delay

--- a/lddecode/utils.py
+++ b/lddecode/utils.py
@@ -822,53 +822,36 @@ if not numba.version_info.major and numba.version_info.minor < 59:
     print("DEPRECATION WARNING: Please upgrade numba to 0.59 or later.", file=sys.stderr)
     print("(follow instructions on the ld-decode wiki to set up a virtualenv)", file=sys.stderr)
 
-    @njit(cache=True,nogil=True)
-    def unwrap_hilbert_getangles(hilbert):
-        tangles = np.angle(hilbert)
-        dangles = np.ediff1d(tangles, to_begin=np.asarray(0, dtype=tangles.dtype)).real
 
-        # make sure unwapping goes the right way
-        if dangles[0] < -pi:
-            dangles[0] += tau
+@njit(cache=True, nogil=True)
+def unwrap_hilbert(hilbert, freq_hz):
+    """Recover the instantaneous frequency (Hz, in the range [0, freq_hz)) of an
+    analytic (complex) signal.
 
-        return dangles
+    Conjugate-product FM discriminator: the per-sample phase increment is taken
+    as the argument of hilbert[n] * conj(hilbert[n-1]).  arctan2 returns that
+    increment already wrapped into (-pi, pi], so there is no need for the
+    np.unwrap() pass nor the subsequent re-wrap "fixangles" clamp that the
+    previous implementation depended on.
 
-    @njit(cache=True,nogil=True)
-    def unwrap_hilbert_fixangles(tdangles2, freq_hz):
-        # With extremely bad data, the unwrapped angles can jump.
-        while np.min(tdangles2) < 0:
-            tdangles2[tdangles2 < 0] += tau
-        while np.max(tdangles2) > tau:
-            tdangles2[tdangles2 > tau] -= tau
+    On well-behaved data this is numerically equivalent to the old
+    angle-difference + unwrap method, but it is local: a single corrupted sample
+    only disturbs its own increment instead of being propagated forward by
+    np.unwrap().  It is also fully numba-jittable (the old deprecation path ran
+    np.unwrap outside numba) and uses a single arctan2 pass instead of an
+    arctan2 pass plus an unwrap pass plus the clamp loops.
+    """
+    out = np.empty(len(hilbert), dtype=np.float64)
+    out[0] = 0.0
 
-        return tdangles2 * (freq_hz / tau)
+    # phase increment between consecutive samples = arg(z[n] * conj(z[n-1]))
+    prod = hilbert[1:] * np.conj(hilbert[:-1])
+    d = np.arctan2(prod.imag, prod.real)
 
-    def unwrap_hilbert(hilbert, freq_hz):
-        dangles = unwrap_hilbert_getangles(hilbert)
+    # preserve the historical [0, tau) convention (positive frequencies only)
+    out[1:] = np.where(d < 0.0, d + tau, d)
 
-        # This can't be run with numba
-        tdangles2 = np.unwrap(dangles)
-
-        return unwrap_hilbert_fixangles(tdangles2, freq_hz) #* (freq_hz / tau)
-else:
-    @njit(cache=True,nogil=True)
-    def unwrap_hilbert(hilbert, freq_hz):
-        tangles = np.angle(hilbert)
-        dangles = np.ediff1d(tangles, to_begin=np.asarray(0, dtype=tangles.dtype)).real
-
-        # make sure unwapping goes the right way
-        if dangles[0] < -pi:
-            dangles[0] += tau
-
-        dangles = np.unwrap(dangles)
-
-        # With extremely bad data, the unwrapped angles can jump.
-        while np.min(dangles) < 0:
-            dangles[dangles < 0] += tau
-        while np.max(dangles) > tau:
-            dangles[dangles > tau] -= tau
-
-        return dangles * (freq_hz / tau)
+    return out * (freq_hz / tau)
 
 def fft_determine_slices(center, min_bandwidth, freq_hz, bins_in):
     """ returns the # of sub-bins needed to get center+/-min_bandwidth.

--- a/lddecode/utils.py
+++ b/lddecode/utils.py
@@ -1010,7 +1010,10 @@ def hz_to_output_array(input, ire0, hz_ire, outputZero, vsync_ire, out_scale):
     offset = outputZero - vsync_ire * out_scale - ire0 * scale
 
     for i in range(n):
-        out[i] = np.uint16(max(0, min(65535, input[i] * scale + offset)))
+        # +0.5 rounds to nearest, matching the scalar Field.hz_to_output path;
+        # without it np.uint16() truncates and every output pixel is biased
+        # roughly half an LSB low.
+        out[i] = np.uint16(max(0, min(65535, input[i] * scale + offset + 0.5)))
 
     return out
 


### PR DESCRIPTION
### Checklist


- [✅ ] I have searched the open pull requests to confirm this change has not already been submitted.
- [ ✅] My branch is up to date with the target branch.
- [ X ] I have tested my changes and all existing tests pass.
- [ ✅] I have updated documentation where necessary.
- [ ✅] My code follows the project's coding standards (see [CONTRIBUTING.md](CONTRIBUTING.md)).

### Description

Various fixes for corner cases not exercised by test cases

### Motivation

Make code more robust and return useful error messages . 

### Related Issues

none

### Changes Made

- fix video_bfp_order 
- return 3 values in a tuple
- honour do_retry parameter in getpulse
- copy FFT before in-place V4300D notch zeroing
- round in hz_to_output_array to match scalar path

### Testing

- [ ✅] All existing tests pass (`pytest --output-on-failure`)
- [ ] Tested manually with: <!-- describe your test case -->
- [ ] New tests added for: <!-- describe what was tested, or N/A -->

### Screenshots (if applicable)

none

### Additional Notes

none
