### PR TITLE
Fix ld-find-start nominal start validation

### DIFF
--- a/lddecode/start_finder.py
+++ b/lddecode/start_finder.py
@@ -9,9 +9,11 @@ trying to infer programme material from RF amplitude alone.
 from __future__ import print_function
 
 import argparse
+import math
 import sys
 import warnings
 from collections import namedtuple
+from copy import deepcopy
 
 from lddecode.core import LDdecode
 from lddecode.utils import make_loader, parse_frequency
@@ -23,6 +25,11 @@ DEFAULT_PRE_ROLL_SEARCH_SECONDS = 5.0
 # A five-frame run can occur while a player is still settling or seeking. One
 # second of clean, normal-speed addresses is long enough to reject that case.
 REQUIRED_VBI_FRAMES = 30
+# ``--start`` is a coarse, nominal frame location.  Verify a short phase run
+# from that exact position before returning it, so it does not begin inside the
+# last few unstable fields preceding the clean pre-roll.
+REQUIRED_START_STABLE_FIELDS = 8
+MAX_START_VALIDATION_SECONDS = 1.0
 
 FrameObservation = namedtuple(
     "FrameObservation", "file_frame readloc address disk_type"
@@ -34,7 +41,19 @@ StartResult = namedtuple(
     "StartResult",
     "file_frame readloc confidence disk_type addresses searched_seconds",
 )
-"""Result from :func:`find_start`; confidence is ``vbi`` or ``fallback``."""
+"""Result from :func:`find_start`; confidence is ``vbi``, ``fallback``, or
+``unvalidated``.  For VBI and unvalidated results, ``readloc`` is the first
+decoded field sample and can precede the nominal ``file_frame`` start
+location."""
+
+
+StartValidationResult = namedtuple(
+    "StartValidationResult", "file_frame readloc reason"
+)
+"""Internal nominal-``--start`` validation result.
+
+``readloc`` is the first decoded field sample; ``reason`` is set on failure.
+"""
 
 
 def file_frame_from_readloc(readloc, bytes_per_field):
@@ -286,6 +305,99 @@ class StartFinder:
             stable_observation.disk_type,
         )
 
+    def _validate_start_frame(self, first_frame, last_frame, bytes_per_field):
+        """Validate the earliest nominal ``--start`` within a clean pre-roll.
+
+        The pre-roll replay begins at a decoded field boundary, whereas
+        ``ld-decode --start`` begins at a nominal sample position.  The latter
+        can still select a preceding unstable field.  Decode each candidate as
+        the normal read path does and retain the first one with a stable phase
+        run.
+        """
+
+        decoder = None
+        try:
+            decoder = self.decoder_factory()
+            field_phases = int(decoder.rf.SysParams["fieldPhases"])
+            initial_decoder_params = deepcopy(decoder.rf.DecoderParams)
+            for candidate in range(int(first_frame), int(last_frame) + 1):
+                # ``decodefield`` can recalibrate RF levels while locking.
+                # Restore the factory state so every nominal start is an
+                # independent probe without constructing another decoder.
+                decoder.rf.DecoderParams.clear()
+                decoder.rf.DecoderParams.update(deepcopy(initial_decoder_params))
+                validation = self._validate_start_frame_candidate(
+                    decoder, candidate, bytes_per_field, field_phases
+                )
+                if validation is not None:
+                    return validation
+        except (KeyboardInterrupt, SystemExit):
+            raise
+        except Exception as error:
+            return StartValidationResult(
+                None,
+                None,
+                "decoder failure while validating nominal --start: {0}".format(
+                    error
+                ),
+            )
+        finally:
+            if decoder is not None:
+                decoder.close()
+
+        return StartValidationResult(
+            None,
+            None,
+            "no phase-stable nominal --start from file frame {0} through {1}".format(
+                first_frame, last_frame
+            ),
+        )
+
+    def _validate_start_frame_candidate(
+        self, decoder, candidate, bytes_per_field, field_phases
+    ):
+        """Return a validation result for one fresh nominal ``--start`` probe."""
+
+        position = candidate * int(bytes_per_field) * 2
+        previous_field = None
+        first_readloc = None
+        previous_phase = None
+        stable_fields = 0
+        for _ in range(REQUIRED_START_STABLE_FIELDS):
+            field, offset = decoder.decodefield(position, 0, previous_field)
+            if field is None or offset is None or not field.valid:
+                return None
+
+            if first_readloc is None:
+                first_readloc = int(field.readloc)
+            phase = getattr(field, "fieldPhaseID", None)
+            if phase is None:
+                return None
+            phase = int(phase)
+            if previous_phase is not None:
+                expected_phase = (
+                    1 if previous_phase == field_phases else previous_phase + 1
+                )
+                if phase != expected_phase:
+                    return None
+
+            try:
+                offset = int(offset)
+            except (TypeError, ValueError):
+                return None
+            if offset <= 0:
+                return None
+
+            previous_phase = phase
+            previous_field = field
+            stable_fields += 1
+            position += offset
+
+        if stable_fields == REQUIRED_START_STABLE_FIELDS:
+            return StartValidationResult(candidate, first_readloc, None)
+
+        return None
+
     def search(self):
         """Return a :class:`StartResult`, or ``None`` when no start is found."""
 
