### PR TITLE
Reduce sync demodulation FFT work

### DIFF
--- a/lddecode/core.py
+++ b/lddecode/core.py
@@ -808,9 +808,10 @@ class RFDecode:
 
         hilbert = npfft.ifft(indata_fft_filt)
         demod = unwrap_hilbert(hilbert, self.freq_hz)
-        demod_fft = npfft.fft(np.clip(demod, 1500000, self.freq_hz * 0.75))
-        sync = npfft.ifft(demod_fft * self.Filters["FVideo05"]).real
-        sync = np.roll(sync, -self.Filters["F05_offset"])
+        demod_rfft = npfft.rfft(np.clip(demod, 1500000, self.freq_hz * 0.75))
+        sync = npfft.irfft(
+            demod_rfft * self.Filters["FVideo_rfft"][1], n=self.blocklen
+        )
 
         if cut:
             sync = sync[self.blockcut : -self.blockcut_end]

--- a/tests/test_demod_fft.py
+++ b/tests/test_demod_fft.py
@@ -36,6 +36,7 @@ def _check_outputs(system):
 
     demod, expected_video, expected_rfhpf = _legacy_outputs(rf, signal)
     actual = rf.demodblock(data=signal)
+    sync = rf.demodblock_sync(data=signal)
 
     names = ["demod", "demod_05", "demod_burst"]
     if system == "PAL":
@@ -44,6 +45,7 @@ def _check_outputs(system):
     np.testing.assert_allclose(actual["video"]["demod_raw"], demod, rtol=1e-6)
     for name, expected in zip(names, expected_video):
         np.testing.assert_allclose(actual["video"][name], expected, rtol=1e-6)
+    np.testing.assert_allclose(sync, expected_video[1], rtol=1e-6)
 
     rotdelay = rf.delays.get("video_rot", 0)
     expected_rfhpf = expected_rfhpf[


### PR DESCRIPTION
### Checklist

- [x] I have searched the open pull requests to confirm this change has not already been submitted.
- [x] My branch is up to date with the target branch.
- [x] I have tested my changes and all existing tests pass.
- [x] Documentation is unchanged because this does not alter user-facing behavior or configuration.
- [x] My code follows the project's coding standards (see [CONTRIBUTING.md](CONTRIBUTING.md)).

### Description

Use the existing phase-adjusted real-FFT filter for sync-only demodulation.

### Motivation

The sync-only path still performed a full FFT, full inverse FFT, and time-domain roll for a real-valued result. The main demodulation path already precomputes the equivalent positive-frequency filter with its sample offset applied in the frequency domain.

### Related Issues

N/A

### Changes Made

- Replace the sync path's full transform and inverse transform with `rfft` and `irfft`.
- Reuse the existing phase-adjusted 0.5 MHz half-spectrum.
- Extend the deterministic NTSC and PAL regression comparisons to cover sync-only demodulation.

### Testing

- [x] Full suite: `nix develop --command python -m pytest -q` — 84 passed.
- [x] Focused tests: `nix develop --command python -m pytest -q tests/test_demod_fft.py` — 2 passed.
- [x] Synthetic benchmark against the former implementation:
  - NTSC: 1.934 → 1.639 ms/block (15.3% lower)
  - PAL: 1.965 → 1.701 ms/block (13.4% lower)

### Screenshots (if applicable)

N/A

### Additional Notes

No dependency or output-format changes.
