### PR TITLE
Read .s8 files without --frequency, and survive an empty decode

### DIFF
--- a/lddecode/utils.py
+++ b/lddecode/utils.py
@@ -262,6 +262,8 @@ def make_loader(filename, inputfreq=None):
         return load_unpacked_data_s16
     elif filename.endswith(".r16") or filename.endswith(".u16"):
         return load_unpacked_data_u16
+    elif filename.endswith(".s8"):
+        return load_unpacked_data_s8
     elif filename.endswith(".r8") or filename.endswith(".u8"):
         return load_unpacked_data_u8
     elif (
@@ -279,9 +281,11 @@ def make_loader(filename, inputfreq=None):
 
 def load_unpacked_data(infile, sample, readlen, sampletype):
     # this is run for unpacked data:
-    # 1 is for 8-bit cxadc data, 2 for 16bit DD, 3 for 16bit cxadc
-
-    samplelength = 2 if sampletype == 3 else sampletype
+    # 1 is for 8-bit cxadc data, 2 for 16bit DD, 3 for 16bit cxadc,
+    # 4 for 32-bit float, 5 for signed 8-bit
+    #
+    # sampletype is not the sample width, so the two are mapped explicitly.
+    samplelength = {1: 1, 2: 2, 3: 2, 4: 4, 5: 1}[sampletype]
 
     infile.seek(sample * samplelength, 0)
     inbuf = infile.read(readlen * samplelength)
@@ -292,6 +296,11 @@ def load_unpacked_data(infile, sample, readlen, sampletype):
         indata = np.frombuffer(inbuf, "uint16", len(inbuf) // 2)
     elif sampletype == 2:
         indata = np.frombuffer(inbuf, "int16", len(inbuf) // 2)
+    elif sampletype == 5:
+        # Scale up to the 16-bit range, so that a given .s8 file decodes
+        # identically whether it reaches us through this loader or through
+        # the ffmpeg path (which converts s8 to pcm_s16le the same way).
+        indata = np.frombuffer(inbuf, "int8", len(inbuf)).astype(np.int16) * 256
     else:
         # NOTE(oln): Can probably use frombuffer for other variants too but
         # didn't have any samples to test with.
@@ -305,6 +314,10 @@ def load_unpacked_data(infile, sample, readlen, sampletype):
 
 def load_unpacked_data_u8(infile, sample, readlen):
     return load_unpacked_data(infile, sample, readlen, 1)
+
+
+def load_unpacked_data_s8(infile, sample, readlen):
+    return load_unpacked_data(infile, sample, readlen, 5)
 
 
 def load_unpacked_data_s16(infile, sample, readlen):

--- a/lddecode/utils.py
+++ b/lddecode/utils.py
@@ -1448,16 +1448,32 @@ class JSONDumper:
 
     def write(self):
         if not self._writing.is_set():
-            json_data = self._build_json()
-            field_info = self._get_field_info()
-            self._queue.put((json_data, field_info))
+            self._enqueue()
 
     def close(self):
-        json_data = self._build_json()
-        field_info = self._get_field_info()
-        self._queue.put((json_data, field_info))
+        self._enqueue()
         self._queue.put(None)  # sentinel to stop the consumer
         self._dumper.join()
+
+    def _enqueue(self):
+        """Queue a snapshot for the writer thread, if there is one to take.
+
+        build_json() returns None until a valid field has been decoded, so a
+        decode that ends without ever getting one -- the source frequency not
+        matching the file, say -- has no metadata to write. Passing that None
+        on would kill the writer thread with an AttributeError and leave a
+        truncated .tbc.json.tmp behind, burying the "Completed without
+        handling any frames" message the main thread prints just before this.
+
+        Nothing is dropped by returning early: field info is only drained once
+        there is a JSON body to attach it to, and with no valid field there is
+        no field info to drain.
+        """
+        json_data = self._build_json()
+        if json_data is None:
+            return
+
+        self._queue.put((json_data, self._get_field_info()))
 
     @staticmethod
     def _consume(queue, ready, outname, verboseVITS):

--- a/tests/test_json_dumper_empty.py
+++ b/tests/test_json_dumper_empty.py
@@ -1,0 +1,70 @@
+"""Tests that a decode producing no fields still shuts down cleanly.
+
+build_json() returns None until a valid field has been decoded. JSONDumper
+handed that None straight to its writer thread, which died on None.items() --
+printing an AttributeError traceback over the "Completed without handling any
+frames" message that explains what actually went wrong, and leaving a
+truncated .tbc.json.tmp behind.
+
+Reaching this needs only a decode that yields nothing; see test_s8_loader.py
+for the .s8 loader gap that was one way to get there.
+"""
+
+import types
+
+from lddecode.utils import JSONDumper
+
+
+class _EmptyDecode:
+    """Stands in for LDdecode after a decode that produced no valid field.
+
+    Only the three attributes JSONDumper touches are provided; building a real
+    LDdecode needs an RF source and a populated DemodCache, none of which the
+    None-handling under test depends on.
+    """
+
+    verboseVITS = False
+
+    def __init__(self):
+        self.field_info_reads = 0
+
+    def build_json(self):
+        return None
+
+    def _read_field_info(self):
+        self.field_info_reads += 1
+        return []
+
+    @property
+    def fieldinfo(self):
+        return types.SimpleNamespace(read=self._read_field_info)
+
+
+def test_empty_decode_writes_no_json_and_leaves_the_thread_alive(tmp_path):
+    """close() must survive build_json() returning None, and write no files."""
+    outname = str(tmp_path / "out")
+    ldd = _EmptyDecode()
+
+    dumper = JSONDumper(ldd, outname)
+    dumper.write()
+    dumper.close()
+
+    assert not dumper._dumper.is_alive()
+    # Neither the final file nor the partial one the writer opens first.
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_empty_decode_does_not_drain_field_info(tmp_path):
+    """Skipping the write must not consume field info that was never written.
+
+    fieldinfo.read() empties the unsent list, so calling it and then dropping
+    the result would silently lose fields if build_json() ever returned None
+    with fields pending.
+    """
+    ldd = _EmptyDecode()
+
+    dumper = JSONDumper(ldd, str(tmp_path / "out"))
+    dumper.write()
+    dumper.close()
+
+    assert ldd.field_info_reads == 0

--- a/tests/test_s8_loader.py
+++ b/tests/test_s8_loader.py
@@ -1,0 +1,69 @@
+"""Tests for reading .s8 (signed 8-bit) source files.
+
+make_loader() recognised .s8 only on its resampling path, where a --frequency
+was given and ffmpeg does the reading. Without --frequency the extension fell
+through every branch to the bare LoadFFmpeg() fallback, which reads from stdin
+with no format arguments: it produced no samples, so the decode ended with
+"Completed without handling any frames" without ever having read the file.
+
+See test_json_dumper_empty.py for the crash that empty decode then triggered.
+"""
+
+import io
+
+import numpy as np
+
+from lddecode.utils import (
+    LoadFFmpeg,
+    load_unpacked_data_s8,
+    make_loader,
+)
+
+
+def test_s8_maps_to_its_own_loader_without_a_frequency():
+    """.s8 with no --frequency must not land on the stdin ffmpeg fallback."""
+    loader = make_loader("capture.s8")
+
+    assert loader is load_unpacked_data_s8
+    assert not isinstance(loader, LoadFFmpeg)
+
+
+def test_s8_still_uses_ffmpeg_when_resampling():
+    """With a --frequency, ffmpeg does the reading and must be told the format."""
+    loader = make_loader("capture.s8", inputfreq=62.5)
+
+    assert isinstance(loader, LoadFFmpeg)
+    assert loader.input_args == ["-f", "s8"]
+
+
+def test_s8_samples_are_scaled_to_the_16_bit_range():
+    """Match the ffmpeg path, which converts s8 to pcm_s16le by scaling by 256.
+
+    The same file has to decode identically whichever loader reads it, so the
+    signed 8-bit values are widened rather than passed through at their native
+    amplitude.
+    """
+    raw = np.array([-128, -1, 0, 1, 127], dtype=np.int8)
+    infile = io.BytesIO(raw.tobytes())
+
+    out = load_unpacked_data_s8(infile, 0, len(raw))
+
+    np.testing.assert_array_equal(out, raw.astype(np.int16) * 256)
+
+
+def test_s8_reads_from_the_right_offset():
+    """Sample offsets are one byte apart, not two -- s8 is a one-byte format."""
+    raw = np.arange(-8, 8, dtype=np.int8)
+    infile = io.BytesIO(raw.tobytes())
+
+    out = load_unpacked_data_s8(infile, 3, 4)
+
+    np.testing.assert_array_equal(out, raw[3:7].astype(np.int16) * 256)
+
+
+def test_s8_short_read_returns_none():
+    """A truncated read is EOF, reported the same way as the other loaders."""
+    raw = np.zeros(4, dtype=np.int8)
+    infile = io.BytesIO(raw.tobytes())
+
+    assert load_unpacked_data_s8(infile, 0, 64) is None


### PR DESCRIPTION
Decoding a 62.5MHz `.s8` capture without passing `--frequency` produced a Python
traceback instead of a usable error:

```
$ ld-decode capture.ntsc-rf.62.5MHz.s8 out
Completed without handling any frames.
Exception in thread lddecode-json-dumper:
  File "lddecode/utils.py", line 1489, in _consume
    for (k, v) in jsondict.items():
AttributeError: 'NoneType' object has no attribute 'items'
```

Two independent bugs, in separate commits so either can be taken alone.

### Read .s8 files without needing --frequency

`make_loader()` recognised `.s8` only on its resampling path, where a
`--frequency` is given and ffmpeg does the reading. Without `--frequency` the
extension fell through every branch to the bare `LoadFFmpeg()` fallback, which
reads from *stdin* with no format arguments, so no samples ever arrived and the
decode ended without having read the file at all. This also affected `ld-cut`,
which calls `make_loader(filename, None)`.

Adds `load_unpacked_data_s8` alongside the other unpacked loaders. Samples are
widened to the 16-bit range, matching the ffmpeg path's conversion of s8 to
`pcm_s16le`, so a file decodes identically whichever loader reads it. Verified:
a 40MHz `.s8` capture decoded through the new loader and through `-f 40MHz`
produces **byte-identical `.tbc` output**, with no `videoParameters`
differences and the same throughput on a warm cache.

`sampletype` was doing double duty as the sample width, which a one-byte signed
type breaks, so the two are now mapped explicitly.

### Keep the JSON writer alive on an empty decode

`build_json()` returns `None` until a valid field has been decoded, but
`JSONDumper` passed that `None` straight to its writer thread, which died on
`None.items()`. Any decode producing no fields — not just this one — ended with
an `AttributeError` traceback printed over the "Completed without handling any
frames" message that explains what actually went wrong, and left a truncated
`.tbc.json.tmp` behind where the thread stopped mid-write.

Queues a snapshot only when there is one to take. Field info is not drained on
the way out, so nothing is lost if `build_json()` ever returns `None` with
fields pending.

### Testing

`tests/test_s8_loader.py` and `tests/test_json_dumper_empty.py`, 7 tests. Both
fixes were confirmed to be load-bearing by reverting each hunk independently —
the dumper tests reproduce the exact `AttributeError` above without the fix.
Full suite passes (103), and the first commit passes standalone (101).

With these applied the original command fails diagnosably instead: it reads the
file and reports "Unable to find any sync pulses", the actual problem being that
62.5MHz data is being read as 40MHz.