@@ -301,6 +413,8 @@ class StartFinder:
         stable_video = _StableVideoTracker()
         last_progress_bucket = -1
         scanning_preamble = True
+        acquiring_sync = False
+        sync_acquire_end = None
 
         try:
             decoder = self.decoder_factory()
@@ -309,7 +423,7 @@ class StartFinder:
                     position, last_progress_bucket
                 )
                 sync_probe = getattr(decoder, "has_sync", None)
-                if scanning_preamble and callable(sync_probe):
+                if scanning_preamble and not acquiring_sync and callable(sync_probe):
                     try:
                         with warnings.catch_warnings():
                             warnings.simplefilter("ignore", RuntimeWarning)
@@ -327,6 +441,14 @@ class StartFinder:
                     if has_sync is False:
                         position += self.sample_rate
                         continue
+                    if has_sync is True:
+                        # A coarse, one-second probe can land within a damaged
+                        # field even when sync is present.  Once sync is seen,
+                        # follow normal field offsets briefly so that the
+                        # decoder can lock onto the next clean field instead
+                        # of repeatedly skipping over the programme start.
+                        acquiring_sync = True
+                        sync_acquire_end = position + self.sample_rate
                 try:
                     # Bad tracking windows can make the RF calculations emit NumPy
                     # RuntimeWarnings. They are expected probe failures, not a
@@ -353,6 +475,8 @@ class StartFinder:
                     first_field = None
                     stable_video.reset()
                     self.detector.reset()
+                    acquiring_sync = False
+                    sync_acquire_end = None
                     continue
 
                 if field is None or offset is None:
@@ -371,6 +495,15 @@ class StartFinder:
                     first_field = None
                     stable_video.reset()
                     self.detector.reset()
+                    if (
+                        acquiring_sync
+                        and sync_acquire_end is not None
+                        and next_position < sync_acquire_end
+                    ):
+                        position = next_position
+                        continue
+                    acquiring_sync = False
+                    sync_acquire_end = None
                     # Before content locks, testing every nominal field makes a
                     # tracking-back capture unnecessarily slow. A one-second
                     # stride still exercises a different field phase on each
@@ -379,6 +512,8 @@ class StartFinder:
                     continue
 
                 scanning_preamble = False
+                acquiring_sync = False
+                sync_acquire_end = None
 
                 stable_start = stable_video.observe(field, decoder.bytes_per_field)
 
@@ -407,9 +542,44 @@ class StartFinder:
                             decoder.bytes_per_field,
                             decoder.rf.SysParams["fieldPhases"],
                         )
