### PR TITLE
Fix .s16/.f32/.r30 loading on numpy >= 2.0

### DIFF
--- a/lddecode/utils.py
+++ b/lddecode/utils.py
@@ -290,11 +290,11 @@ def load_unpacked_data(infile, sample, readlen, sampletype):
     inbuf = infile.read(readlen * samplelength)
 
     if sampletype == 4:
-        indata = np.fromstring(inbuf, "float32", len(inbuf) // 4) * 32768
+        indata = np.frombuffer(inbuf, "float32", len(inbuf) // 4) * 32768
     elif sampletype == 3:
         indata = np.frombuffer(inbuf, "uint16", len(inbuf) // 2)
     elif sampletype == 2:
-        indata = np.fromstring(inbuf, "int16", len(inbuf) // 2)
+        indata = np.frombuffer(inbuf, "int16", len(inbuf) // 2)
     else:
         # NOTE(oln): Can probably use frombuffer for other variants too but
         # didn't have any samples to test with.
@@ -334,7 +334,7 @@ def load_packed_data_3_32(infile, sample, readlen):
     needed = int(np.ceil(readlen * 3 / 4) * 4) + 4
 
     inbuf = infile.read(needed)
-    indata = np.fromstring(inbuf, "uint32", len(inbuf) // 4)
+    indata = np.frombuffer(inbuf, "uint32", len(inbuf) // 4)
 
     if len(indata) < needed:
         return None


### PR DESCRIPTION
## Summary

`np.fromstring` was removed in numpy 2.0. The uint8/uint16 loaders in `lddecode/utils.py` were already converted to `np.frombuffer`, but the int16 (`.s16`), float32 (`.f32`), and packed r30 paths still used `fromstring` and fail with a `ValueError` on current numpy:

```
ValueError: The binary mode of fromstring is removed, use frombuffer instead
```

This makes the raw sample formats unloadable in any environment with numpy 2.x (including the repo's own nix dev shell).

## Testing

Verified by decoding a raw `.s16` file with the fixed loader (numpy 2.3). The two already-converted loaders (u8/u16) show the pattern is equivalent; `frombuffer` returns a read-only view, which is fine here since the float32 path immediately creates a new array and the int16 path is only read from.

(Found while writing an end-to-end test for the upcoming AC3 PR, which synthesizes a `.s16` input — that PR currently carries this same commit and will be rebased once this merges.)