### PR TITLE
Restore some decode throughput lost since April

### DIFF
--- a/lddecode/core.py
+++ b/lddecode/core.py
@@ -34,6 +34,7 @@ from .utils import LRUupdate, clb_findbursts, angular_mean_helper, phase_distanc
 from .utils import build_hilbert, unwrap_hilbert, emphasis_iir, filtfft
 from .utils import fft_do_slice, fft_determine_slices, StridedCollector, hz_to_output_array
 from .utils import Pulse, nb_std, n_ornotrange, gen_bpf_supergauss, FieldInfo
+from .utils import concatenate_blocks
 
 try:
     # If Anaconda's numpy is installed, mkl will use all threads for fft etc
@@ -1400,7 +1401,7 @@ class DemodCache:
 
         rv = {}
         for k in t.keys():
-            rv[k] = np.concatenate(t[k]) if len(t[k]) else None
+            rv[k] = concatenate_blocks(t[k]) if len(t[k]) else None
 
         if rv["audio"] is not None:
             rv["audio_phase1"] = rv["audio"]

--- a/lddecode/utils.py
+++ b/lddecode/utils.py
@@ -124,7 +124,7 @@ sinc_phase_count = 2**16
 #     return table
 
 
-@njit(nogil=True, fastmath=True)
+@njit(nogil=True, cache=True, fastmath=True)
 def scale_field(buf, dsout, interpolated_pixel_locs, wowfactors, sinc_lut, lineoffset, outwidth, wow_level_adjust_smoothing = 0, level_adjust_threshold = 15):
     # average out any unusual spikes in wow that happen on a per line basis
     # this indicates an hsync tbc error vs. being normal wow from playback speed variations