-                        return StartResult(
+                        last_validation_frame = qualified.file_frame
+                        if pre_roll.file_frame < qualified.file_frame:
+                            validation_frames = max(
+                                1,
+                                int(
+                                    math.ceil(
+                                        float(decoder.rf.SysParams["FPS"])
+                                        * MAX_START_VALIDATION_SECONDS
+                                    )
+                                ),
+                            )
+                            last_validation_frame = min(
+                                qualified.file_frame - 1,
+                                pre_roll.file_frame + validation_frames - 1,
+                            )
+                        validation = self._validate_start_frame(
                             pre_roll.file_frame,
-                            pre_roll.readloc,
+                            last_validation_frame,
+                            decoder.bytes_per_field,
+                        )
+                        if validation.file_frame is None:
+                            if self.report is not None:
+                                self.report(
+                                    "confirmed {0} VBI run, but {1}".format(
+                                        qualified.disk_type, validation.reason
+                                    )
+                                )
+                            return StartResult(
+                                pre_roll.file_frame,
+                                pre_roll.readloc,
+                                "unvalidated",
+                                qualified.disk_type,
+                                tuple(item.address for item in self.detector.run),
+                                float(position) / self.sample_rate,
+                            )
+                        return StartResult(
+                            validation.file_frame,
+                            validation.readloc,
                             "vbi",
                             qualified.disk_type,
                             tuple(item.address for item in self.detector.run),
@@ -566,7 +736,7 @@ def main(args=None):
         print(argument)
         print(
             "ld-find-start: found {0} run at file frame {1} "
-            "(sample {2}, searched {3:.2f}s)".format(
+            "(first decoded field sample {2}, searched {3:.2f}s)".format(
                 result.disk_type,
                 result.file_frame,
                 result.readloc,
@@ -576,13 +746,31 @@ def main(args=None):
         )
         return 0
 
-    print(
-        "ld-find-start: WARNING: no advancing CAV/CLV VBI run; "
-        "guarded stable-video candidate is {0} (sample {1})".format(
-            argument, result.readloc
-        ),
-        file=sys.stderr,
-    )
+    if result.confidence == "fallback":
+        print(
+            "ld-find-start: WARNING: no advancing CAV/CLV VBI run; "
+            "guarded stable-video candidate is {0} (sample {1})".format(
+                argument, result.readloc
+            ),
+            file=sys.stderr,
+        )
+    elif result.confidence == "unvalidated":
+        print(
+            "ld-find-start: WARNING: confirmed {0} VBI run, but no "
+            "phase-stable nominal --start was verified; guarded candidate is "
+            "{1} (first decoded field sample {2})".format(
+                result.disk_type, argument, result.readloc
+            ),
+            file=sys.stderr,
+        )
+    else:
+        print(
+            "ld-find-start: ERROR: unknown start confidence {0}".format(
+                result.confidence
+            ),
+            file=sys.stderr,
+        )
+        return 1
     return 2
 
 

--- a/lddecode/start_finder.py
+++ b/lddecode/start_finder.py
@@ -16,7 +16,7 @@ from collections import namedtuple
 from copy import deepcopy
 
 from lddecode.core import LDdecode
-from lddecode.utils import make_loader, parse_frequency
+from lddecode.utils import inrange, make_loader, parse_frequency
 
 RF_SAMPLE_RATE = 40000000
 DEFAULT_MAX_SEARCH_SECONDS = 300.0
@@ -43,8 +43,8 @@ StartResult = namedtuple(
 )
 """Result from :func:`find_start`; confidence is ``vbi``, ``fallback``, or
 ``unvalidated``.  For VBI and unvalidated results, ``readloc`` is the first
-decoded field sample and can precede the nominal ``file_frame`` start
-location."""
+decoded field sample (after any leading invalid-field recovery) and can
+precede the nominal ``file_frame`` start location."""
 
 
 StartValidationResult = namedtuple(
@@ -52,7 +52,8 @@ StartValidationResult = namedtuple(
 )
 """Internal nominal-``--start`` validation result.
 
-``readloc`` is the first decoded field sample; ``reason`` is set on failure.
+``readloc`` is the first valid decoded field sample after any leading
+invalid-field recovery; ``reason`` is set on failure.
 """
 
 
@@ -305,14 +306,22 @@ class StartFinder:
             stable_observation.disk_type,
         )
 
-    def _validate_start_frame(self, first_frame, last_frame, bytes_per_field):
+    def _validate_start_frame(
+        self,
+        first_frame,
+        last_frame,
+        bytes_per_field,
+        vbi_start_readloc=None,
+    ):
         """Validate the earliest nominal ``--start`` within a clean pre-roll.
 
         The pre-roll replay begins at a decoded field boundary, whereas
         ``ld-decode --start`` begins at a nominal sample position.  The latter
         can still select a preceding unstable field.  Decode each candidate as
-        the normal read path does and retain the first one with a stable phase
-        run.
+        the normal read path does, including recovery from leading invalid
+        fields, and retain the first one with a stable phase run.  When a
+        replayed pre-roll exists, do not let that recovery reach the confirmed
+        VBI frame.
         """
 
         decoder = None
@@ -327,7 +336,11 @@ class StartFinder:
                 decoder.rf.DecoderParams.clear()
                 decoder.rf.DecoderParams.update(deepcopy(initial_decoder_params))
                 validation = self._validate_start_frame_candidate(
-                    decoder, candidate, bytes_per_field, field_phases
+                    decoder,
+                    candidate,
+                    bytes_per_field,
+                    field_phases,
+                    vbi_start_readloc,
                 )
                 if validation is not None:
                     return validation
@@ -354,18 +367,63 @@ class StartFinder:
         )
 
     def _validate_start_frame_candidate(
-        self, decoder, candidate, bytes_per_field, field_phases
+        self,
+        decoder,
+        candidate,
+        bytes_per_field,
+        field_phases,
+        vbi_start_readloc,
     ):
-        """Return a validation result for one fresh nominal ``--start`` probe."""
+        """Return a validation result for one fresh nominal ``--start`` probe.
 
-        position = candidate * int(bytes_per_field) * 2
+        ``LDdecode.readfield`` follows a positive offset after an invalid
+        leading field and restarts its phase relationship.  Do the same, but
+        only within this nominal frame so an earlier candidate cannot borrow a
+        later frame's clean run.
+        """
+
+        nominal_position = candidate * int(bytes_per_field) * 2
+        nominal_end = nominal_position + (int(bytes_per_field) * 2)
+        position = nominal_position
         previous_field = None
         first_readloc = None
         previous_phase = None
         stable_fields = 0
-        for _ in range(REQUIRED_START_STABLE_FIELDS):
+        while stable_fields < REQUIRED_START_STABLE_FIELDS:
+            if vbi_start_readloc is not None and position >= vbi_start_readloc:
+                return None
+
             field, offset = decoder.decodefield(position, 0, previous_field)
-            if field is None or offset is None or not field.valid:
+            if field is None or offset is None:
+                return None
+
+            try:
+                offset = int(offset)
+            except (TypeError, ValueError):
+                return None
+            if offset <= 0:
+                return None
+            next_position = position + offset
+
+            if vbi_start_readloc is not None:
+                try:
+                    field_readloc = int(field.readloc)
+                except (AttributeError, TypeError, ValueError):
+                    return None
+                if field_readloc >= vbi_start_readloc:
+                    return None
+
+            if not field.valid:
+                # Recovery is permitted only before the stable run begins and
+                # only while it remains in the candidate's nominal frame.
+                if stable_fields or next_position >= nominal_end:
+                    return None
+                previous_field = None
+                previous_phase = None
+                position = next_position
+                continue
+
+            if self._would_report_player_skip(decoder, field):
                 return None
 
             if first_readloc is None:
@@ -381,22 +439,34 @@ class StartFinder:
                 if phase != expected_phase:
                     return None
 
-            try:
-                offset = int(offset)
-            except (TypeError, ValueError):
-                return None
-            if offset <= 0:
-                return None
-
             previous_phase = phase
             previous_field = field
             stable_fields += 1
-            position += offset
+            position = next_position
 
-        if stable_fields == REQUIRED_START_STABLE_FIELDS:
-            return StartValidationResult(candidate, first_readloc, None)
+        return StartValidationResult(candidate, first_readloc, None)
 
-        return None
+    @staticmethod
+    def _would_report_player_skip(decoder, field):
+        """Return whether ``LDdecode.readfield`` would warn about this field.
+
+        The lightweight fake fields used by start-finder tests do not carry
+        picture geometry. Real decoder fields do, and must meet the same
+        minimum quality rule as a normal decode before they can make a nominal
+        start safe.
+        """
+
+        try:
+            fieldlength = (
+                field.linelocs[decoder.output_lines] - field.linelocs[0]
+            ) / field.inlinelen
+            return field.sync_confidence < 50 and not inrange(
+                fieldlength,
+                decoder.output_lines - 2,
+                decoder.output_lines + 2,
+            )
+        except (AttributeError, IndexError, KeyError, TypeError, ZeroDivisionError):
+            return False
 
     def search(self):
         """Return a :class:`StartResult`, or ``None`` when no start is found."""
@@ -557,10 +627,14 @@ class StartFinder:
                                 qualified.file_frame - 1,
                                 pre_roll.file_frame + validation_frames - 1,
                             )
+                        vbi_start_readloc = (
+                            qualified.readloc if self.pre_roll_search_seconds else None
+                        )
                         validation = self._validate_start_frame(
                             pre_roll.file_frame,
                             last_validation_frame,
                             decoder.bytes_per_field,
+                            vbi_start_readloc,
                         )
                         if validation.file_frame is None:
                             if self.report is not None:

--- a/tests/test_start_finder.py
+++ b/tests/test_start_finder.py
@@ -95,7 +95,10 @@ class FakeDecoder:
         self.bytes_per_field = bytes_per_field
         self.isCLV = False
         self.closed = False
-        self.rf = SimpleNamespace(SysParams={"fieldPhases": 4})
+        self.rf = SimpleNamespace(
+            SysParams={"fieldPhases": 4, "FPS": 30},
+            DecoderParams={"ire0": 0},
+        )
 
     def decodefield(self, _position, _mtf, _previous):
         event = self.events.pop(0)
@@ -124,6 +127,85 @@ class SyncProbeFakeDecoder(FakeDecoder):
         return next(self.sync_results)
 
 
+class SyncRecoveryFakeDecoder(FakeDecoder):
+    """Return fields only at the positions reached by normal field stepping."""
+
+    def __init__(self, events, bytes_per_field=100):
+        super().__init__([], bytes_per_field)
+        self.events_by_position = dict(events)
+        self.sync_positions = []
+
+    def has_sync(self, position):
+        self.sync_positions.append(position)
+        return True
+
+    def decodefield(self, position, _mtf, _previous):
+        return self.events_by_position.get(position, (None, None))
+
+
+class StartValidationFakeDecoder(FakeDecoder):
+    """Emit a phase sequence keyed by the requested nominal sample position."""
+
+    def __init__(self, phases, start_position=1000, bytes_per_field=100):
+        super().__init__([], bytes_per_field)
+        self.phases = list(phases)
+        self.start_position = start_position
+        self.calls = []
+
+    def decodefield(self, position, _mtf, previous):
+        self.calls.append((position, previous))
+        index = (position - self.start_position) // self.bytes_per_field
+        if index < 0 or index >= len(self.phases):
+            return None, None
+        phase = self.phases[index]
+        return (
+            FakeField(
+                position,
+                bool(index % 2),
+                field_phase_id=phase,
+            ),
+            self.bytes_per_field,
+        )
+
+
+class ParameterResetValidationDecoder(FakeDecoder):
+    """Require RF parameters to be reset before the second candidate."""
+
+    def __init__(self):
+        super().__init__([])
+        self.calls = []
+
+    def decodefield(self, position, _mtf, previous):
+        self.calls.append((position, self.rf.DecoderParams["ire0"], previous))
+        if 1000 <= position < 1200:
+            self.rf.DecoderParams["ire0"] = 99
+            phase = 4 if position == 1000 else 3
+        elif 1200 <= position < 2000:
+            if self.rf.DecoderParams["ire0"] != 0:
+                return None, None
+            phase = ((position - 1200) // self.bytes_per_field) % 4 + 1
+        else:
+            return None, None
+        return (
+            FakeField(
+                position,
+                bool((position // self.bytes_per_field) % 2),
+                field_phase_id=phase,
+            ),
+            self.bytes_per_field,
+        )
+
+
+def validation_decoder(start_file_frame, phases=None, bytes_per_field=100):
+    if phases is None:
+        phases = [1, 2, 3, 4, 1, 2, 3, 4]
+    return StartValidationFakeDecoder(
+        phases,
+        start_position=start_file_frame * bytes_per_field * 2,
+        bytes_per_field=bytes_per_field,
+    )
+
+
 def five_frames(start_file_frame=7, sample_base=0, disk_type="CAV"):
     fields = []
     for index in range(5):
@@ -135,8 +217,13 @@ def five_frames(start_file_frame=7, sample_base=0, disk_type="CAV"):
 
 def test_start_finder_returns_first_cav_frame_of_vbi_run():
     decoder = FakeDecoder(five_frames())
+    validation = validation_decoder(7)
+    decoders = iter([decoder, validation])
     result = StartFinder(
-        lambda: decoder, sample_rate=100, required_frames=5, pre_roll_search_seconds=0
+        lambda: next(decoders),
+        sample_rate=100,
+        required_frames=5,
+        pre_roll_search_seconds=0,
     ).search()
     assert result.confidence == "vbi"
     assert result.file_frame == 7
@@ -144,12 +231,14 @@ def test_start_finder_returns_first_cav_frame_of_vbi_run():
     assert result.disk_type == "CAV"
     assert result.addresses == (100, 101, 102, 103, 104)
     assert decoder.closed
+    assert validation.closed
 
 
 def test_start_finder_recreates_decoder_after_decode_failure():
     first = FakeDecoder([RuntimeError("bad RF")])
     second = FakeDecoder(five_frames(start_file_frame=9))
-    decoders = iter([first, second])
+    validation = validation_decoder(9)
+    decoders = iter([first, second, validation])
     result = StartFinder(
         lambda: next(decoders), sample_rate=100, required_frames=5, pre_roll_search_seconds=0
     ).search()
@@ -157,17 +246,162 @@ def test_start_finder_recreates_decoder_after_decode_failure():
     assert result.file_frame == 9
     assert first.closed
     assert second.closed
+    assert validation.closed
 
 
 def test_start_finder_skips_sync_free_preamble_without_full_field_decode():
     decoder = SyncProbeFakeDecoder(five_frames(), [False, True])
+    validation = validation_decoder(7)
+    decoders = iter([decoder, validation])
     result = StartFinder(
-        lambda: decoder, sample_rate=100, required_frames=5, pre_roll_search_seconds=0
+        lambda: next(decoders),
+        sample_rate=100,
+        required_frames=5,
+        pre_roll_search_seconds=0,
     ).search()
 
     assert result.confidence == "vbi"
     assert decoder.sync_positions == [0, 100]
     assert decoder.closed
+    assert validation.closed
+
+
+def test_start_finder_recovers_from_an_invalid_field_after_sync_detection():
+    # A one-second sync probe can identify video but land in a malformed field.
+    # Follow its field offset to the next clean field; jumping a full second
+    # would miss this VBI run entirely.
+    decoder = SyncRecoveryFakeDecoder(
+        [
+            (0, (FakeField(0, True, valid=False), 10)),
+            (10, (FakeField(1000, True), 100)),
+            (110, (FakeField(1100, False, 0), 100)),
+            (210, (FakeField(1200, True), 100)),
+            (310, (FakeField(1300, False, 1), 100)),
+            (410, (FakeField(1400, True), 100)),
+            (510, (FakeField(1500, False, 2), 100)),
+        ]
+    )
+    validation = validation_decoder(5)
+    decoders = iter([decoder, validation])
+
+    result = StartFinder(
+        lambda: next(decoders),
+        sample_rate=100,
+        required_frames=3,
+        pre_roll_search_seconds=0,
+    ).search()
+
+    assert result.confidence == "vbi"
+    assert result.file_frame == 5
+    assert decoder.sync_positions == [0]
+    assert decoder.closed
+    assert validation.closed
+
+
+def test_start_validation_skips_nominal_frames_with_phase_mismatches():
+    # Frame 5 is the decoded-field pre-roll boundary, but the normal decoder
+    # starts before it and sees unstable phases until nominal frame 8.
+    phases = [4, 3, 2, 3, 4, 3, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3]
+    decoder = StartValidationFakeDecoder(phases)
+    finder = StartFinder(lambda: decoder, sample_rate=100)
+
+    result = finder._validate_start_frame(5, 8, 100)
+    assert result.file_frame == 8
+    assert result.readloc == 1600
+    assert result.reason is None
+    success_start = decoder.calls.index((1600, None))
+    assert decoder.calls[success_start + 1][1].readloc == 1600
+    assert decoder.closed
+
+
+def test_start_validation_reuses_one_decoder_with_reset_rf_parameters():
+    decoder = ParameterResetValidationDecoder()
+    factory_calls = []
+
+    def decoder_factory():
+        factory_calls.append(None)
+        return decoder
+
+    result = StartFinder(decoder_factory, sample_rate=100)._validate_start_frame(
+        5, 6, 100
+    )
+
+    assert result.file_frame == 6
+    assert factory_calls == [None]
+    candidate_six_start = next(
+        call for call in decoder.calls if call[0] == 1200 and call[2] is None
+    )
+    assert candidate_six_start[1] == 0
+    assert decoder.closed
+
+
+def test_start_finder_caps_nominal_validation_at_one_second():
+    forward = FakeDecoder(five_frames(start_file_frame=40))
+    replay = FakeDecoder(
+        [
+            FakeField(
+                index * 100,
+                index % 2 == 0,
+                field_phase_id=(index % 4) + 1,
+            )
+            for index in range(81)
+        ]
+    )
+    validation = validation_decoder(0, [4, 3] * 60)
+    decoders = iter([forward, replay, validation])
+
+    result = StartFinder(
+        lambda: next(decoders),
+        sample_rate=10000,
+        required_frames=5,
+        pre_roll_search_seconds=5,
+    ).search()
+
+    assert result.confidence == "unvalidated"
+    starts = [position for position, previous in validation.calls if previous is None]
+    assert starts == [frame * 200 for frame in range(30)]
+    assert validation.closed
+
+
+def test_start_finder_returns_unvalidated_result_when_no_nominal_start_is_safe():
+    forward = FakeDecoder(five_frames())
+    validation = validation_decoder(7, [4, 3, 4, 3, 4, 3, 4, 3])
+    decoders = iter([forward, validation])
+    reports = []
+
+    result = StartFinder(
+        lambda: next(decoders),
+        sample_rate=100,
+        required_frames=5,
+        pre_roll_search_seconds=0,
+        report=reports.append,
+    ).search()
+
+    assert result.confidence == "unvalidated"
+    assert result.file_frame == 7
+    assert "no phase-stable nominal --start" in reports[-1]
+    assert forward.closed
+    assert validation.closed
+
+
+def test_start_finder_reports_validation_decoder_failure_as_unvalidated():
+    forward = FakeDecoder(five_frames())
+    validation = FakeDecoder([RuntimeError("validation RF")])
+    decoders = iter([forward, validation])
+    reports = []
+
+    result = StartFinder(
+        lambda: next(decoders),
+        sample_rate=100,
+        required_frames=5,
+        pre_roll_search_seconds=0,
+        report=reports.append,
+    ).search()
+
+    assert result.confidence == "unvalidated"
+    assert "decoder failure while validating" in reports[-1]
+    assert forward.closed
+    assert validation.closed
 
 
 def test_start_finder_returns_guarded_fallback_for_stable_video_without_vbi():
@@ -186,13 +420,19 @@ def test_start_finder_returns_guarded_fallback_for_stable_video_without_vbi():
 
 def test_start_finder_returns_first_clv_frame_of_the_stable_run():
     decoder = FakeDecoder(five_frames(start_file_frame=30, disk_type="CLV"))
+    validation = validation_decoder(30)
+    decoders = iter([decoder, validation])
     result = StartFinder(
-        lambda: decoder, sample_rate=100, required_frames=5, pre_roll_search_seconds=0
+        lambda: next(decoders),
+        sample_rate=100,
+        required_frames=5,
+        pre_roll_search_seconds=0,
     ).search()
     assert result.confidence == "vbi"
     assert result.disk_type == "CLV"
     assert result.file_frame == 30
     assert result.readloc == 6000
+    assert validation.closed
 
 
 def test_start_finder_keeps_clean_pre_roll_after_last_phase_break():
@@ -210,7 +450,10 @@ def test_start_finder_keeps_clean_pre_roll_after_last_phase_break():
             FakeField(4000, False, field_phase_id=4),
         ]
     )
-    decoders = iter([forward, replay])
+    validation = validation_decoder(
+        18, [4, 3, 2, 3, 4, 1, 2, 3, 4, 1]
+    )
+    decoders = iter([forward, replay, validation])
 
     result = StartFinder(
         lambda: next(decoders),
@@ -220,10 +463,11 @@ def test_start_finder_keeps_clean_pre_roll_after_last_phase_break():
     ).search()
 
     assert result.confidence == "vbi"
-    assert result.file_frame == 18
-    assert result.readloc == 3700
+    assert result.file_frame == 19
+    assert result.readloc == 3800
     assert forward.closed
     assert replay.closed
+    assert validation.closed
 
 
 def test_main_writes_only_confirmed_start_argument_to_stdout(monkeypatch, capsys):
@@ -233,6 +477,7 @@ def test_main_writes_only_confirmed_start_argument_to_stdout(monkeypatch, capsys
     captured = capsys.readouterr()
     assert captured.out == "--start 42\n"
     assert "found CAV run" in captured.err
+    assert "first decoded field sample 8400" in captured.err
 
 
 def test_main_keeps_guarded_fallback_off_stdout(monkeypatch, capsys):
@@ -241,6 +486,17 @@ def test_main_keeps_guarded_fallback_off_stdout(monkeypatch, capsys):
     assert main(["capture.ldf"]) == 2
     captured = capsys.readouterr()
     assert captured.out == ""
+    assert "--start 42" in captured.err
+
+
+def test_main_keeps_unvalidated_vbi_candidate_off_stdout(monkeypatch, capsys):
+    result = StartResult(42, 8400, "unvalidated", "CAV", (1, 2, 3, 4, 5), 3.0)
+    monkeypatch.setattr("lddecode.start_finder.find_start", lambda *_args, **_kwargs: result)
+    assert main(["capture.ldf"]) == 2
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert "confirmed CAV VBI run" in captured.err
+    assert "first decoded field sample 8400" in captured.err
     assert "--start 42" in captured.err
 
 

--- a/tests/test_start_finder.py
+++ b/tests/test_start_finder.py
@@ -162,10 +162,24 @@ class StartValidationFakeDecoder(FakeDecoder):
             FakeField(
                 position,
                 bool(index % 2),
+                valid=phase is not None,
                 field_phase_id=phase,
             ),
             self.bytes_per_field,
         )
+
+
+class OffsetValidationFakeDecoder(FakeDecoder):
+    """Emit validation fields and offsets keyed by the requested position."""
+
+    def __init__(self, events, bytes_per_field=100):
+        super().__init__([], bytes_per_field)
+        self.events = dict(events)
+        self.calls = []
+
+    def decodefield(self, position, _mtf, previous):
+        self.calls.append((position, previous))
+        return self.events.get(position, (None, None))
 
 
 class ParameterResetValidationDecoder(FakeDecoder):
@@ -314,6 +328,90 @@ def test_start_validation_skips_nominal_frames_with_phase_mismatches():
     assert decoder.closed
 
 
+def test_start_validation_recovers_leading_invalid_field_within_nominal_frame():
+    decoder = StartValidationFakeDecoder(
+        [None, 1, 2, 3, 4, 1, 2, 3, 4], start_position=1000
+    )
+    result = StartFinder(lambda: decoder, sample_rate=100)._validate_start_frame(
+        5, 5, 100
+    )
+
+    assert result.file_frame == 5
+    assert result.readloc == 1100
+    assert decoder.calls[0] == (1000, None)
+    assert decoder.calls[1] == (1100, None)
+    assert decoder.calls[2][1].readloc == 1100
+    assert decoder.closed
+
+
+def test_start_validation_rejects_leading_recovery_into_next_nominal_frame():
+    events = {
+        1000: (FakeField(1000, True, valid=False), 200),
+    }
+    for index, phase in enumerate((1, 2, 3, 4, 1, 2, 3, 4)):
+        position = 1200 + (index * 100)
+        events[position] = (FakeField(position, bool(index % 2), field_phase_id=phase), 100)
+    decoder = OffsetValidationFakeDecoder(events)
+
+    result = StartFinder(lambda: decoder, sample_rate=100)._validate_start_frame(
+        5, 6, 100
+    )
+
+    assert result.file_frame == 6
+    assert [call[0] for call in decoder.calls] == [1000] + list(
+        range(1200, 2000, 100)
+    )
+    assert decoder.closed
+
+
+def test_start_validation_rejects_invalid_field_after_stable_run_begins():
+    decoder = StartValidationFakeDecoder(
+        [1, None, 2, 3, 4, 1, 2, 3, 4], start_position=1000
+    )
+
+    result = StartFinder(lambda: decoder, sample_rate=100)._validate_start_frame(
+        5, 5, 100
+    )
+
+    assert result.file_frame is None
+    assert [call[0] for call in decoder.calls] == [1000, 1100]
+    assert decoder.closed
+
+
+def test_start_validation_rejects_fields_that_would_warn_of_player_skip():
+    warning_field = FakeField(1100, False, field_phase_id=2)
+    warning_field.sync_confidence = 10
+    warning_field.linelocs = [0] * 11
+    warning_field.inlinelen = 1
+    decoder = OffsetValidationFakeDecoder(
+        {
+            1000: (FakeField(1000, True, field_phase_id=1), 100),
+            1100: (warning_field, 100),
+        }
+    )
+    decoder.output_lines = 10
+
+    result = StartFinder(lambda: decoder, sample_rate=100)._validate_start_frame(
+        5, 5, 100
+    )
+
+    assert result.file_frame is None
+    assert [call[0] for call in decoder.calls] == [1000, 1100]
+    assert decoder.closed
+
+
+def test_start_validation_does_not_probe_into_confirmed_vbi_frame():
+    decoder = validation_decoder(5)
+
+    result = StartFinder(lambda: decoder, sample_rate=100)._validate_start_frame(
+        5, 5, 100, vbi_start_readloc=1500
+    )
+
+    assert result.file_frame is None
+    assert [call[0] for call in decoder.calls] == list(range(1000, 1500, 100))
+    assert decoder.closed
+
+
 def test_start_validation_reuses_one_decoder_with_reset_rf_parameters():
     decoder = ParameterResetValidationDecoder()
     factory_calls = []
@@ -436,7 +534,7 @@ def test_start_finder_returns_first_clv_frame_of_the_stable_run():
 
 
 def test_start_finder_keeps_clean_pre_roll_after_last_phase_break():
-    forward = FakeDecoder(five_frames(start_file_frame=20))
+    forward = FakeDecoder(five_frames(start_file_frame=25))
     replay = FakeDecoder(
         [
             FakeField(3500, True, field_phase_id=1),


### PR DESCRIPTION
### Checklist

- [x] I have searched the open pull requests to confirm this change has not already been submitted.
- [x] My branch is up to date with the target branch.
- [x] I have tested my changes and all existing tests pass.
- [x] I have updated documentation where necessary.
- [x] My code follows the project's coding standards (see [CONTRIBUTING.md](CONTRIBUTING.md)).

### Description

Makes `ld-find-start` validate the nominal `--start` frame using the same sequential field relationship as `ld-decode`. It now returns a start only when the first eight decoded fields have a stable phase sequence.

### Motivation

The finder could recover content too late after a positive sync probe, then return a pre-roll frame whose nominal `--start` position still decoded unstable fields. On `ghosts_of_mississippi_s2.ldf`, frame 360 produced phase-sequence mismatch warnings while frame 363 was a safe start.

### Related Issues

N/A

### Changes Made

- Recover field-by-field for up to one source second after a positive sync probe lands in an invalid field.
- Validate nominal start candidates with chained `prevfield` state, restoring RF decoder parameters between candidates, and limit the search to one source second before VBI.
- Withhold unsafe starts as `unvalidated` (exit 2/no stdout) and clarify that reported `readloc` is the first decoded field sample.

### Testing

- [x] All existing tests pass (`python -m pytest -q`; 91 passed).
- [x] Tested manually with: `ld-find-start /Users/epowell/ld/ghosts_of_mississippi_s2.ldf` selects `--start 363`; a short `ld-decode --start 363` run emitted no phase-sequence mismatch warnings.
- [x] New tests added for: positive-sync recovery, chained phase validation, RF parameter reset, one-second candidate cap, and guarded unvalidated CLI behavior.

### Screenshots (if applicable)

N/A — command-line behavior only.

### Additional Notes

If VBI is confirmed but no nominal start validates within the bounded window, the tool deliberately emits no `--start` argument rather than guessing.
