### PR TITLE
Reduce redundant video FFT work

### DIFF
--- a/lddecode/core.py
+++ b/lddecode/core.py
@@ -553,6 +553,9 @@ class RFDecode:
         # This high pass filter is intended to detect RF dropouts
         Frfhpf = sps.butter(1, 10 / self.freq_half, btype="highpass")
         self.Filters["Frfhpf"] = filtfft(Frfhpf, self.blocklen)
+        self.Filters["Frfhpf_rfft"] = self.Filters["Frfhpf"][
+            : self.blocklen // 2 + 1
+        ]
 
         # First phase FFT filtering
 
@@ -678,6 +681,28 @@ class RFDecode:
                 self.blocklen,
             )
             SF["FVideoPilot"] = SF["Fvideo_lpf"] * SF["Fdeemp"] * SF["Fpilot"]
+
+        # These filters produce real outputs, so keep their positive-frequency
+        # halves and transform all video products together.
+        rfft_len = self.blocklen // 2 + 1
+        bins = np.arange(rfft_len)
+
+        def shifted_half_spectrum(filt, offset=0):
+            half = filt[:rfft_len]
+            if offset:
+                half = half * np.exp(2j * np.pi * offset * bins / self.blocklen)
+            return half
+
+        video_filters = [
+            shifted_half_spectrum(SF["FVideo"]),
+            shifted_half_spectrum(SF["FVideo05"], SF["F05_offset"]),
+            shifted_half_spectrum(
+                SF["FVideoBurst"], SF["FVideoBurst_offset"]
+            ),
+        ]
+        if self.system == "PAL":
+            video_filters.append(shifted_half_spectrum(SF["FVideoPilot"]))
+        SF["FVideo_rfft"] = np.asarray(video_filters)
 
     def computeaudiofilters(self):
         SP = self.SysParams
@@ -806,7 +831,11 @@ class RFDecode:
         if getattr(self, "delays", None) is not None and "video_rot" in self.delays:
             rotdelay = self.delays["video_rot"]
 
