### PR TITLE
Optimize sync FFT path and refresh benchmark filters

### DIFF
--- a/lddecode/core.py
+++ b/lddecode/core.py
@@ -808,9 +808,11 @@ class RFDecode:
 
         hilbert = npfft.ifft(indata_fft_filt)
         demod = unwrap_hilbert(hilbert, self.freq_hz)
-        demod_fft = npfft.fft(np.clip(demod, 1500000, self.freq_hz * 0.75))
-        sync = npfft.ifft(demod_fft * self.Filters["FVideo05"]).real
-        sync = np.roll(sync, -self.Filters["F05_offset"])
+        demod_rfft = npfft.rfft(np.clip(demod, 1500000, self.freq_hz * 0.75))
+        sync = npfft.irfft(
+            demod_rfft * self.Filters["FVideo_rfft"][1],
+            n=self.blocklen,
+        )
 
         if cut:
             sync = sync[self.blockcut : -self.blockcut_end]

--- a/tools/bench_rf.py
+++ b/tools/bench_rf.py
@@ -170,7 +170,7 @@ def bench_substeps(rf, signal, n_blocks):
     for _ in range(n_blocks):
         st = time.perf_counter()
         video_results = npfft.irfft(
-            demod_rfft * rf.Filters["FVideo_rfft_stack"], n=rf.blocklen, axis=1
+            demod_rfft * rf.Filters["FVideo_rfft"], n=rf.blocklen, axis=1
         )
         times.append(time.perf_counter() - st)
     steps["5_batch_irfft"] = np.array(times)
@@ -192,7 +192,9 @@ def bench_substeps(rf, signal, n_blocks):
     times = []
     for _ in range(n_blocks):
         st = time.perf_counter()
-        rfhpf = npfft.irfft(indata_rfft * rf.Filters["Frfhpf_half"], n=rf.blocklen)
+        rfhpf = npfft.irfft(
+            indata_rfft * rf.Filters["Frfhpf_rfft"], n=rf.blocklen
+        )
         times.append(time.perf_counter() - st)
     steps["6_rfhpf_irfft"] = np.array(times)
 


### PR DESCRIPTION
## Summary

- update `tools/bench_rf.py` to use the merged `FVideo_rfft` and `Frfhpf_rfft` filter names
- use the real-transform path in `demodblock_sync`
- reuse the already phase-shifted 0.5 MHz filter and remove the separate output roll

## Why

The benchmark retained names from an earlier FFT redundancy experiment, so its substep mode no longer ran against the merged implementation. The sync-only demodulation path used by `ld-find-start` also retained the former full FFT/full inverse FFT sequence even though it produces the same real-valued 0.5 MHz output as the optimized normal demodulation path.

## Impact

This restores the RF substep benchmark and applies the same reduced FFT work to sync-only demodulation, which should improve `ld-find-start` throughput while preserving its output.

## Validation

- `python -m pytest -q` — 84 passed
- exact array-equality regression between sync-only and normal sync output
- NTSC benchmark smoke test with `--substeps`
- PAL benchmark smoke test with `--substeps`
- `git diff --check`