@@ -163,22 +163,19 @@ def scale_field(buf, dsout, interpolated_pixel_locs, wowfactors, sinc_lut, lineo
         # fractional phase
         frac = coord - coord_int
 
-        phase_pos = frac * sinc_phase_count
-        phase_start = int(phase_pos)
-        phase_end = phase_start + 1
-
-        alpha = np.float32(phase_pos - phase_start)
-
-        w_start = sinc_lut[phase_start]
-        w_end = sinc_lut[phase_end]
+        # sinc_phase_count is 2**16, so the nearest tabulated phase is already
+        # accurate far below float32 precision. Interpolating between two
+        # adjacent phases would double LUT reads and add per-tap math in the
+        # innermost loop of the decoder for no change in output.
+        # If the LUT gets smaller, consider adding linear interpolation.
+        phase = int(frac * sinc_phase_count + np.float32(0.5))
+        w = sinc_lut[phase]
 
         start = coord_int - half_taps_m1
 
         result = 0.0
         for t in range(sinc_tap_count):
-            # do linear interpolation between pre-computed phases
-            ws = w_start[t]
-            result += buf[start + t] * (ws + alpha * (w_end[t] - ws))
+            result += buf[start + t] * w[t]
 
         dsout[i - dsout_start] = level_adjust * result
 
@@ -427,7 +424,7 @@ class LoadFFmpeg:
         # small amounts. The last byte returned by ffmpeg is at the end of
         # this buffer.
         self.rewind_size = 16 * 1024 * 1024
-        self.rewind_buf = b""
+        self.rewind_buf = bytearray()
 
     def _close(self):
         if self.ffmpeg is not None:
@@ -445,7 +442,8 @@ class LoadFFmpeg:
         self.position += len(data)
 
         self.rewind_buf += data
-        self.rewind_buf = self.rewind_buf[-self.rewind_size :]
+        if len(self.rewind_buf) > 2 * self.rewind_size:
+            del self.rewind_buf[: len(self.rewind_buf) - self.rewind_size]
 
         return data
 
@@ -469,7 +467,7 @@ class LoadFFmpeg:
             end = min(start + readlen_bytes, len(self.rewind_buf))
             if start < 0:
                 raise IOError("Seeking too far backwards with ffmpeg")
-            buf_data = self.rewind_buf[start:end]
+            buf_data = bytes(self.rewind_buf[start:end])
             sample_bytes += len(buf_data)
             readlen_bytes -= len(buf_data)
         else:
@@ -517,7 +515,7 @@ class LoadLDF:
 
         self.position = 0
         self.rewind_size = 2 * 1024 * 1024
-        self.rewind_buf = b""
+        self.rewind_buf = bytearray()
 
         # Forward seeks farther than this (in bytes) restart the decoder with a
         # container seek instead of reading and discarding samples one by one.
@@ -575,7 +573,7 @@ class LoadLDF:
         self._stop_event = stop_event
 
         self.position = sample * 2
-        self.rewind_buf = b""
+        self.rewind_buf = bytearray()
 
         self._reader_thread = threading.Thread(
             target=self._reader_loop,
@@ -681,7 +679,8 @@ class LoadLDF:
         self.position += len(data)
 
         self.rewind_buf += data
-        self.rewind_buf = self.rewind_buf[-self.rewind_size:]
+        if len(self.rewind_buf) > 2 * self.rewind_size:
+            del self.rewind_buf[: len(self.rewind_buf) - self.rewind_size]
 
         return data
 
@@ -709,7 +708,7 @@ class LoadLDF:
                 self._start_decoder(sample)
                 buf_data = b""
             else:
-                buf_data = self.rewind_buf[start:end]
+                buf_data = bytes(self.rewind_buf[start:end])
                 sample_bytes += len(buf_data)
                 readlen_bytes -= len(buf_data)
         else:
@@ -1226,6 +1225,18 @@ def LRUupdate(l, k):
         pass
 
     l.insert(0, k)
+
+
+def concatenate_blocks(blocks):
+    """Concatenate demodulator cache blocks, being sensitive to performance"""
+    dtype = blocks[0].dtype
+    if dtype.names is None:
+        return np.concatenate(blocks)
+
+    # np.concatenate does per-field/per-element copy on structured/record dtype.
+    # ~30x slower than simple memcpy. We happen to know the blocks here share
+    # the same dtype, so just copy the bytes.
+    return np.concatenate([b.view(np.uint8) for b in blocks]).view(dtype)
 
 
 # numba jit functions, used to numba-ify parts of more complex functions


### PR DESCRIPTION
### Checklist
- [X] I have searched the open pull requests to confirm this change has not already been submitted.
- [X] My branch is up to date with the target branch.
- [X] I have tested my changes and all existing tests pass.
- [X] I have updated documentation where necessary.
- [X] My code follows the project's coding standards (see [CONTRIBUTING.md](CONTRIBUTING.md)).

### Description
Four independent decoder/demodulator performance regressions roughly halved throughput (including downstream in vhs-decode) and this tries to bring a little performance back.

1. `LoadFFmpeg`/`LoadLDF` rewind buffer (biggest one). Appending to and trimming the rewind buffer copies the bytes twice each read. 8a42fec2 raised `LoadFFmpeg`'s window from 2MB to 16MB, which turned ~4MB of memcpy per 61KB read into ~32MB. Demodulator threads starve waiting on the big copy.

2. `scale_field` lost `@njit(cache=True)`. Was dropped in 163408c5, I'm guessing an artifact of runtime kernel overrides while testing the change.

3. Sinc LUT's inter-phase interpolation doesn't change anything. `sinc_phase_count` is 2**16, so the nearest tabulated phase is already accurate below float32 precision. Interpolating between the phases is costly when this math is encountered frequently.

4. Wasteful `np.concatenate` on block record arrays. `nb_concatenate` was dropped in 980f3a2d and cf2e13ed but the replacement had an expensive deep traversal of block structure.

### Motivation
When vhs-decode 0.4.0 launched with these regressions, users brought up the slow performance in the Domesday86 Discord.

### Changes Made
1. Fixed with a `bytearray` and compaction only once the window has grown to twice its target size. The combination of those two is was better than just either one.
2. Added the `cache=True` back. @eshaz: let me know if you'd wanted to make tap counts or something else runtime-alterable.
3. Dropped the linear interpolation to just publish the nearest phase. Depends on the LUT staying this large.
4. Custom concatenation function. @happycube I asked an AI to determine why the numba flow had to be dropped, and it hinted you might have run into `can't unbox heterogeneous list`; this _should_ be faster than the numba kernel anyway.

### Testing
- [X] All existing tests pass (`pytest --output-on-failure`)
- [X] Tested manually with a barrage of LaserDisc (and VHS w/ patched vhs-decode) sources in both NTSC and PAL. TBC output was identical.