-        rv["rfhpf"] = npfft.ifft(indata_fft * self.Filters["Frfhpf"]).real
+        rv["rfhpf"] = npfft.irfft(
+            indata_fft[: self.blocklen // 2 + 1]
+            * self.Filters["Frfhpf_rfft"],
+            n=self.blocklen,
+        )
         rv["rfhpf"] = rv["rfhpf"][
             self.blockcut - rotdelay : -self.blockcut_end - rotdelay
         ].astype(np.float32)
@@ -846,18 +875,17 @@ class RFDecode:
         demod = unwrap_hilbert(hilbert, self.freq_hz)
 
         # use a clipped demod for video output processing to reduce speckling impact
-        demod_fft = npfft.fft(np.clip(demod, 1500000, self.freq_hz * 0.75))
+        demod_rfft = npfft.rfft(np.clip(demod, 1500000, self.freq_hz * 0.75))
+        video_results = npfft.irfft(
+            demod_rfft * self.Filters["FVideo_rfft"],
+            n=self.blocklen,
+            axis=1,
+        )
 
-        out_video = npfft.ifft(demod_fft * self.Filters["FVideo"]).real
-
-        out_video05 = npfft.ifft(demod_fft * self.Filters["FVideo05"]).real
-        out_video05 = np.roll(out_video05, -self.Filters["F05_offset"])
-
-        out_videoburst = npfft.ifft(demod_fft * self.Filters["FVideoBurst"]).real
-        out_videoburst = np.roll(out_videoburst, -self.Filters["FVideoBurst_offset"])
+        out_video, out_video05, out_videoburst = video_results[:3]
 
         if self.system == "PAL":
-            out_videopilot = npfft.ifft(demod_fft * self.Filters["FVideoPilot"]).real
+            out_videopilot = video_results[3]
             video_out = np.rec.array(
                 [
                     out_video.astype(np.float32),

--- a/tests/test_demod_fft.py
+++ b/tests/test_demod_fft.py
@@ -1,0 +1,60 @@
+import numpy as np
+import scipy.fft as npfft
+
+from lddecode.core import RFDecode
+from lddecode.utils import unwrap_hilbert
+
+
+def _legacy_outputs(rf, signal):
+    indata_fft = npfft.fft(signal)
+    hilbert = npfft.ifft(indata_fft * rf.Filters["RFVideo"])
+    demod = unwrap_hilbert(hilbert, rf.freq_hz)
+    demod_fft = npfft.fft(np.clip(demod, 1500000, rf.freq_hz * 0.75))
+
+    video = [
+        npfft.ifft(demod_fft * rf.Filters["FVideo"]).real,
+        np.roll(
+            npfft.ifft(demod_fft * rf.Filters["FVideo05"]).real,
+            -rf.Filters["F05_offset"],
+        ),
+        np.roll(
+            npfft.ifft(demod_fft * rf.Filters["FVideoBurst"]).real,
+            -rf.Filters["FVideoBurst_offset"],
+        ),
+    ]
+    if rf.system == "PAL":
+        video.append(npfft.ifft(demod_fft * rf.Filters["FVideoPilot"]).real)
+
+    rfhpf = npfft.ifft(indata_fft * rf.Filters["Frfhpf"]).real
+    return demod, video, rfhpf
+
+
+def _check_outputs(system):
+    rf = RFDecode(system=system)
+    rng = np.random.default_rng(12345)
+    signal = rng.integers(0, 16384, rf.blocklen).astype(np.float64)
+
+    demod, expected_video, expected_rfhpf = _legacy_outputs(rf, signal)
+    actual = rf.demodblock(data=signal)
+
+    names = ["demod", "demod_05", "demod_burst"]
+    if system == "PAL":
+        names.append("demod_pilot")
+
+    np.testing.assert_allclose(actual["video"]["demod_raw"], demod, rtol=1e-6)
+    for name, expected in zip(names, expected_video):
+        np.testing.assert_allclose(actual["video"][name], expected, rtol=1e-6)
+
+    rotdelay = rf.delays.get("video_rot", 0)
+    expected_rfhpf = expected_rfhpf[
+        rf.blockcut - rotdelay : -rf.blockcut_end - rotdelay
+    ]
+    np.testing.assert_allclose(actual["rfhpf"], expected_rfhpf, rtol=1e-6)
+
+
+def test_ntsc_outputs_match_full_fft():
+    _check_outputs("NTSC")
+
+
+def test_pal_outputs_match_full_fft():
+    _check_outputs("PAL")


### PR DESCRIPTION
### Checklist

- [x] I have searched the open pull requests to confirm this change has not already been submitted.
- [x] My branch is up to date with the target branch.
- [x] I have tested my changes and all existing tests pass.
- [x] Documentation is unchanged because this does not alter user-facing behavior or configuration.
- [x] My code follows the project's coding standards (see [CONTRIBUTING.md](CONTRIBUTING.md)).

### Description

Reduce redundant FFT work in the video demodulation path while preserving its output contract.

### Motivation

The existing path computes several full-complex transforms and performs separate inverse transforms and post-transform rolls even though the dropout and video outputs are real-valued. This change avoids that redundant work.

### Related Issues

N/A

### Changes Made

- Use the positive-frequency half-spectrum for real-valued dropout and video outputs.
- Batch the video inverse transforms with `irfft`.
- Apply the existing filter sample offsets in the frequency domain.
- Add deterministic NTSC and PAL comparisons against the former full-FFT path.

### Testing

- [x] Full suite: `nix develop --command python -m pytest -q` — 84 passed.
- [x] Focused tests: `nix develop --command python -m pytest -q tests/test_demod_fft.py` — 2 passed.
- [x] Synthetic 200-block benchmark against current upstream main:
  - NTSC: 2.60 → 1.81 ms/block (~30.4% lower)
  - PAL: 2.83 → 2.06 ms/block (~27.2% lower)

### Screenshots (if applicable)

N/A

### Additional Notes

No new dependency is introduced; this uses the existing SciPy FFT implementation. The record-array output construction and public behavior remain unchanged.